### PR TITLE
Add UX capsule to map for 33 not 32

### DIFF
--- a/src/abignore
+++ b/src/abignore
@@ -21,7 +21,7 @@
 
 # 1 Added variable:
 #
-#  'const __anonymous_struct__ efi_guid_ux_capsule'    {efi_guid_ux_capsule@@LIBEFIVAR_1.32}
+#  'const __anonymous_struct__ efi_guid_ux_capsule'    {efi_guid_ux_capsule@@LIBEFIVAR_1.33}
 #
 [suppress_variable]
   soname_regexp = ^libefivar\\.so\\.[[:digit:]]+

--- a/src/libefivar.map.in
+++ b/src/libefivar.map.in
@@ -111,10 +111,7 @@ LIBEFIVAR_1.30 {
 		efi_error_clear;
 } LIBEFIVAR_1.29;
 
-LIBEFIVAR_1.32 {
-	global: efi_guid_ux_capsule;
-} LIBEFIVAR_1.30;
-
 LIBEFIVAR_1.33 {
-	global: efidp_make_nvdimm;
-} LIBEFIVAR_1.32;
+	global: efi_guid_ux_capsule;
+		efidp_make_nvdimm;
+} LIBEFIVAR_1.30;


### PR DESCRIPTION
commit cd732494 fixed UX capsule support, but it mistakingly marked
it for version 32.  It's still broken in the 32 release.
(see https://github.com/rhboot/fwupdate/issues/93)

It really should be marked for 33.