### PR TITLE
Enable C11 mode

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -27,7 +27,7 @@ PKGS	=
 
 clang_cflags = -D_GNU_SOURCE
 gcc_cflags = -specs=$(TOPDIR)/gcc.specs
-cflags	= $(CFLAGS) -I${TOPDIR}/src/include/ \
+cflags	= $(CFLAGS) -std=c11 -I${TOPDIR}/src/include/ \
 	$(if $(findstring clang,$(CC)),$(clang_cflags),) \
 	$(if $(findstring gcc,$(CC)),$(gcc_cflags),) \
 	$(call pkg-config-cflags)


### PR DESCRIPTION
This commit sets the C language standards version to C11.

`efivar` uses C11 language features in a few places (such as `generics.h`).

However, because there is no `-std=c11` option, some old versions of GCC fail to compile and do not give an useful error message.

Fixes #87 (in a way, at least provides better error messages in that case).