### PR TITLE
Fix compile errors with musl libc

### DIFF
--- a/src/linux.c
+++ b/src/linux.c
@@ -937,7 +937,7 @@ make_blockdev_path(uint8_t *buf, ssize_t size, struct disk_info *info)
 		rc = sysfs_test_sata(linkbuf+loff, PATH_MAX-off);
 		if (rc < 0)
 			return -1;
-		if (!found && rc > 0) {
+		else if (rc > 0) {
 			ssize_t linksz=0;
 			rc = sysfs_parse_sata(buf+off, size?size-off:0, &sz,
 					      linkbuf+loff, PATH_MAX-off,

--- a/src/util.h
+++ b/src/util.h
@@ -292,4 +292,14 @@ get_sector_size(int filedes)
 		_rc;							\
 	})
 
+#ifndef strndupa
+#define strndupa(s, l) \
+       (__extension__ ({const char *__in = (s); \
+                        size_t __len = strnlen (__in, (l)); \
+                        char *__out = (char *) alloca (__len + 1); \
+                        strncpy(__out, __in, __len); \
+                        __out[__len] = '\0'; \
+                        __out; }))
+#endif
+
 #endif /* EFIVAR_UTIL_H */


### PR DESCRIPTION
 - musl does not include strndupa in string.h
 - `found` is always false at [linux.c:940](https://github.com/rhboot/efivar/blob/master/src/linux.c#L940) (just a random nit, not required to compile with musl)