### PR TITLE
Add efi_get_variable_exists()

### DIFF
--- a/docs/efi_get_variable.3
+++ b/docs/efi_get_variable.3
@@ -17,6 +17,8 @@ manipulate UEFI variables
 \fBint efi_get_variable_attributes(efi_guid_t \fR\fIguid\fR\fB, const char *\fR\fIname\fR\fB,
 						  uint32_t *\fR\fIattributes\fR\fB);\fR
 
+\fBint efi_get_variable_exists(efi_guid_t\fR \fIguid\fR\fB, const char\fR \fI*name\fR\fB);\fR
+
 \fBint efi_get_variable_size(efi_guid_t \fR\fIguid\fR\fB, const char *\fR\fIname\fR\fB,
 					 size_t *\fR\fIsize\fR\fB);\fR
 
@@ -57,6 +59,9 @@ gets the variable specified by \fIguid\fR and \fIname\fR. The value is stored in
 .PP
 .BR efi_get_variable_attributes ()
 gets attributes for the variable specified by \fIguid\fR and \fIname\fR.
+.PP
+.BR efi_get_variable_exists ()
+gets if the variable specified by \fIguid\fR and \fIname\fR exists.
 .PP
 .BR efi_get_variable_size ()
 gets the size of the data for the variable specified by \fIguid\fR and \fIname\fR.
@@ -101,7 +106,7 @@ translates from a libefivar efi_guid_$FOO symbol name to an efi_guid_t the calle
 .IR errno (3)
 is set appropriately.
 .PP
-\fBefi_del_variable\fR(), \fBefi_get_variable\fR(), \fBefi_get_variable_attributes\fR(), \fBefi_get_variable_size\fR(), \fBefi_append_variable\fR(), \fBefi_set_variable\fR(), \fBefi_str_to_guid\fR(), \fBefi_guid_to_str\fR(), \fBefi_name_to_guid\fR(), and \fBefi_guid_to_name\fR() return negative on error and zero on success.
+\fBefi_del_variable\fR(), \fBefi_get_variable\fR(), \fBefi_get_variable_attributes\fR(), \fBefi_get_variable_exists\fR(), \fBefi_get_variable_size\fR(), \fBefi_append_variable\fR(), \fBefi_set_variable\fR(), \fBefi_str_to_guid\fR(), \fBefi_guid_to_str\fR(), \fBefi_name_to_guid\fR(), and \fBefi_guid_to_name\fR() return negative on error and zero on success.
 .SH AUTHORS
 .nf
 Peter Jones <pjones@redhat.com>

--- a/src/include/efivar/efivar.h
+++ b/src/include/efivar/efivar.h
@@ -88,6 +88,8 @@ extern int efi_get_variable_size(efi_guid_t guid, const char *name,
 extern int efi_get_variable_attributes(efi_guid_t, const char *name,
 				       uint32_t *attributes)
 				__attribute__((__nonnull__ (2, 3)));
+extern int efi_get_variable_exists(efi_guid_t, const char *name)
+				__attribute__((__nonnull__ (2)));
 extern int efi_get_variable(efi_guid_t guid, const char *name, uint8_t **data,
 			    size_t *data_size, uint32_t *attributes)
 				__attribute__((__nonnull__ (2, 3, 4, 5)));

--- a/src/lib.c
+++ b/src/lib.c
@@ -176,6 +176,15 @@ efi_get_variable_attributes(efi_guid_t guid, const char *name,
 }
 
 int
+__attribute__((__nonnull__ (2)))
+__attribute__((__visibility__ ("default")))
+efi_get_variable_exists(efi_guid_t guid, const char *name)
+{
+	uint32_t unused_attributes = 0;
+	return efi_get_variable_attributes(guid, name, &unused_attributes);
+}
+
+int
 __attribute__((__nonnull__ (2, 3)))
 __attribute__((__visibility__ ("default")))
 efi_get_variable_size(efi_guid_t guid, const char *name, size_t *size)

--- a/src/libefivar.abixml
+++ b/src/libefivar.abixml
@@ -16,6 +16,7 @@
     <elf-symbol name='efi_get_variable' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_get_variable_attributes' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_get_variable_size' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='efi_get_variable_exists' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_guid_cmp' version='LIBEFIVAR_0.24' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_guid_is_empty' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_guid_to_id_guid' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -269,6 +270,11 @@
       <parameter type-id='type-id-2' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='181' column='1'/>
       <parameter type-id='type-id-37' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='181' column='1'/>
       <parameter type-id='type-id-32' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='181' column='1'/>
+      <return type-id='type-id-1'/>
+    </function-decl>
+    <function-decl name='efi_get_variable_exists' mangled-name='efi_get_variable_exists' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable_exists@@libefivar.so.0'>
+      <parameter type-id='type-id-2' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='181' column='1'/>
+      <parameter type-id='type-id-37' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='181' column='1'/>
       <return type-id='type-id-1'/>
     </function-decl>
     <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-41'/>

--- a/src/libefivar.map.in
+++ b/src/libefivar.map.in
@@ -5,6 +5,7 @@ libefivar.so.0 {
 		efi_get_next_variable_name;
 		efi_get_variable;
 		efi_get_variable_attributes;
+		efi_get_variable_exists;
 		efi_get_variable_size;
 		efi_guid_is_empty;
 		efi_guid_to_id_guid;

--- a/src/test/tester.c
+++ b/src/test/tester.c
@@ -136,6 +136,11 @@ int do_test(struct test *test)
 	if (rc < 0)
 		report_error(test, ret, rc, "get size test failed: %m\n");
 
+	printf("testing efi_get_variable_exists()\n");
+	rc = efi_get_variable_exists(TEST_GUID, test->name);
+	if (rc < 0)
+		report_error(test, ret, rc, "get exists test failed: %m\n");
+
 	if (datasize != test->size)
 		report_error(test, ret, -1, "get size test failed: wrong size: %zd should be %zd\n", datasize, test->size);
 


### PR DESCRIPTION
Sometimes we just want to know if a variable exists, and don't care about the
attributes or what the variable contains. Use efi_get_variable_attributes()
under the covers to avoid adding yet-another-fvunc to all the backends.