### PR TITLE
Swap in % for @ to fix assembly on (at least) ARM.

### DIFF
--- a/src/guids.S
+++ b/src/guids.S
@@ -1,28 +1,28 @@
 	.globl well_known_guids
 	.data
 	.balign 16
-	.type	well_known_guids, @object
+	.type	well_known_guids, %object
 	.size	well_known_guids, well_known_guids_end - well_known_guids
 well_known_guids:
 .incbin "guids.bin"
 	.globl well_known_guids_end
 	.data
 	.balign 16
-	.type	well_known_guids_end, @object
+	.type	well_known_guids_end, %object
 	.size	well_known_guids_end, 1
 well_known_guids_end:
 	.byte 0
 	.globl well_known_names
 	.data
 	.balign 16
-	.type	well_known_names, @object
+	.type	well_known_names, %object
 	.size	well_known_names, well_known_names_end - well_known_names
 well_known_names:
 .incbin "names.bin"
 	.globl well_known_names_end
 	.data
 	.balign 16
-	.type	well_known_names_end, @object
+	.type	well_known_names_end, %object
 	.size	well_known_names_end, 1
 well_known_names_end:
 	.byte 0

--- a/src/makeguids.c
+++ b/src/makeguids.c
@@ -141,7 +141,7 @@ main(int argc, char *argv[])
 		fprintf(symout, "\t.globl %s\n"
 				"\t.data\n"
 				"\t.balign 1\n"
-				"\t.type %s, @object\n"
+				"\t.type %s, %%object\n"
 				"\t.size %s, %s_end - %s\n"
 				"%s:\n",
 			outbuf[i].symbol,


### PR DESCRIPTION
Quoting from the gas manual:

> Note on targets where the @ character is the start of a comment
> (eg ARM) then another character is used instead. For example the
> ARM port uses the % character.

Luckily, % works fine on x86 too, so let's do that unconditionally.

Signed-off-by: Adam Conrad adconrad@0c3.net
