### PR TITLE
efivar: fix efi_well_known_guids and efi_well_known_guids_end definit…

### DIFF
--- a/src/efivar.c
+++ b/src/efivar.c
@@ -486,13 +486,13 @@ int main(int argc, char *argv[])
 		case ACTION_LIST_GUIDS: {
 			efi_guid_t sentinal = {0xffffffff,0xffff,0xffff,0xffff,
 					       {0xff,0xff,0xff,0xff,0xff,0xff}};
-			extern struct guidname efi_well_known_guids[];
-			extern struct guidname *efi_well_known_guids_end;
+			extern struct guidname efi_well_known_guids;
+			extern struct guidname efi_well_known_guids_end;
 			intptr_t start = (intptr_t)&efi_well_known_guids;
 			intptr_t end = (intptr_t)&efi_well_known_guids_end;
 			unsigned int i;
 
-			struct guidname *guid = &efi_well_known_guids[0];
+			struct guidname *guid = &efi_well_known_guids;
 			for (i = 0; i < (end-start) / sizeof(*guid); i++) {
 				if (!efi_guid_cmp(&sentinal, &guid[i].guid))
 					break;


### PR DESCRIPTION
…ions

From github:

build command: make CROSS_COMPILE=aarch64-linux-gnu- prefix=/home/b58867/Desktop/ls1043ardb/efivar/efivar_arm64 static

compilation error:
aarch64-linux-gnu-gcc -O2 -flto -g3 -I/home/b58867/Desktop/ls1043ardb/efivar/src/include/ -specs=/home/b58867/Desktop/ls1043ardb/efivar/gcc.specs -L. -Wl,-z,muldefs -static -o efivar-static efivar.c dp.static.o dp-acpi.static.o dp-hw.static.o dp-media.static.o dp-message.static.o efivarfs.static.o error.static.o export.static.o guid.static.o guids.static.o guid-symbols.static.o lib.static.o vars.static.o -ldl
guid.c:112:24: error: type of ‘efi_well_known_guids_end’ does not match original declaration [-Werror]
extern struct guidname efi_well_known_guids_end
^
efivar.c:490:28: note: previously declared here
extern struct guidname *efi_well_known_guids_end;
^
efivar.c:489:27: error: type of ‘efi_well_known_guids’ does not match original declaration [-Werror]
extern struct guidname efi_well_known_guids[];
^
guid.c:108:24: note: previously declared here
extern struct guidname efi_well_known_guids
^
lto1: all warnings being treated as errors
lto-wrapper: fatal error: aarch64-linux-gnu-gcc returned 1 exit status

Fixes github issue #102

Signed-off-by: Peter Jones <pjones@redhat.com>