### PR TITLE
Make NVDIMM support actually work.

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -33,6 +33,7 @@ clang_cflags = -D_GNU_SOURCE -std=gnu11 -Wno-address-of-packed-member
 gcc_cflags = -specs=$(TOPDIR)/gcc.specs
 cflags	= $(CFLAGS) -I${TOPDIR}/src/include/ \
 	$(if $(findstring clang,$(CC)),$(clang_cflags),) \
+	$(if $(findstring ccc-analyzer,$(CC)),$(clang_cflags),) \
 	$(if $(findstring gcc,$(CC)),$(gcc_cflags),) \
 	$(call pkg-config-cflags)
 clang_ccldflags =
@@ -40,6 +41,7 @@ gcc_ccldflags =
 ccldflags = $(cflags) -L. $(CCLDFLAGS) $(LDFLAGS) \
 	-Wl,-z,muldefs \
 	$(if $(findstring clang,$(CCLD)),$(clang_ccldflags),) \
+	$(if $(findstring ccc-analyzer,$(CCLD)),$(clang_ccldflags),) \
 	$(if $(findstring gcc,$(CCLD)),$(gcc_ccldflags),) \
 	$(call pkg-config-ldflags)
 SOFLAGS=-shared

--- a/Make.rules
+++ b/Make.rules
@@ -24,6 +24,7 @@ include $(TOPDIR)/Make.version
 
 %.abixml : %.so
 	$(ABIDW) --headers-dir $(TOPDIR)/src/include/efivar/ --out-file $@ $^
+	@sed -i -s 's,$(TOPDIR)/,,g' $@
 
 %.abicheck : %.so
 	$(ABIDIFF) \

--- a/Make.rules
+++ b/Make.rules
@@ -21,6 +21,7 @@ include $(TOPDIR)/Make.version
 	  -Wl,-soname,$@.1 \
 	  -Wl,--version-script=$(MAP) \
 	  -o $@ $^ $(LDLIBS)
+	ln -vfs $@ $@.1
 
 %.abixml : %.so
 	$(ABIDW) --headers-dir $(TOPDIR)/src/include/efivar/ --out-file $@ $^

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,10 @@ install :
 abidw abicheck efivar efivar-static static:
 	$(MAKE) -C src $@
 
+abiupdate :
+	$(MAKE) clean all
+	$(MAKE) -C src abiclean abixml
+
 $(SUBDIRS) :
 	$(MAKE) -C $@
 
@@ -35,7 +39,7 @@ a :
 		exit 1 ; \
 	fi
 
-.PHONY: $(SUBDIRS) a brick
+.PHONY: $(SUBDIRS) a brick abiupdate
 
 GITTAG = $(shell bash -c "echo $$(($(VERSION) + 1))")
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -34,6 +34,12 @@ all : $(TARGETS)
 
 static : $(STATICTARGETS)
 
+abiclean :
+	@rm -vf $(patsubst %.so,%.abixml,$@)
+
+abixml : | $(LIBTARGETS)
+abixml : $(patsubst %.so,%.abixml,$(LIBTARGETS))
+
 abidw : $(patsubst %.so,%.abixml,$(LIBTARGETS))
 	git commit -s --amend $^
 
@@ -104,7 +110,7 @@ install : all
 test : all
 	$(MAKE) -C test $@
 
-.PHONY: test deps
+.PHONY: test deps abiclean abixml
 .SECONDARY : libefivar.so.1.$(VERSION) libefivar.so.1
 .SECONDARY : libefiboot.so.1.$(VERSION) libefivar.so.1
 .SECONDARY : include/efivar/efivar-guids.h guid-symbols.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@ TARGETS=$(LIBTARGETS) $(BINTARGETS) $(PCTARGETS)
 STATICTARGETS=$(STATICLIBTARGETS) $(STATICBINTARGETS)
 
 LIBEFIBOOT_SOURCES = crc32.c creator.c disk.c gpt.c loadopt.c path-helpers.c \
-		     linux.c
+		     linux.c $(wildcard linux-*.c)
 LIBEFIBOOT_OBJECTS = $(patsubst %.c,%.o,$(LIBEFIBOOT_SOURCES))
 LIBEFIVAR_SOURCES = dp.c dp-acpi.c dp-hw.c dp-media.c dp-message.c \
 	efivarfs.c error.c export.c guid.c guids.S guid-symbols.c \

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,7 +14,8 @@ PCTARGETS=efivar.pc efiboot.pc
 TARGETS=$(LIBTARGETS) $(BINTARGETS) $(PCTARGETS)
 STATICTARGETS=$(STATICLIBTARGETS) $(STATICBINTARGETS)
 
-LIBEFIBOOT_SOURCES = crc32.c creator.c disk.c gpt.c linux.c loadopt.c
+LIBEFIBOOT_SOURCES = crc32.c creator.c disk.c gpt.c loadopt.c path-helpers.c \
+		     linux.c
 LIBEFIBOOT_OBJECTS = $(patsubst %.c,%.o,$(LIBEFIBOOT_SOURCES))
 LIBEFIVAR_SOURCES = dp.c dp-acpi.c dp-hw.c dp-media.c dp-message.c \
 	efivarfs.c error.c export.c guid.c guids.S guid-symbols.c \

--- a/src/disk.h
+++ b/src/disk.h
@@ -21,8 +21,10 @@
 #ifndef _EFIBOOT_DISK_H
 #define _EFIBOOT_DISK_H
 
+extern bool HIDDEN is_partitioned(int fd);
+
 extern HIDDEN ssize_t _make_hd_dn(uint8_t *buf, ssize_t size, int fd,
-                                  uint32_t partition, uint32_t options);
+                                  int32_t partition, uint32_t options);
 #define make_hd_dn(buf, size, off, fd, partition, option) \
 	_make_hd_dn(((buf)+(off)), ((size)?((size)-(off)):0), (fd),\
 		    (partition), (options))

--- a/src/disk.h
+++ b/src/disk.h
@@ -21,9 +21,8 @@
 #ifndef _EFIBOOT_DISK_H
 #define _EFIBOOT_DISK_H
 
-extern ssize_t _make_hd_dn(uint8_t *buf, ssize_t size, int fd,
-			   uint32_t partition, uint32_t options)
-        HIDDEN;
+extern HIDDEN ssize_t _make_hd_dn(uint8_t *buf, ssize_t size, int fd,
+                                  uint32_t partition, uint32_t options);
 #define make_hd_dn(buf, size, off, fd, partition, option) \
 	_make_hd_dn(((buf)+(off)), ((size)?((size)-(off)):0), (fd),\
 		    (partition), (options))

--- a/src/dp-acpi.c
+++ b/src/dp-acpi.c
@@ -262,7 +262,8 @@ efidp_make_acpi_hid(uint8_t *buf, ssize_t size, uint32_t hid, uint32_t uid)
 ssize_t PUBLIC NONNULL(6, 7, 8)
 efidp_make_acpi_hid_ex(uint8_t *buf, ssize_t size,
 		       uint32_t hid, uint32_t uid, uint32_t cid,
-		       char *hidstr, char *uidstr, char *cidstr)
+		       const char *hidstr, const char *uidstr,
+		       const char *cidstr)
 {
 	efidp_acpi_hid_ex *acpi_hid = (efidp_acpi_hid_ex *)buf;
 	ssize_t req;

--- a/src/efivar.h
+++ b/src/efivar.h
@@ -33,6 +33,7 @@
 #include "linux.h"
 #include "crc32.h"
 #include "hexdump.h"
+#include "path-helpers.h"
 
 #endif /* !PRIVATE_EFIVAR_H_ */
 // vim:fenc=utf-8:tw=75:et

--- a/src/efivarfs.c
+++ b/src/efivarfs.c
@@ -348,7 +348,7 @@ efivarfs_set_variable(efi_guid_t guid, const char *name, uint8_t *data,
 	alloc_size = sizeof (attributes) + data_size;
 	buf = malloc(alloc_size);
 	if (buf == NULL) {
-		efi_error("malloc(%zu) failed\n", alloc_size);
+		efi_error("malloc(%zu) failed", alloc_size);
 		goto err;
 	}
 

--- a/src/gpt.c
+++ b/src/gpt.c
@@ -535,14 +535,14 @@ compare_gpts(gpt_header *pgpt, gpt_header *agpt, uint64_t lastlba)
 		return;
 
 	if (le64_to_cpu(pgpt->my_lba) != le64_to_cpu(agpt->alternate_lba)) {
-		efi_error("GPT:Primary header LBA != Alt. header alternate_lba\n"
+		efi_error("GPT:Primary header LBA != Alt. header alternate_lba"
 			  "GPT:0x%" PRIx64 " != 0x%" PRIx64,
 			  (uint64_t)le64_to_cpu(pgpt->my_lba),
 			  (uint64_t)le64_to_cpu(agpt->alternate_lba));
 		error_found++;
 	}
 	if (le64_to_cpu(pgpt->alternate_lba) != le64_to_cpu(agpt->my_lba)) {
-		efi_error("GPT:Primary header alternate_lba != Alt. header my_lba\n"
+		efi_error("GPT:Primary header alternate_lba != Alt. header my_lba"
 			  "GPT:0x%" PRIx64 " != 0x%" PRIx64,
 			  (uint64_t)le64_to_cpu(pgpt->alternate_lba),
 			  (uint64_t)le64_to_cpu(agpt->my_lba));
@@ -550,7 +550,7 @@ compare_gpts(gpt_header *pgpt, gpt_header *agpt, uint64_t lastlba)
 	}
 	if (le64_to_cpu(pgpt->first_usable_lba) !=
 	    le64_to_cpu(agpt->first_usable_lba)) {
-		efi_error("GPT:first_usable_lbas don't match.\n"
+		efi_error("GPT:first_usable_lbas don't match."
 			  "GPT:0x%" PRIx64 " != 0x%" PRIx64,
 			  (uint64_t)le64_to_cpu(pgpt->first_usable_lba),
 			  (uint64_t)le64_to_cpu(agpt->first_usable_lba));
@@ -558,7 +558,7 @@ compare_gpts(gpt_header *pgpt, gpt_header *agpt, uint64_t lastlba)
 	}
 	if (le64_to_cpu(pgpt->last_usable_lba) !=
 	    le64_to_cpu(agpt->last_usable_lba)) {
-		efi_error("GPT:last_usable_lbas don't match.\n"
+		efi_error("GPT:last_usable_lbas don't match."
 			  "GPT:0x%" PRIx64 " != 0x%" PRIx64,
 			  (uint64_t)le64_to_cpu(pgpt->last_usable_lba),
 			  (uint64_t)le64_to_cpu(agpt->last_usable_lba));
@@ -591,14 +591,14 @@ compare_gpts(gpt_header *pgpt, gpt_header *agpt, uint64_t lastlba)
 		error_found++;
 	}
 	if (le64_to_cpu(pgpt->alternate_lba) != lastlba) {
-		efi_error("GPT:Primary header thinks Alt. header is not at the end of the disk.\n"
+		efi_error("GPT:Primary header thinks Alt. header is not at the end of the disk."
 			  "GPT:0x%" PRIx64 " != 0x%" PRIx64,
 			  (uint64_t)le64_to_cpu(pgpt->alternate_lba), lastlba);
 		error_found++;
 	}
 
 	if (le64_to_cpu(agpt->my_lba) != lastlba) {
-		efi_error("GPT:Alternate GPT header not at the end of the disk.\n"
+		efi_error("GPT:Alternate GPT header not at the end of the disk."
 			  "GPT:0x%" PRIx64 " != 0x%" PRIx64,
 			  (uint64_t)le64_to_cpu(agpt->my_lba), lastlba);
 		error_found++;

--- a/src/include/efivar/efivar-dp.h
+++ b/src/include/efivar/efivar-dp.h
@@ -133,10 +133,11 @@ typedef struct {
 	/* three ascii string fields follow */
 	char		hidstr[];
 } EFIVAR_PACKED efidp_acpi_hid_ex;
-extern ssize_t efidp_make_acpi_hid_ex(uint8_t *buf, ssize_t size, uint32_t hid,
-				      uint32_t uid, uint32_t cid, char *hidstr,
-				      char *uidstr, char *cidstr)
-	__attribute__((__nonnull__ (6,7,8)));
+extern ssize_t __attribute__((__nonnull__ (6,7,8)))
+efidp_make_acpi_hid_ex(uint8_t *buf, ssize_t size,
+                       uint32_t hid, uint32_t uid, uint32_t cid,
+                       const char *hidstr, const char *uidstr,
+                       const char *cidstr);
 
 #define EFIDP_PNP_EISA_ID_CONST		0x41d0
 #define EFIDP_PNP_ACPI_ID_CONST		0x8e09

--- a/src/lib.c
+++ b/src/lib.c
@@ -226,9 +226,9 @@ efi_variables_supported(void)
 	return 1;
 }
 
-static void libefivar_init(void) CONSTRUCTOR;
+static void CONSTRUCTOR libefivar_init(void);
 
-static void
+static void CONSTRUCTOR
 libefivar_init(void)
 {
 	struct efi_var_operations *ops_list[] = {

--- a/src/libefiboot.abixml
+++ b/src/libefiboot.abixml
@@ -42,287 +42,295 @@
     <type-decl name='unsigned short int' size-in-bits='16' id='type-id-10'/>
     <typedef-decl name='__uint16_t' type-id='type-id-10' filepath='/usr/include/bits/types.h' line='39' column='1' id='type-id-11'/>
     <typedef-decl name='uint16_t' type-id='type-id-11' filepath='/usr/include/bits/stdint-uintn.h' line='25' column='1' id='type-id-6'/>
-    <array-type-def dimensions='0' type-id='type-id-6' size-in-bits='infinite' id='type-id-7'/>
-    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-12'/>
-    <type-decl name='long int' size-in-bits='64' id='type-id-13'/>
-    <typedef-decl name='__ssize_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='181' column='1' id='type-id-14'/>
-    <typedef-decl name='ssize_t' type-id='type-id-14' filepath='/usr/include/sys/types.h' line='109' column='1' id='type-id-15'/>
-    <function-decl name='efi_loadopt_desc' mangled-name='efi_loadopt_desc' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='378' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_desc@@libefiboot.so.0'>
-      <parameter type-id='type-id-12' name='opt' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='378' column='1'/>
-      <parameter type-id='type-id-15' name='limit' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='378' column='1'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-12'/>
+
+    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='16' id='type-id-7'>
+      <subrange length='1' type-id='type-id-12' id='type-id-13'/>
+
+    </array-type-def>
+    <typedef-decl name='efi_load_option' type-id='type-id-4' filepath='include/efivar/efiboot-loadopt.h' line='24' column='1' id='type-id-14'/>
+    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-15'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-16'/>
+    <typedef-decl name='__ssize_t' type-id='type-id-16' filepath='/usr/include/bits/types.h' line='181' column='1' id='type-id-17'/>
+    <typedef-decl name='ssize_t' type-id='type-id-17' filepath='/usr/include/sys/types.h' line='109' column='1' id='type-id-18'/>
+    <function-decl name='efi_loadopt_desc' mangled-name='efi_loadopt_desc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_desc@@libefiboot.so.0'>
+      <parameter type-id='type-id-15' name='opt'/>
+      <parameter type-id='type-id-18' name='limit'/>
       <return type-id='type-id-3'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-16'/>
-    <typedef-decl name='__uint8_t' type-id='type-id-1' filepath='/usr/include/bits/types.h' line='37' column='1' id='type-id-17'/>
-    <typedef-decl name='uint8_t' type-id='type-id-17' filepath='/usr/include/bits/stdint-uintn.h' line='24' column='1' id='type-id-18'/>
-    <pointer-type-def type-id='type-id-18' size-in-bits='64' id='type-id-19'/>
-    <function-decl name='efi_loadopt_args_as_ucs2' mangled-name='efi_loadopt_args_as_ucs2' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='344' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_args_as_ucs2@@libefiboot.so.0'>
-      <parameter type-id='type-id-16' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='344' column='1'/>
-      <parameter type-id='type-id-15' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='344' column='1'/>
-      <parameter type-id='type-id-19' name='utf8' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='344' column='1'/>
-      <return type-id='type-id-15'/>
+    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-19'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-1' filepath='/usr/include/bits/types.h' line='37' column='1' id='type-id-20'/>
+    <typedef-decl name='uint8_t' type-id='type-id-20' filepath='/usr/include/bits/stdint-uintn.h' line='24' column='1' id='type-id-21'/>
+    <pointer-type-def type-id='type-id-21' size-in-bits='64' id='type-id-22'/>
+    <function-decl name='efi_loadopt_args_as_ucs2' mangled-name='efi_loadopt_args_as_ucs2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_args_as_ucs2@@libefiboot.so.0'>
+      <parameter type-id='type-id-19' name='buf'/>
+      <parameter type-id='type-id-18' name='size'/>
+      <parameter type-id='type-id-22' name='utf8'/>
+      <return type-id='type-id-18'/>
     </function-decl>
-    <function-decl name='efi_loadopt_args_as_utf8' mangled-name='efi_loadopt_args_as_utf8' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='317' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_args_as_utf8@@libefiboot.so.0'>
-      <parameter type-id='type-id-19' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='317' column='1'/>
-      <parameter type-id='type-id-15' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='317' column='1'/>
-      <parameter type-id='type-id-19' name='utf8' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='317' column='1'/>
-      <return type-id='type-id-15'/>
+    <function-decl name='efi_loadopt_args_as_utf8' mangled-name='efi_loadopt_args_as_utf8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_args_as_utf8@@libefiboot.so.0'>
+      <parameter type-id='type-id-22' name='buf'/>
+      <parameter type-id='type-id-18' name='size'/>
+      <parameter type-id='type-id-22' name='utf8'/>
+      <parameter type-id='type-id-22' name='buf'/>
+      <parameter type-id='type-id-18' name='size'/>
+      <parameter type-id='type-id-22' name='utf8'/>
+      <return type-id='type-id-18'/>
     </function-decl>
-    <type-decl name='char' size-in-bits='8' id='type-id-20'/>
-    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-21'/>
-    <function-decl name='efi_loadopt_args_from_file' mangled-name='efi_loadopt_args_from_file' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='272' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_args_from_file@@libefiboot.so.0'>
-      <parameter type-id='type-id-19' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='272' column='1'/>
-      <parameter type-id='type-id-15' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='272' column='1'/>
-      <parameter type-id='type-id-21' name='filename' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='272' column='1'/>
-      <return type-id='type-id-15'/>
+    <type-decl name='char' size-in-bits='8' id='type-id-23'/>
+    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-24'/>
+    <function-decl name='efi_loadopt_args_from_file' mangled-name='efi_loadopt_args_from_file' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_args_from_file@@libefiboot.so.0'>
+      <parameter type-id='type-id-22' name='buf'/>
+      <parameter type-id='type-id-18' name='size'/>
+      <parameter type-id='type-id-24' name='filename'/>
+      <return type-id='type-id-18'/>
     </function-decl>
-    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-23'/>
-    <typedef-decl name='size_t' type-id='type-id-23' filepath='/usr/lib/gcc/x86_64-redhat-linux/7/include/stddef.h' line='216' column='1' id='type-id-24'/>
-    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-25'/>
-    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-26'/>
-    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-27'/>
-    <function-decl name='efi_loadopt_optional_data' mangled-name='efi_loadopt_optional_data' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='237' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_optional_data@@libefiboot.so.0'>
-      <parameter type-id='type-id-12' name='opt' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='237' column='1'/>
-      <parameter type-id='type-id-24' name='opt_size' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='237' column='1'/>
-      <parameter type-id='type-id-26' name='datap' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='238' column='1'/>
-      <parameter type-id='type-id-27' name='len' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='238' column='1'/>
-      <return type-id='type-id-22'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-25'/>
+    <typedef-decl name='size_t' type-id='type-id-12' filepath='/usr/lib/gcc/x86_64-redhat-linux/8/include/stddef.h' line='216' column='1' id='type-id-26'/>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-27'/>
+    <pointer-type-def type-id='type-id-27' size-in-bits='64' id='type-id-28'/>
+    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-29'/>
+    <function-decl name='efi_loadopt_optional_data' mangled-name='efi_loadopt_optional_data' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_optional_data@@libefiboot.so.0'>
+      <parameter type-id='type-id-15' name='opt'/>
+      <parameter type-id='type-id-26' name='opt_size'/>
+      <parameter type-id='type-id-28' name='datap'/>
+      <parameter type-id='type-id-29' name='len'/>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='832' column='1' id='type-id-28'>
+    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='832' column='1' id='type-id-30'>
       <data-member access='private'>
-        <var-decl name='' type-id='type-id-29' visibility='default'/>
+        <var-decl name='' type-id='type-id-31' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='838' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='838' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='pci' type-id='type-id-31' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='839' column='1'/>
+        <var-decl name='pci' type-id='type-id-33' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='839' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='pccard' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='840' column='1'/>
+        <var-decl name='pccard' type-id='type-id-34' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='840' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='mmio' type-id='type-id-33' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='841' column='1'/>
+        <var-decl name='mmio' type-id='type-id-35' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='841' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='hw_vendor' type-id='type-id-34' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='842' column='1'/>
+        <var-decl name='hw_vendor' type-id='type-id-36' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='842' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='controller' type-id='type-id-35' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='843' column='1'/>
+        <var-decl name='controller' type-id='type-id-37' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='843' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='bmc' type-id='type-id-36' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='844' column='1'/>
+        <var-decl name='bmc' type-id='type-id-38' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='844' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='acpi_hid' type-id='type-id-37' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='845' column='1'/>
+        <var-decl name='acpi_hid' type-id='type-id-39' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='845' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='acpi_hid_ex' type-id='type-id-38' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='846' column='1'/>
+        <var-decl name='acpi_hid_ex' type-id='type-id-40' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='846' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='acpi_adr' type-id='type-id-39' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='847' column='1'/>
+        <var-decl name='acpi_adr' type-id='type-id-41' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='847' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='atapi' type-id='type-id-40' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='848' column='1'/>
+        <var-decl name='atapi' type-id='type-id-42' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='848' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='scsi' type-id='type-id-41' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='849' column='1'/>
+        <var-decl name='scsi' type-id='type-id-43' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='849' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='fc' type-id='type-id-42' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='850' column='1'/>
+        <var-decl name='fc' type-id='type-id-44' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='850' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='fcex' type-id='type-id-43' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='851' column='1'/>
+        <var-decl name='fcex' type-id='type-id-45' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='851' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='firewire' type-id='type-id-44' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='852' column='1'/>
+        <var-decl name='firewire' type-id='type-id-46' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='852' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='usb' type-id='type-id-45' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='853' column='1'/>
+        <var-decl name='usb' type-id='type-id-47' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='853' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='usb_class' type-id='type-id-46' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='854' column='1'/>
+        <var-decl name='usb_class' type-id='type-id-48' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='854' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='usb_wwid' type-id='type-id-47' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='855' column='1'/>
+        <var-decl name='usb_wwid' type-id='type-id-49' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='855' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='lun' type-id='type-id-48' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='856' column='1'/>
+        <var-decl name='lun' type-id='type-id-50' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='856' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sata' type-id='type-id-49' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='857' column='1'/>
+        <var-decl name='sata' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='857' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='i2o' type-id='type-id-50' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='858' column='1'/>
+        <var-decl name='i2o' type-id='type-id-52' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='858' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='mac_addr' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='859' column='1'/>
+        <var-decl name='mac_addr' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='859' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='ipv4_addr' type-id='type-id-52' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='860' column='1'/>
+        <var-decl name='ipv4_addr' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='860' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='ipv6_addr' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='861' column='1'/>
+        <var-decl name='ipv6_addr' type-id='type-id-55' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='861' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='vlan' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='862' column='1'/>
+        <var-decl name='vlan' type-id='type-id-56' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='862' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='infiniband' type-id='type-id-55' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='863' column='1'/>
+        <var-decl name='infiniband' type-id='type-id-57' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='863' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='uart' type-id='type-id-56' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='864' column='1'/>
+        <var-decl name='uart' type-id='type-id-58' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='864' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='msg_vendor' type-id='type-id-57' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='865' column='1'/>
+        <var-decl name='msg_vendor' type-id='type-id-59' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='865' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='uart_flow_control' type-id='type-id-58' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='866' column='1'/>
+        <var-decl name='uart_flow_control' type-id='type-id-60' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='866' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sas' type-id='type-id-59' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='867' column='1'/>
+        <var-decl name='sas' type-id='type-id-61' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='867' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sas_ex' type-id='type-id-60' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='868' column='1'/>
+        <var-decl name='sas_ex' type-id='type-id-62' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='868' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='iscsi' type-id='type-id-61' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='869' column='1'/>
+        <var-decl name='iscsi' type-id='type-id-63' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='869' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='nvme' type-id='type-id-62' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='870' column='1'/>
+        <var-decl name='nvme' type-id='type-id-64' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='870' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='uri' type-id='type-id-63' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='871' column='1'/>
+        <var-decl name='uri' type-id='type-id-65' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='871' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='ufs' type-id='type-id-64' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='872' column='1'/>
+        <var-decl name='ufs' type-id='type-id-66' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='872' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sd' type-id='type-id-65' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='873' column='1'/>
+        <var-decl name='sd' type-id='type-id-67' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='873' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='bt' type-id='type-id-66' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='874' column='1'/>
+        <var-decl name='bt' type-id='type-id-68' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='874' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='wifi' type-id='type-id-67' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='875' column='1'/>
+        <var-decl name='wifi' type-id='type-id-69' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='875' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='emmc' type-id='type-id-68' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='876' column='1'/>
+        <var-decl name='emmc' type-id='type-id-70' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='876' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='btle' type-id='type-id-69' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='877' column='1'/>
+        <var-decl name='btle' type-id='type-id-71' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='877' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='dns' type-id='type-id-70' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='878' column='1'/>
+        <var-decl name='dns' type-id='type-id-72' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='878' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='nvdimm' type-id='type-id-71' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='879' column='1'/>
+        <var-decl name='nvdimm' type-id='type-id-73' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='879' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='hd' type-id='type-id-72' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='880' column='1'/>
+        <var-decl name='hd' type-id='type-id-74' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='880' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='cdrom' type-id='type-id-73' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='881' column='1'/>
+        <var-decl name='cdrom' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='881' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='media_vendor' type-id='type-id-74' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='882' column='1'/>
+        <var-decl name='media_vendor' type-id='type-id-76' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='882' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='file' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='883' column='1'/>
+        <var-decl name='file' type-id='type-id-77' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='883' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='protocol' type-id='type-id-76' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='884' column='1'/>
+        <var-decl name='protocol' type-id='type-id-78' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='884' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='firmware_file' type-id='type-id-77' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='885' column='1'/>
+        <var-decl name='firmware_file' type-id='type-id-79' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='885' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='firmware_volume' type-id='type-id-78' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='886' column='1'/>
+        <var-decl name='firmware_volume' type-id='type-id-80' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='886' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='relative_offset' type-id='type-id-79' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='887' column='1'/>
+        <var-decl name='relative_offset' type-id='type-id-81' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='887' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='ramdisk' type-id='type-id-80' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='888' column='1'/>
+        <var-decl name='ramdisk' type-id='type-id-82' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='888' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='bios_boot' type-id='type-id-81' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='889' column='1'/>
+        <var-decl name='bios_boot' type-id='type-id-83' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='889' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='833' column='1' id='type-id-29'>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='833' column='1' id='type-id-31'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='type' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='834' column='1'/>
+        <var-decl name='type' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='834' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8'>
-        <var-decl name='subtype' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='835' column='1'/>
+        <var-decl name='subtype' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='835' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
         <var-decl name='length' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='836' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='36' column='1' id='type-id-82'>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='36' column='1' id='type-id-84'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='type' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='37' column='1'/>
+        <var-decl name='type' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='37' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8'>
-        <var-decl name='subtype' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='38' column='1'/>
+        <var-decl name='subtype' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='38' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
         <var-decl name='length' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='39' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_header' type-id='type-id-82' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='40' column='1' id='type-id-30'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-31' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='55' column='1' id='type-id-83'>
+    <typedef-decl name='efidp_header' type-id='type-id-84' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='40' column='1' id='type-id-32'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-33' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='55' column='1' id='type-id-85'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='56' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='56' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='function' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='57' column='1'/>
+        <var-decl name='function' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='57' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='device' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='58' column='1'/>
+        <var-decl name='device' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='58' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_pci' type-id='type-id-83' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='59' column='1' id='type-id-31'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='64' column='1' id='type-id-84'>
+    <typedef-decl name='efidp_pci' type-id='type-id-85' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='59' column='1' id='type-id-33'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-34' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='64' column='1' id='type-id-86'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='65' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='65' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='function' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='66' column='1'/>
+        <var-decl name='function' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='66' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_pccard' type-id='type-id-84' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='67' column='1' id='type-id-32'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-33' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='70' column='1' id='type-id-85'>
+    <typedef-decl name='efidp_pccard' type-id='type-id-86' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='67' column='1' id='type-id-34'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-35' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='70' column='1' id='type-id-87'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='71' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='71' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='memory_type' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='starting_address' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='73' column='1'/>
+        <var-decl name='starting_address' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='73' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='ending_address' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='74' column='1'/>
+        <var-decl name='ending_address' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='74' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='__uint64_t' type-id='type-id-23' filepath='/usr/include/bits/types.h' line='44' column='1' id='type-id-87'/>
-    <typedef-decl name='uint64_t' type-id='type-id-87' filepath='/usr/include/bits/stdint-uintn.h' line='27' column='1' id='type-id-86'/>
-    <typedef-decl name='efidp_mmio' type-id='type-id-85' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='75' column='1' id='type-id-33'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-34' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='750' column='1' id='type-id-88'>
+    <typedef-decl name='__uint64_t' type-id='type-id-12' filepath='/usr/include/bits/types.h' line='44' column='1' id='type-id-89'/>
+    <typedef-decl name='uint64_t' type-id='type-id-89' filepath='/usr/include/bits/stdint-uintn.h' line='27' column='1' id='type-id-88'/>
+    <typedef-decl name='efidp_mmio' type-id='type-id-87' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='75' column='1' id='type-id-35'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-36' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='78' column='1' id='type-id-90'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='751' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='79' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-89' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='752' column='1'/>
+        <var-decl name='vendor_guid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='80' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='vendor_data' type-id='type-id-90' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='753' column='1'/>
+        <var-decl name='vendor_data' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='81' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-89' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='33' column='1' id='type-id-91'>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='33' column='1' id='type-id-93'>
       <data-member access='public' layout-offset-in-bits='0'>
         <var-decl name='a' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='34' column='1'/>
       </data-member>
@@ -336,39 +344,45 @@
         <var-decl name='d' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='37' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='e' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='38' column='1'/>
+        <var-decl name='e' type-id='type-id-94' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='38' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='1' type-id='type-id-18' size-in-bits='48' id='type-id-92'>
-      <subrange length='6'/>
+
+    <array-type-def dimensions='1' type-id='type-id-21' size-in-bits='48' id='type-id-94'>
+      <subrange length='6' type-id='type-id-12' id='type-id-95'/>
+
     </array-type-def>
-    <typedef-decl name='efi_guid_t' type-id='type-id-91' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='39' column='1' id='type-id-89'/>
-    <array-type-def dimensions='0' type-id='type-id-18' size-in-bits='infinite' id='type-id-90'/>
-    <typedef-decl name='efidp_hw_vendor' type-id='type-id-88' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='82' column='1' id='type-id-34'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-35' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='99' column='1' id='type-id-93'>
+    <typedef-decl name='efi_guid_t' type-id='type-id-93' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='39' column='1' id='type-id-91'/>
+
+    <array-type-def dimensions='1' type-id='type-id-21' size-in-bits='8' id='type-id-92'>
+      <subrange length='1' type-id='type-id-12' id='type-id-13'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_hw_vendor' type-id='type-id-90' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='82' column='1' id='type-id-36'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-37' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='99' column='1' id='type-id-96'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='100' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='controller' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='101' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_controller' type-id='type-id-93' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='102' column='1' id='type-id-35'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='104' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-36' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='105' column='1' id='type-id-94'>
+    <typedef-decl name='efidp_controller' type-id='type-id-96' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='102' column='1' id='type-id-37'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='104' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-38' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='105' column='1' id='type-id-97'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='interface_type' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='107' column='1'/>
+        <var-decl name='interface_type' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='107' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='base_addr' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='108' column='1'/>
+        <var-decl name='base_addr' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='108' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_bmc' type-id='type-id-94' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='109' column='1' id='type-id-36'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='96' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-37' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='119' column='1' id='type-id-95'>
+    <typedef-decl name='efidp_bmc' type-id='type-id-97' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='109' column='1' id='type-id-38'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='96' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-39' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='119' column='1' id='type-id-98'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='120' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='hid' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='121' column='1'/>
@@ -377,10 +391,10 @@
         <var-decl name='uid' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='122' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_acpi_hid' type-id='type-id-95' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='123' column='1' id='type-id-37'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-38' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='128' column='1' id='type-id-96'>
+    <typedef-decl name='efidp_acpi_hid' type-id='type-id-98' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='123' column='1' id='type-id-39'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-40' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='128' column='1' id='type-id-99'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='129' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='129' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='hid' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='130' column='1'/>
@@ -392,39 +406,47 @@
         <var-decl name='cid' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='132' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='hidstr' type-id='type-id-97' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='134' column='1'/>
+        <var-decl name='hidstr' type-id='type-id-100' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='134' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='0' type-id='type-id-20' size-in-bits='infinite' id='type-id-97'/>
-    <typedef-decl name='efidp_acpi_hid_ex' type-id='type-id-96' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='135' column='1' id='type-id-38'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-39' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='165' column='1' id='type-id-98'>
+
+    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='8' id='type-id-100'>
+      <subrange length='1' type-id='type-id-12' id='type-id-13'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_acpi_hid_ex' type-id='type-id-99' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='135' column='1' id='type-id-40'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-41' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='165' column='1' id='type-id-101'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='166' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='166' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='adr' type-id='type-id-99' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='167' column='1'/>
+        <var-decl name='adr' type-id='type-id-102' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='167' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='0' type-id='type-id-5' size-in-bits='infinite' id='type-id-99'/>
-    <typedef-decl name='efidp_acpi_adr' type-id='type-id-98' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='168' column='1' id='type-id-39'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-40' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='326' column='1' id='type-id-100'>
+
+    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='32' id='type-id-102'>
+      <subrange length='1' type-id='type-id-12' id='type-id-13'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_acpi_adr' type-id='type-id-101' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='168' column='1' id='type-id-41'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-42' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='326' column='1' id='type-id-103'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='327' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='327' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='primary' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='328' column='1'/>
+        <var-decl name='primary' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='328' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='slave' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='329' column='1'/>
+        <var-decl name='slave' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='329' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
         <var-decl name='lun' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='330' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_atapi' type-id='type-id-100' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='331' column='1' id='type-id-40'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-41' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='336' column='1' id='type-id-101'>
+    <typedef-decl name='efidp_atapi' type-id='type-id-103' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='331' column='1' id='type-id-42'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-43' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='336' column='1' id='type-id-104'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='337' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='337' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='target' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='338' column='1'/>
@@ -433,67 +455,69 @@
         <var-decl name='lun' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='339' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_scsi' type-id='type-id-101' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='340' column='1' id='type-id-41'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-42' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='345' column='1' id='type-id-102'>
+    <typedef-decl name='efidp_scsi' type-id='type-id-104' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='340' column='1' id='type-id-43'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-44' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='345' column='1' id='type-id-105'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='346' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='346' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='reserved' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='347' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='wwn' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='348' column='1'/>
+        <var-decl name='wwn' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='348' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='lun' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='349' column='1'/>
+        <var-decl name='lun' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='349' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_fc' type-id='type-id-102' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='350' column='1' id='type-id-42'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-43' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='353' column='1' id='type-id-103'>
+    <typedef-decl name='efidp_fc' type-id='type-id-105' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='350' column='1' id='type-id-44'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-45' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='353' column='1' id='type-id-106'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='354' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='354' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='reserved' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='355' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='wwn' type-id='type-id-104' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='356' column='1'/>
+        <var-decl name='wwn' type-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='356' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='lun' type-id='type-id-104' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='357' column='1'/>
+        <var-decl name='lun' type-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='357' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='1' type-id='type-id-18' size-in-bits='64' id='type-id-104'>
-      <subrange length='8'/>
+
+    <array-type-def dimensions='1' type-id='type-id-21' size-in-bits='64' id='type-id-107'>
+      <subrange length='8' type-id='type-id-12' id='type-id-108'/>
+
     </array-type-def>
-    <typedef-decl name='efidp_fcex' type-id='type-id-103' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='358' column='1' id='type-id-43'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-44' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='361' column='1' id='type-id-105'>
+    <typedef-decl name='efidp_fcex' type-id='type-id-106' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='358' column='1' id='type-id-45'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-46' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='361' column='1' id='type-id-109'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='362' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='362' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='reserved' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='363' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='guid' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='364' column='1'/>
+        <var-decl name='guid' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='364' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_1394' type-id='type-id-105' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='365' column='1' id='type-id-44'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-45' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='368' column='1' id='type-id-106'>
+    <typedef-decl name='efidp_1394' type-id='type-id-109' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='365' column='1' id='type-id-46'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-47' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='368' column='1' id='type-id-110'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='369' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='369' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='parent_port' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='370' column='1'/>
+        <var-decl name='parent_port' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='370' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='interface' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='371' column='1'/>
+        <var-decl name='interface' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='371' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_usb' type-id='type-id-106' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='372' column='1' id='type-id-45'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-46' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='375' column='1' id='type-id-107'>
+    <typedef-decl name='efidp_usb' type-id='type-id-110' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='372' column='1' id='type-id-47'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-48' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='375' column='1' id='type-id-111'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='376' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='376' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='vendor_id' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='377' column='1'/>
@@ -502,19 +526,19 @@
         <var-decl name='product_id' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='378' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='device_class' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='379' column='1'/>
+        <var-decl name='device_class' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='379' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='72'>
-        <var-decl name='device_subclass' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='380' column='1'/>
+        <var-decl name='device_subclass' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='380' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='device_protocol' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='381' column='1'/>
+        <var-decl name='device_protocol' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='381' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_usb_class' type-id='type-id-107' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='382' column='1' id='type-id-46'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-47' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='402' column='1' id='type-id-108'>
+    <typedef-decl name='efidp_usb_class' type-id='type-id-111' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='382' column='1' id='type-id-48'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-49' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='402' column='1' id='type-id-112'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='403' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='403' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='interface' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='404' column='1'/>
@@ -529,19 +553,19 @@
         <var-decl name='serial_number' type-id='type-id-7' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='407' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_usb_wwid' type-id='type-id-108' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='408' column='1' id='type-id-47'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-48' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='411' column='1' id='type-id-109'>
+    <typedef-decl name='efidp_usb_wwid' type-id='type-id-112' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='408' column='1' id='type-id-49'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-50' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='411' column='1' id='type-id-113'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='412' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='412' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='lun' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='413' column='1'/>
+        <var-decl name='lun' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='413' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_lun' type-id='type-id-109' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='414' column='1' id='type-id-48'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-49' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='417' column='1' id='type-id-110'>
+    <typedef-decl name='efidp_lun' type-id='type-id-113' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='414' column='1' id='type-id-50'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='417' column='1' id='type-id-114'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='418' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='418' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='hba_port' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='419' column='1'/>
@@ -553,40 +577,42 @@
         <var-decl name='lun' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='421' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_sata' type-id='type-id-110' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='422' column='1' id='type-id-49'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-50' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='428' column='1' id='type-id-111'>
+    <typedef-decl name='efidp_sata' type-id='type-id-114' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='422' column='1' id='type-id-51'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-52' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='428' column='1' id='type-id-115'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='429' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='429' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='target' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='430' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_i2o' type-id='type-id-111' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='431' column='1' id='type-id-50'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='296' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='434' column='1' id='type-id-112'>
+    <typedef-decl name='efidp_i2o' type-id='type-id-115' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='431' column='1' id='type-id-52'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='296' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='434' column='1' id='type-id-116'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='435' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='435' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='mac_addr' type-id='type-id-113' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='436' column='1'/>
+        <var-decl name='mac_addr' type-id='type-id-117' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='436' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='if_type' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='437' column='1'/>
+        <var-decl name='if_type' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='437' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='1' type-id='type-id-18' size-in-bits='256' id='type-id-113'>
-      <subrange length='32'/>
+
+    <array-type-def dimensions='1' type-id='type-id-21' size-in-bits='256' id='type-id-117'>
+      <subrange length='32' type-id='type-id-12' id='type-id-118'/>
+
     </array-type-def>
-    <typedef-decl name='efidp_mac_addr' type-id='type-id-112' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='438' column='1' id='type-id-51'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='216' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-52' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='446' column='1' id='type-id-114'>
+    <typedef-decl name='efidp_mac_addr' type-id='type-id-116' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='438' column='1' id='type-id-53'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='216' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='446' column='1' id='type-id-119'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='447' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='447' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='local_ipv4_addr' type-id='type-id-115' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='448' column='1'/>
+        <var-decl name='local_ipv4_addr' type-id='type-id-120' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='448' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='remote_ipv4_addr' type-id='type-id-115' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='449' column='1'/>
+        <var-decl name='remote_ipv4_addr' type-id='type-id-120' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='449' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
         <var-decl name='local_port' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='450' column='1'/>
@@ -598,29 +624,31 @@
         <var-decl name='protocol' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='452' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='static_ip_addr' type-id='type-id-116' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='453' column='1'/>
+        <var-decl name='static_ip_addr' type-id='type-id-121' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='453' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='152'>
-        <var-decl name='gateway' type-id='type-id-115' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='454' column='1'/>
+        <var-decl name='gateway' type-id='type-id-120' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='454' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='184'>
-        <var-decl name='netmask' type-id='type-id-115' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='455' column='1'/>
+        <var-decl name='netmask' type-id='type-id-120' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='455' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='1' type-id='type-id-18' size-in-bits='32' id='type-id-115'>
-      <subrange length='4'/>
+
+    <array-type-def dimensions='1' type-id='type-id-21' size-in-bits='32' id='type-id-120'>
+      <subrange length='4' type-id='type-id-12' id='type-id-122'/>
+
     </array-type-def>
-    <typedef-decl name='efidp_boolean' type-id='type-id-18' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='43' column='1' id='type-id-116'/>
-    <typedef-decl name='efidp_ipv4_addr' type-id='type-id-114' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='456' column='1' id='type-id-52'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='360' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='468' column='1' id='type-id-117'>
+    <typedef-decl name='efidp_boolean' type-id='type-id-21' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='43' column='1' id='type-id-121'/>
+    <typedef-decl name='efidp_ipv4_addr' type-id='type-id-119' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='456' column='1' id='type-id-54'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='360' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-55' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='468' column='1' id='type-id-123'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='469' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='469' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='local_ipv6_addr' type-id='type-id-118' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='470' column='1'/>
+        <var-decl name='local_ipv6_addr' type-id='type-id-124' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='470' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='remote_ipv6_addr' type-id='type-id-118' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='471' column='1'/>
+        <var-decl name='remote_ipv6_addr' type-id='type-id-124' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='471' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
         <var-decl name='local_port' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='472' column='1'/>
@@ -632,145 +660,160 @@
         <var-decl name='protocol' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='474' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='336'>
-        <var-decl name='ip_addr_origin' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='475' column='1'/>
+        <var-decl name='ip_addr_origin' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='475' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='344'>
-        <var-decl name='prefix_length' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='476' column='1'/>
+        <var-decl name='prefix_length' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='476' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='gateway_ipv6_addr' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='477' column='1'/>
+        <var-decl name='gateway_ipv6_addr' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='477' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='1' type-id='type-id-18' size-in-bits='128' id='type-id-118'>
-      <subrange length='16'/>
+
+    <array-type-def dimensions='1' type-id='type-id-21' size-in-bits='128' id='type-id-124'>
+      <subrange length='16' type-id='type-id-12' id='type-id-125'/>
+
     </array-type-def>
-    <typedef-decl name='efidp_ipv6_addr' type-id='type-id-117' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='478' column='1' id='type-id-53'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='485' column='1' id='type-id-119'>
+    <typedef-decl name='efidp_ipv6_addr' type-id='type-id-123' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='478' column='1' id='type-id-55'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-56' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='485' column='1' id='type-id-126'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='486' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='486' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='vlan_id' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='487' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_vlan' type-id='type-id-119' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='488' column='1' id='type-id-54'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='384' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-55' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='491' column='1' id='type-id-120'>
+    <typedef-decl name='efidp_vlan' type-id='type-id-126' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='488' column='1' id='type-id-56'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='384' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-57' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='491' column='1' id='type-id-127'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='492' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='492' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='resource_flags' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='493' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='port_gid' type-id='type-id-121' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='494' column='1'/>
+        <var-decl name='port_gid' type-id='type-id-128' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='494' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='' type-id='type-id-122' visibility='default'/>
+        <var-decl name='' type-id='type-id-129' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='target_port_id' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='499' column='1'/>
+        <var-decl name='target_port_id' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='499' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='device_id' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='500' column='1'/>
+        <var-decl name='device_id' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='500' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='1' type-id='type-id-86' size-in-bits='128' id='type-id-121'>
-      <subrange length='2'/>
+
+    <array-type-def dimensions='1' type-id='type-id-88' size-in-bits='128' id='type-id-128'>
+      <subrange length='2' type-id='type-id-12' id='type-id-130'/>
+
     </array-type-def>
-    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='495' column='1' id='type-id-122'>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='495' column='1' id='type-id-129'>
       <data-member access='private'>
-        <var-decl name='ioc_guid' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='496' column='1'/>
+        <var-decl name='ioc_guid' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='496' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='service_id' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='497' column='1'/>
+        <var-decl name='service_id' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='497' column='1'/>
       </data-member>
     </union-decl>
-    <typedef-decl name='efidp_infiniband' type-id='type-id-120' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='501' column='1' id='type-id-55'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='152' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-56' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='510' column='1' id='type-id-123'>
+    <typedef-decl name='efidp_infiniband' type-id='type-id-127' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='501' column='1' id='type-id-57'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='152' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-58' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='510' column='1' id='type-id-131'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='511' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='511' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='reserved' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='512' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='baud_rate' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='513' column='1'/>
+        <var-decl name='baud_rate' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='513' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='data_bits' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='514' column='1'/>
+        <var-decl name='data_bits' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='514' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='136'>
-        <var-decl name='parity' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='515' column='1'/>
+        <var-decl name='parity' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='515' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='stop_bits' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='516' column='1'/>
+        <var-decl name='stop_bits' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='516' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_uart' type-id='type-id-123' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='517' column='1' id='type-id-56'/>
-    <typedef-decl name='efidp_msg_vendor' type-id='type-id-88' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='545' column='1' id='type-id-57'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-58' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='554' column='1' id='type-id-124'>
+    <typedef-decl name='efidp_uart' type-id='type-id-131' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='517' column='1' id='type-id-58'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-59' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='541' column='1' id='type-id-132'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='555' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='542' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-89' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='556' column='1'/>
+        <var-decl name='vendor_guid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='543' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='vendor_data' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='544' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_msg_vendor' type-id='type-id-132' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='545' column='1' id='type-id-59'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-60' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='554' column='1' id='type-id-133'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='555' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='vendor_guid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='556' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
         <var-decl name='flow_control_map' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='557' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_uart_flow_control' type-id='type-id-124' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='558' column='1' id='type-id-58'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='352' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-59' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='565' column='1' id='type-id-125'>
+    <typedef-decl name='efidp_uart_flow_control' type-id='type-id-133' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='558' column='1' id='type-id-60'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='352' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-61' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='565' column='1' id='type-id-134'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='566' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='566' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-89' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='567' column='1'/>
+        <var-decl name='vendor_guid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='567' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
         <var-decl name='reserved' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='568' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='sas_address' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='569' column='1'/>
+        <var-decl name='sas_address' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='569' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='lun' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='570' column='1'/>
+        <var-decl name='lun' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='570' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='device_topology_info' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='571' column='1'/>
+        <var-decl name='device_topology_info' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='571' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='drive_bay_id' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='572' column='1'/>
+        <var-decl name='drive_bay_id' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='572' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='336'>
         <var-decl name='rtp' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='573' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_sas' type-id='type-id-125' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='574' column='1' id='type-id-59'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-60' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='598' column='1' id='type-id-126'>
+    <typedef-decl name='efidp_sas' type-id='type-id-134' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='574' column='1' id='type-id-61'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-62' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='598' column='1' id='type-id-135'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='599' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='599' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='sas_address' type-id='type-id-104' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='600' column='1'/>
+        <var-decl name='sas_address' type-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='600' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='lun' type-id='type-id-104' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='601' column='1'/>
+        <var-decl name='lun' type-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='601' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='device_topology_info' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='602' column='1'/>
+        <var-decl name='device_topology_info' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='602' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='168'>
-        <var-decl name='drive_bay_id' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='603' column='1'/>
+        <var-decl name='drive_bay_id' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='603' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='176'>
         <var-decl name='rtp' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='604' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_sas_ex' type-id='type-id-126' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='605' column='1' id='type-id-60'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='144' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-61' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='611' column='1' id='type-id-127'>
+    <typedef-decl name='efidp_sas_ex' type-id='type-id-135' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='605' column='1' id='type-id-62'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='144' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-63' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='611' column='1' id='type-id-136'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='612' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='612' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='protocol' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='613' column='1'/>
@@ -779,250 +822,275 @@
         <var-decl name='options' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='614' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='lun' type-id='type-id-104' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='615' column='1'/>
+        <var-decl name='lun' type-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='615' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
         <var-decl name='tpgt' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='616' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='target_name' type-id='type-id-90' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='617' column='1'/>
+        <var-decl name='target_name' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='617' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_iscsi' type-id='type-id-127' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='618' column='1' id='type-id-61'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-62' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='646' column='1' id='type-id-128'>
+    <typedef-decl name='efidp_iscsi' type-id='type-id-136' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='618' column='1' id='type-id-63'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-64' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='646' column='1' id='type-id-137'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='647' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='647' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='namespace_id' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='648' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='ieee_eui_64' type-id='type-id-104' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='649' column='1'/>
+        <var-decl name='ieee_eui_64' type-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='649' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_nvme' type-id='type-id-128' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='650' column='1' id='type-id-62'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-63' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='655' column='1' id='type-id-129'>
+    <typedef-decl name='efidp_nvme' type-id='type-id-137' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='650' column='1' id='type-id-64'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-65' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='655' column='1' id='type-id-138'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='656' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='656' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='uri' type-id='type-id-90' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='657' column='1'/>
+        <var-decl name='uri' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='657' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_uri' type-id='type-id-129' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='658' column='1' id='type-id-63'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-64' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='661' column='1' id='type-id-130'>
+    <typedef-decl name='efidp_uri' type-id='type-id-138' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='658' column='1' id='type-id-65'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-66' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='661' column='1' id='type-id-139'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='662' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='662' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='target_id' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='663' column='1'/>
+        <var-decl name='target_id' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='663' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='lun' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='664' column='1'/>
+        <var-decl name='lun' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='664' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_ufs' type-id='type-id-130' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='665' column='1' id='type-id-64'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-65' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='668' column='1' id='type-id-131'>
+    <typedef-decl name='efidp_ufs' type-id='type-id-139' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='665' column='1' id='type-id-66'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-67' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='668' column='1' id='type-id-140'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='669' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='669' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='slot_number' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='670' column='1'/>
+        <var-decl name='slot_number' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='670' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_sd' type-id='type-id-131' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='671' column='1' id='type-id-65'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-66' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='674' column='1' id='type-id-132'>
+    <typedef-decl name='efidp_sd' type-id='type-id-140' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='671' column='1' id='type-id-67'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-68' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='674' column='1' id='type-id-141'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='675' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='675' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='addr' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='676' column='1'/>
+        <var-decl name='addr' type-id='type-id-94' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='676' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_bt' type-id='type-id-132' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='677' column='1' id='type-id-66'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='288' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-67' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='680' column='1' id='type-id-133'>
+    <typedef-decl name='efidp_bt' type-id='type-id-141' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='677' column='1' id='type-id-68'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='288' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-69' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='680' column='1' id='type-id-142'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='681' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='681' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='ssid' type-id='type-id-113' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='682' column='1'/>
+        <var-decl name='ssid' type-id='type-id-117' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='682' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_wifi' type-id='type-id-133' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='683' column='1' id='type-id-67'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-68' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='686' column='1' id='type-id-134'>
+    <typedef-decl name='efidp_wifi' type-id='type-id-142' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='683' column='1' id='type-id-69'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-70' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='686' column='1' id='type-id-143'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='687' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='687' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='slot' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='688' column='1'/>
+        <var-decl name='slot' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='688' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_emmc' type-id='type-id-134' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='689' column='1' id='type-id-68'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-69' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='692' column='1' id='type-id-135'>
+    <typedef-decl name='efidp_emmc' type-id='type-id-143' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='689' column='1' id='type-id-70'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-71' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='692' column='1' id='type-id-144'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='693' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='693' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='addr' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='694' column='1'/>
+        <var-decl name='addr' type-id='type-id-94' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='694' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='addr_type' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='695' column='1'/>
+        <var-decl name='addr_type' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='695' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_btle' type-id='type-id-135' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='696' column='1' id='type-id-69'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-70' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='702' column='1' id='type-id-136'>
+    <typedef-decl name='efidp_btle' type-id='type-id-144' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='696' column='1' id='type-id-71'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-72' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='702' column='1' id='type-id-145'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='703' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='703' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='is_ipv6' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='704' column='1'/>
+        <var-decl name='is_ipv6' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='704' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='addrs' type-id='type-id-137' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='705' column='1'/>
+        <var-decl name='addrs' type-id='type-id-146' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='705' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='49' column='1' id='type-id-138'>
+    <union-decl name='__anonymous_union__' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='49' column='1' id='type-id-147'>
       <data-member access='private'>
-        <var-decl name='addr' type-id='type-id-139' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='50' column='1'/>
+        <var-decl name='addr' type-id='type-id-148' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='50' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='v4' type-id='type-id-140' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='51' column='1'/>
+        <var-decl name='v4' type-id='type-id-149' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='51' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='v6' type-id='type-id-141' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='52' column='1'/>
+        <var-decl name='v6' type-id='type-id-150' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='52' column='1'/>
       </data-member>
     </union-decl>
-    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='128' id='type-id-139'>
-      <subrange length='4'/>
+
+    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='128' id='type-id-148'>
+      <subrange length='4' type-id='type-id-12' id='type-id-122'/>
+
     </array-type-def>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-140' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='41' column='1' id='type-id-142'>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-149' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='41' column='1' id='type-id-151'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='addr' type-id='type-id-115' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='42' column='1'/>
+        <var-decl name='addr' type-id='type-id-120' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='42' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efi_ipv4_addr_t' type-id='type-id-142' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='43' column='1' id='type-id-140'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-141' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='45' column='1' id='type-id-143'>
+    <typedef-decl name='efi_ipv4_addr_t' type-id='type-id-151' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='43' column='1' id='type-id-149'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-150' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='45' column='1' id='type-id-152'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='addr' type-id='type-id-118' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='46' column='1'/>
+        <var-decl name='addr' type-id='type-id-124' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='46' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efi_ipv6_addr_t' type-id='type-id-143' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='47' column='1' id='type-id-141'/>
-    <typedef-decl name='efi_ip_addr_t' type-id='type-id-138' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='53' column='1' id='type-id-144'/>
-    <array-type-def dimensions='0' type-id='type-id-144' size-in-bits='infinite' id='type-id-137'/>
-    <typedef-decl name='efidp_dns' type-id='type-id-136' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='706' column='1' id='type-id-70'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-71' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='709' column='1' id='type-id-145'>
+    <typedef-decl name='efi_ipv6_addr_t' type-id='type-id-152' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='47' column='1' id='type-id-150'/>
+    <typedef-decl name='efi_ip_addr_t' type-id='type-id-147' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='53' column='1' id='type-id-153'/>
+
+    <array-type-def dimensions='1' type-id='type-id-153' size-in-bits='128' id='type-id-146'>
+      <subrange length='1' type-id='type-id-12' id='type-id-13'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_dns' type-id='type-id-145' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='706' column='1' id='type-id-72'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-73' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='709' column='1' id='type-id-154'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='710' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='710' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='uuid' type-id='type-id-89' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='711' column='1'/>
+        <var-decl name='uuid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='711' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_nvdimm' type-id='type-id-145' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='712' column='1' id='type-id-71'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='336' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-72' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='717' column='1' id='type-id-146'>
+    <typedef-decl name='efidp_nvdimm' type-id='type-id-154' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='712' column='1' id='type-id-73'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='336' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-74' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='717' column='1' id='type-id-155'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='718' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='718' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='partition_number' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='719' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='start' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='720' column='1'/>
+        <var-decl name='start' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='720' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='size' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='721' column='1'/>
+        <var-decl name='size' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='721' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='signature' type-id='type-id-118' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='722' column='1'/>
+        <var-decl name='signature' type-id='type-id-124' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='722' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='format' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='723' column='1'/>
+        <var-decl name='format' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='723' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='signature_type' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='724' column='1'/>
+        <var-decl name='signature_type' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='724' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_hd' type-id='type-id-146' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='728' column='1' id='type-id-72'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-73' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='742' column='1' id='type-id-147'>
+    <typedef-decl name='efidp_hd' type-id='type-id-155' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='728' column='1' id='type-id-74'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='742' column='1' id='type-id-156'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='743' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='743' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='boot_catalog_entry' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='744' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='partition_rba' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='745' column='1'/>
+        <var-decl name='partition_rba' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='745' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='sectors' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='746' column='1'/>
+        <var-decl name='sectors' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='746' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_cdrom' type-id='type-id-147' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='747' column='1' id='type-id-73'/>
-    <typedef-decl name='efidp_media_vendor' type-id='type-id-88' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='754' column='1' id='type-id-74'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='761' column='1' id='type-id-148'>
+    <typedef-decl name='efidp_cdrom' type-id='type-id-156' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='747' column='1' id='type-id-75'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-76' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='750' column='1' id='type-id-157'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='762' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='751' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='vendor_guid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='752' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='vendor_data' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='753' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_media_vendor' type-id='type-id-157' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='754' column='1' id='type-id-76'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-77' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='761' column='1' id='type-id-158'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='762' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='name' type-id='type-id-7' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='763' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_file' type-id='type-id-148' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='764' column='1' id='type-id-75'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-76' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='768' column='1' id='type-id-149'>
+    <typedef-decl name='efidp_file' type-id='type-id-158' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='764' column='1' id='type-id-77'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-78' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='768' column='1' id='type-id-159'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='769' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='769' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='protocol_guid' type-id='type-id-89' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='770' column='1'/>
+        <var-decl name='protocol_guid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='770' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_protocol' type-id='type-id-149' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='771' column='1' id='type-id-76'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-77' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='780' column='1' id='type-id-150'>
+    <typedef-decl name='efidp_protocol' type-id='type-id-159' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='771' column='1' id='type-id-78'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-79' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='774' column='1' id='type-id-160'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='781' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='775' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='pi_info' type-id='type-id-90' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='782' column='1'/>
+        <var-decl name='pi_info' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='776' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_firmware_file' type-id='type-id-150' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='777' column='1' id='type-id-77'/>
-    <typedef-decl name='efidp_firmware_volume' type-id='type-id-150' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='783' column='1' id='type-id-78'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-79' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='786' column='1' id='type-id-151'>
+    <typedef-decl name='efidp_firmware_file' type-id='type-id-160' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='777' column='1' id='type-id-79'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-80' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='780' column='1' id='type-id-161'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='787' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='781' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='pi_info' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='782' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_firmware_volume' type-id='type-id-161' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='783' column='1' id='type-id-80'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-81' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='786' column='1' id='type-id-162'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='787' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='reserved' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='788' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='first_byte' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='789' column='1'/>
+        <var-decl name='first_byte' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='789' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='last_byte' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='790' column='1'/>
+        <var-decl name='last_byte' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='790' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_relative_offset' type-id='type-id-151' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='791' column='1' id='type-id-79'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='304' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-80' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='794' column='1' id='type-id-152'>
+    <typedef-decl name='efidp_relative_offset' type-id='type-id-162' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='791' column='1' id='type-id-81'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='304' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-82' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='794' column='1' id='type-id-163'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='795' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='795' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='start_addr' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='796' column='1'/>
+        <var-decl name='start_addr' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='796' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='end_addr' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='797' column='1'/>
+        <var-decl name='end_addr' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='797' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='disk_type_guid' type-id='type-id-89' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='798' column='1'/>
+        <var-decl name='disk_type_guid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='798' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
         <var-decl name='instance_number' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='799' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_ramdisk' type-id='type-id-152' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='800' column='1' id='type-id-80'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-81' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='813' column='1' id='type-id-153'>
+    <typedef-decl name='efidp_ramdisk' type-id='type-id-163' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='800' column='1' id='type-id-82'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-83' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='813' column='1' id='type-id-164'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-30' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='814' column='1'/>
+        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='814' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
         <var-decl name='device_type' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='815' column='1'/>
@@ -1031,100 +1099,209 @@
         <var-decl name='status' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='816' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='description' type-id='type-id-90' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='817' column='1'/>
+        <var-decl name='description' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='817' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_bios_boot' type-id='type-id-153' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='818' column='1' id='type-id-81'/>
-    <typedef-decl name='efidp_data' type-id='type-id-28' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='890' column='1' id='type-id-154'/>
-    <pointer-type-def type-id='type-id-154' size-in-bits='64' id='type-id-155'/>
-    <typedef-decl name='efidp' type-id='type-id-155' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='891' column='1' id='type-id-156'/>
-    <function-decl name='efi_loadopt_path' mangled-name='efi_loadopt_path' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='206' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_path@@libefiboot.so.0'>
-      <parameter type-id='type-id-12' name='opt' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='206' column='1'/>
-      <parameter type-id='type-id-15' name='limit' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='206' column='1'/>
-      <return type-id='type-id-156'/>
+    <typedef-decl name='efidp_bios_boot' type-id='type-id-164' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='818' column='1' id='type-id-83'/>
+    <typedef-decl name='efidp_data' type-id='type-id-30' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='890' column='1' id='type-id-165'/>
+    <pointer-type-def type-id='type-id-165' size-in-bits='64' id='type-id-166'/>
+    <typedef-decl name='efidp' type-id='type-id-166' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='891' column='1' id='type-id-167'/>
+    <function-decl name='efi_loadopt_path' mangled-name='efi_loadopt_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_path@@libefiboot.so.0'>
+      <parameter type-id='type-id-15' name='opt'/>
+      <parameter type-id='type-id-18' name='limit'/>
+      <return type-id='type-id-167'/>
     </function-decl>
-    <function-decl name='efi_loadopt_pathlen' mangled-name='efi_loadopt_pathlen' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='190' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_pathlen@@libefiboot.so.0'>
-      <parameter type-id='type-id-12' name='opt' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='190' column='1'/>
-      <parameter type-id='type-id-15' name='limit' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='190' column='1'/>
+    <function-decl name='efi_loadopt_pathlen' mangled-name='efi_loadopt_pathlen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_pathlen@@libefiboot.so.0'>
+      <parameter type-id='type-id-15' name='opt'/>
+      <parameter type-id='type-id-18' name='limit'/>
       <return type-id='type-id-6'/>
     </function-decl>
-    <type-decl name='void' id='type-id-157'/>
-    <function-decl name='efi_loadopt_attr_clear' mangled-name='efi_loadopt_attr_clear' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_attr_clear@@libefiboot.so.0'>
-      <parameter type-id='type-id-12' name='opt' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='181' column='1'/>
-      <parameter type-id='type-id-6' name='attr' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='181' column='1'/>
-      <return type-id='type-id-157'/>
+    <type-decl name='void' id='type-id-168'/>
+    <function-decl name='efi_loadopt_attr_clear' mangled-name='efi_loadopt_attr_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_attr_clear@@libefiboot.so.0'>
+      <parameter type-id='type-id-15' name='opt'/>
+      <parameter type-id='type-id-6' name='attr'/>
+      <return type-id='type-id-168'/>
     </function-decl>
-    <function-decl name='efi_loadopt_attr_set' mangled-name='efi_loadopt_attr_set' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='173' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_attr_set@@libefiboot.so.0'>
-      <parameter type-id='type-id-12' name='opt' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='181' column='1'/>
-      <parameter type-id='type-id-6' name='attr' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='181' column='1'/>
-      <return type-id='type-id-157'/>
+    <function-decl name='efi_loadopt_attr_set' mangled-name='efi_loadopt_attr_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_attr_set@@libefiboot.so.0'>
+      <parameter type-id='type-id-15' name='opt'/>
+      <parameter type-id='type-id-6' name='attr'/>
+      <return type-id='type-id-168'/>
     </function-decl>
-    <function-decl name='efi_loadopt_attrs' mangled-name='efi_loadopt_attrs' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='165' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_attrs@@libefiboot.so.0'>
-      <parameter type-id='type-id-12' name='opt' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='165' column='1'/>
+    <function-decl name='efi_loadopt_attrs' mangled-name='efi_loadopt_attrs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_attrs@@libefiboot.so.0'>
+      <parameter type-id='type-id-15' name='opt'/>
       <return type-id='type-id-5'/>
     </function-decl>
-    <function-decl name='efi_loadopt_optional_data_size' mangled-name='efi_loadopt_optional_data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='104' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_optional_data_size@@libefiboot.so.0'>
-      <parameter type-id='type-id-12' name='opt' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='104' column='1'/>
-      <parameter type-id='type-id-24' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='104' column='1'/>
-      <return type-id='type-id-15'/>
+    <function-decl name='efi_loadopt_is_valid' mangled-name='efi_loadopt_is_valid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_is_valid@@libefiboot.so.0'>
+      <parameter type-id='type-id-15' name='opt'/>
+      <parameter type-id='type-id-26' name='size'/>
+      <return type-id='type-id-25'/>
     </function-decl>
-    <function-decl name='efi_loadopt_is_valid' mangled-name='efi_loadopt_is_valid' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='154' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_is_valid@@libefiboot.so.0'>
-      <parameter type-id='type-id-12' name='opt' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='154' column='1'/>
-      <parameter type-id='type-id-24' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='154' column='1'/>
-      <return type-id='type-id-22'/>
+    <function-decl name='efi_loadopt_optional_data_size' mangled-name='efi_loadopt_optional_data_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_optional_data_size@@libefiboot.so.0'>
+      <parameter type-id='type-id-15' name='opt'/>
+      <parameter type-id='type-id-26' name='size'/>
+      <return type-id='type-id-18'/>
     </function-decl>
-    <function-decl name='efi_loadopt_create' mangled-name='efi_loadopt_create' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='41' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_create@@libefiboot.so.0'>
-      <parameter type-id='type-id-19' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='41' column='1'/>
-      <parameter type-id='type-id-15' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='41' column='1'/>
-      <parameter type-id='type-id-5' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='41' column='1'/>
-      <parameter type-id='type-id-156' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='42' column='1'/>
-      <parameter type-id='type-id-15' name='dp_size' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='42' column='1'/>
-      <parameter type-id='type-id-25' name='description' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='42' column='1'/>
-      <parameter type-id='type-id-19' name='optional_data' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='43' column='1'/>
-      <parameter type-id='type-id-24' name='optional_data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='43' column='1'/>
-      <return type-id='type-id-15'/>
+    <function-decl name='efi_loadopt_create' mangled-name='efi_loadopt_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_create@@libefiboot.so.0'>
+      <parameter type-id='type-id-22' name='buf'/>
+      <parameter type-id='type-id-18' name='size'/>
+      <parameter type-id='type-id-5' name='attributes'/>
+      <parameter type-id='type-id-167' name='dp'/>
+      <parameter type-id='type-id-18' name='dp_size'/>
+      <parameter type-id='type-id-27' name='description'/>
+      <parameter type-id='type-id-22' name='optional_data'/>
+      <parameter type-id='type-id-26' name='optional_data_size'/>
+      <return type-id='type-id-18'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-20' const='yes' id='type-id-158'/>
-    <pointer-type-def type-id='type-id-158' size-in-bits='64' id='type-id-159'/>
-    <qualified-type-def type-id='type-id-159' const='yes' id='type-id-160'/>
-    <function-decl name='efi_generate_ipv4_device_path' mangled-name='efi_generate_ipv4_device_path' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='428' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_generate_ipv4_device_path@@libefiboot.so.0'>
-      <parameter type-id='type-id-19' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='428' column='1'/>
-      <parameter type-id='type-id-15' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='428' column='1'/>
-      <parameter type-id='type-id-160' name='ifname' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='429' column='1'/>
-      <parameter type-id='type-id-160' name='local_addr' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='430' column='1'/>
-      <parameter type-id='type-id-160' name='remote_addr' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='431' column='1'/>
-      <parameter type-id='type-id-160' name='gateway_addr' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='432' column='1'/>
-      <parameter type-id='type-id-160' name='netmask' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='433' column='1'/>
-      <parameter type-id='type-id-6' name='local_port' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='434' column='1'/>
-      <parameter type-id='type-id-6' name='remote_port' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='435' column='1'/>
-      <parameter type-id='type-id-6' name='protocol' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='436' column='1'/>
-      <parameter type-id='type-id-18' name='addr_origin' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='437' column='1'/>
-      <return type-id='type-id-15'/>
+    <qualified-type-def type-id='type-id-23' const='yes' id='type-id-169'/>
+    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-170'/>
+    <qualified-type-def type-id='type-id-170' const='yes' id='type-id-171'/>
+    <function-decl name='efi_generate_ipv4_device_path' mangled-name='efi_generate_ipv4_device_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_generate_ipv4_device_path@@libefiboot.so.0'>
+      <parameter type-id='type-id-22' name='buf'/>
+      <parameter type-id='type-id-18' name='size'/>
+      <parameter type-id='type-id-171' name='ifname'/>
+      <parameter type-id='type-id-171' name='local_addr'/>
+      <parameter type-id='type-id-171' name='remote_addr'/>
+      <parameter type-id='type-id-171' name='gateway_addr'/>
+      <parameter type-id='type-id-171' name='netmask'/>
+      <parameter type-id='type-id-6' name='local_port'/>
+      <parameter type-id='type-id-6' name='remote_port'/>
+      <parameter type-id='type-id-6' name='protocol'/>
+      <parameter type-id='type-id-21' name='addr_origin'/>
+      <return type-id='type-id-18'/>
     </function-decl>
-    <function-decl name='efi_generate_file_device_path' mangled-name='efi_generate_file_device_path' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='341' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_generate_file_device_path@@libefiboot.so.0'>
-      <parameter type-id='type-id-19' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='341' column='1'/>
-      <parameter type-id='type-id-15' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='341' column='1'/>
-      <parameter type-id='type-id-160' name='filepath' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='342' column='1'/>
-      <parameter type-id='type-id-5' name='options' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='343' column='1'/>
-      <return type-id='type-id-15'/>
+    <function-decl name='efi_generate_file_device_path' mangled-name='efi_generate_file_device_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_generate_file_device_path@@libefiboot.so.0'>
+      <parameter type-id='type-id-22' name='buf'/>
+      <parameter type-id='type-id-18' name='size'/>
+      <parameter type-id='type-id-171' name='filepath'/>
+      <parameter type-id='type-id-5' name='options'/>
+      <return type-id='type-id-18'/>
     </function-decl>
-    <function-decl name='efi_generate_file_device_path_from_esp' mangled-name='efi_generate_file_device_path_from_esp' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='317' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_generate_file_device_path_from_esp@@libefiboot.so.0'>
-      <parameter type-id='type-id-19' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='317' column='1'/>
-      <parameter type-id='type-id-15' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='317' column='1'/>
-      <parameter type-id='type-id-159' name='devpath' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='318' column='1'/>
-      <parameter type-id='type-id-22' name='partition' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='318' column='1'/>
-      <parameter type-id='type-id-159' name='relpath' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='319' column='1'/>
-      <parameter type-id='type-id-5' name='options' filepath='/home/pjones/devel/github.com/efivar/master/src/creator.c' line='320' column='1'/>
-      <return type-id='type-id-15'/>
+    <function-decl name='efi_generate_file_device_path_from_esp' mangled-name='efi_generate_file_device_path_from_esp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_generate_file_device_path_from_esp@@libefiboot.so.0'>
+      <parameter type-id='type-id-22' name='buf'/>
+      <parameter type-id='type-id-18' name='size'/>
+      <parameter type-id='type-id-170' name='devpath'/>
+      <parameter type-id='type-id-25' name='partition'/>
+      <parameter type-id='type-id-170' name='relpath'/>
+      <parameter type-id='type-id-5' name='options'/>
+      <return type-id='type-id-18'/>
     </function-decl>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/bits/libio.h' line='245' column='1' id='type-id-172'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_flags' type-id='type-id-25' visibility='default' filepath='/usr/include/bits/libio.h' line='246' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_IO_read_ptr' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='251' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_IO_read_end' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='252' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='_IO_read_base' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='253' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_IO_write_base' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='254' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='_IO_write_ptr' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='255' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='_IO_write_end' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='256' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='_IO_buf_base' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='257' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='_IO_buf_end' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='258' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='_IO_save_base' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='260' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='_IO_backup_base' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='261' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='_IO_save_end' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='262' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='_markers' type-id='type-id-173' visibility='default' filepath='/usr/include/bits/libio.h' line='264' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='_chain' type-id='type-id-174' visibility='default' filepath='/usr/include/bits/libio.h' line='266' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='_fileno' type-id='type-id-25' visibility='default' filepath='/usr/include/bits/libio.h' line='268' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='_flags2' type-id='type-id-25' visibility='default' filepath='/usr/include/bits/libio.h' line='272' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='_old_offset' type-id='type-id-175' visibility='default' filepath='/usr/include/bits/libio.h' line='274' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='_cur_column' type-id='type-id-10' visibility='default' filepath='/usr/include/bits/libio.h' line='278' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1040'>
+        <var-decl name='_vtable_offset' type-id='type-id-176' visibility='default' filepath='/usr/include/bits/libio.h' line='279' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1048'>
+        <var-decl name='_shortbuf' type-id='type-id-100' visibility='default' filepath='/usr/include/bits/libio.h' line='280' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='_offset' type-id='type-id-177' visibility='default' filepath='/usr/include/bits/libio.h' line='293' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='__pad1' type-id='type-id-178' visibility='default' filepath='/usr/include/bits/libio.h' line='301' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='__pad2' type-id='type-id-178' visibility='default' filepath='/usr/include/bits/libio.h' line='302' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='__pad3' type-id='type-id-178' visibility='default' filepath='/usr/include/bits/libio.h' line='303' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='__pad4' type-id='type-id-178' visibility='default' filepath='/usr/include/bits/libio.h' line='304' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='__pad5' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/libio.h' line='306' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='_mode' type-id='type-id-25' visibility='default' filepath='/usr/include/bits/libio.h' line='307' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='_unused2' type-id='type-id-179' visibility='default' filepath='/usr/include/bits/libio.h' line='309' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' filepath='/usr/include/bits/libio.h' line='160' column='1' id='type-id-180'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_next' type-id='type-id-173' visibility='default' filepath='/usr/include/bits/libio.h' line='161' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_sbuf' type-id='type-id-174' visibility='default' filepath='/usr/include/bits/libio.h' line='162' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_pos' type-id='type-id-25' visibility='default' filepath='/usr/include/bits/libio.h' line='166' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-180' size-in-bits='64' id='type-id-173'/>
+    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-174'/>
+    <typedef-decl name='__off_t' type-id='type-id-16' filepath='/usr/include/bits/types.h' line='140' column='1' id='type-id-175'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-176'/>
+    <typedef-decl name='__off64_t' type-id='type-id-16' filepath='/usr/include/bits/types.h' line='141' column='1' id='type-id-177'/>
+    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-178'/>
+
+    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='160' id='type-id-179'>
+      <subrange length='20' type-id='type-id-12' id='type-id-181'/>
+
+    </array-type-def>
+    <var-decl name='stderr' type-id='type-id-174' visibility='default' filepath='/usr/include/stdio.h' line='137' column='1'/>
     <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-157'/>
+      <return type-id='type-id-168'/>
     </function-decl>
     <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-157'/>
+      <return type-id='type-id-168'/>
     </function-decl>
     <function-decl name='__builtin_calloc' mangled-name='calloc' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-157'/>
+      <return type-id='type-id-168'/>
     </function-decl>
   </abi-instr>
 </abi-corpus>

--- a/src/libefiboot.abixml
+++ b/src/libefiboot.abixml
@@ -21,1287 +21,1552 @@
     <elf-symbol name='efi_loadopt_path' version='libefiboot.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_loadopt_pathlen' version='libefiboot.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-function-symbols>
-  <abi-instr version='1.0' address-size='64' path='&lt;artificial&gt;' comp-dir-path='/home/pjones/devel/github.com/efivar/master/src' language='LANG_C99'>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-1'/>
-    <qualified-type-def type-id='type-id-1' const='yes' id='type-id-2'/>
-    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-3'/>
-    <class-decl name='efi_load_option_s' size-in-bits='48' is-struct='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='28' column='1' id='type-id-4'>
+  <abi-instr version='1.0' address-size='64' path='linux-sas.c' comp-dir-path='src' language='LANG_C99'>
+    <class-decl name='dev_probe' size-in-bits='384' is-struct='yes' visibility='default' filepath='src/linux.h' line='206' column='1' id='type-id-1'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='attributes' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='29' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='file_path_list_length' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='30' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='description' type-id='type-id-7' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/loadopt.c' line='31' column='1'/>
-      </data-member>
-    </class-decl>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-8'/>
-    <typedef-decl name='__uint32_t' type-id='type-id-8' filepath='/usr/include/bits/types.h' line='41' column='1' id='type-id-9'/>
-    <typedef-decl name='uint32_t' type-id='type-id-9' filepath='/usr/include/bits/stdint-uintn.h' line='26' column='1' id='type-id-5'/>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-10'/>
-    <typedef-decl name='__uint16_t' type-id='type-id-10' filepath='/usr/include/bits/types.h' line='39' column='1' id='type-id-11'/>
-    <typedef-decl name='uint16_t' type-id='type-id-11' filepath='/usr/include/bits/stdint-uintn.h' line='25' column='1' id='type-id-6'/>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-12'/>
-
-    <array-type-def dimensions='1' type-id='type-id-6' size-in-bits='16' id='type-id-7'>
-      <subrange length='1' type-id='type-id-12' id='type-id-13'/>
-
-    </array-type-def>
-    <typedef-decl name='efi_load_option' type-id='type-id-4' filepath='include/efivar/efiboot-loadopt.h' line='24' column='1' id='type-id-14'/>
-    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-15'/>
-    <type-decl name='long int' size-in-bits='64' id='type-id-16'/>
-    <typedef-decl name='__ssize_t' type-id='type-id-16' filepath='/usr/include/bits/types.h' line='181' column='1' id='type-id-17'/>
-    <typedef-decl name='ssize_t' type-id='type-id-17' filepath='/usr/include/sys/types.h' line='109' column='1' id='type-id-18'/>
-    <function-decl name='efi_loadopt_desc' mangled-name='efi_loadopt_desc' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_desc@@libefiboot.so.0'>
-      <parameter type-id='type-id-15' name='opt'/>
-      <parameter type-id='type-id-18' name='limit'/>
-      <return type-id='type-id-3'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-6' size-in-bits='64' id='type-id-19'/>
-    <typedef-decl name='__uint8_t' type-id='type-id-1' filepath='/usr/include/bits/types.h' line='37' column='1' id='type-id-20'/>
-    <typedef-decl name='uint8_t' type-id='type-id-20' filepath='/usr/include/bits/stdint-uintn.h' line='24' column='1' id='type-id-21'/>
-    <pointer-type-def type-id='type-id-21' size-in-bits='64' id='type-id-22'/>
-    <function-decl name='efi_loadopt_args_as_ucs2' mangled-name='efi_loadopt_args_as_ucs2' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_args_as_ucs2@@libefiboot.so.0'>
-      <parameter type-id='type-id-19' name='buf'/>
-      <parameter type-id='type-id-18' name='size'/>
-      <parameter type-id='type-id-22' name='utf8'/>
-      <return type-id='type-id-18'/>
-    </function-decl>
-    <function-decl name='efi_loadopt_args_as_utf8' mangled-name='efi_loadopt_args_as_utf8' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_args_as_utf8@@libefiboot.so.0'>
-      <parameter type-id='type-id-22' name='buf'/>
-      <parameter type-id='type-id-18' name='size'/>
-      <parameter type-id='type-id-22' name='utf8'/>
-      <parameter type-id='type-id-22' name='buf'/>
-      <parameter type-id='type-id-18' name='size'/>
-      <parameter type-id='type-id-22' name='utf8'/>
-      <return type-id='type-id-18'/>
-    </function-decl>
-    <type-decl name='char' size-in-bits='8' id='type-id-23'/>
-    <pointer-type-def type-id='type-id-23' size-in-bits='64' id='type-id-24'/>
-    <function-decl name='efi_loadopt_args_from_file' mangled-name='efi_loadopt_args_from_file' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_args_from_file@@libefiboot.so.0'>
-      <parameter type-id='type-id-22' name='buf'/>
-      <parameter type-id='type-id-18' name='size'/>
-      <parameter type-id='type-id-24' name='filename'/>
-      <return type-id='type-id-18'/>
-    </function-decl>
-    <type-decl name='int' size-in-bits='32' id='type-id-25'/>
-    <typedef-decl name='size_t' type-id='type-id-12' filepath='/usr/lib/gcc/x86_64-redhat-linux/8/include/stddef.h' line='216' column='1' id='type-id-26'/>
-    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-27'/>
-    <pointer-type-def type-id='type-id-27' size-in-bits='64' id='type-id-28'/>
-    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-29'/>
-    <function-decl name='efi_loadopt_optional_data' mangled-name='efi_loadopt_optional_data' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_optional_data@@libefiboot.so.0'>
-      <parameter type-id='type-id-15' name='opt'/>
-      <parameter type-id='type-id-26' name='opt_size'/>
-      <parameter type-id='type-id-28' name='datap'/>
-      <parameter type-id='type-id-29' name='len'/>
-      <return type-id='type-id-25'/>
-    </function-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='832' column='1' id='type-id-30'>
-      <data-member access='private'>
-        <var-decl name='' type-id='type-id-31' visibility='default'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='838' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='pci' type-id='type-id-33' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='839' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='pccard' type-id='type-id-34' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='840' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='mmio' type-id='type-id-35' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='841' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='hw_vendor' type-id='type-id-36' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='842' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='controller' type-id='type-id-37' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='843' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='bmc' type-id='type-id-38' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='844' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='acpi_hid' type-id='type-id-39' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='845' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='acpi_hid_ex' type-id='type-id-40' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='846' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='acpi_adr' type-id='type-id-41' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='847' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='atapi' type-id='type-id-42' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='848' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='scsi' type-id='type-id-43' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='849' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='fc' type-id='type-id-44' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='850' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='fcex' type-id='type-id-45' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='851' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='firewire' type-id='type-id-46' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='852' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='usb' type-id='type-id-47' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='853' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='usb_class' type-id='type-id-48' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='854' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='usb_wwid' type-id='type-id-49' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='855' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='lun' type-id='type-id-50' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='856' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='sata' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='857' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='i2o' type-id='type-id-52' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='858' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='mac_addr' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='859' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='ipv4_addr' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='860' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='ipv6_addr' type-id='type-id-55' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='861' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='vlan' type-id='type-id-56' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='862' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='infiniband' type-id='type-id-57' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='863' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='uart' type-id='type-id-58' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='864' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='msg_vendor' type-id='type-id-59' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='865' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='uart_flow_control' type-id='type-id-60' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='866' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='sas' type-id='type-id-61' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='867' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='sas_ex' type-id='type-id-62' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='868' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='iscsi' type-id='type-id-63' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='869' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='nvme' type-id='type-id-64' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='870' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='uri' type-id='type-id-65' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='871' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='ufs' type-id='type-id-66' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='872' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='sd' type-id='type-id-67' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='873' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='bt' type-id='type-id-68' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='874' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='wifi' type-id='type-id-69' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='875' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='emmc' type-id='type-id-70' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='876' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='btle' type-id='type-id-71' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='877' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='dns' type-id='type-id-72' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='878' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='nvdimm' type-id='type-id-73' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='879' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='hd' type-id='type-id-74' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='880' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='cdrom' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='881' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='media_vendor' type-id='type-id-76' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='882' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='file' type-id='type-id-77' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='883' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='protocol' type-id='type-id-78' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='884' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='firmware_file' type-id='type-id-79' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='885' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='firmware_volume' type-id='type-id-80' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='886' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='relative_offset' type-id='type-id-81' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='887' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='ramdisk' type-id='type-id-82' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='888' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='bios_boot' type-id='type-id-83' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='889' column='1'/>
-      </data-member>
-    </union-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='833' column='1' id='type-id-31'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='type' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='834' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8'>
-        <var-decl name='subtype' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='835' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='length' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='836' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='36' column='1' id='type-id-84'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='type' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='37' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='8'>
-        <var-decl name='subtype' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='38' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='length' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='39' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_header' type-id='type-id-84' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='40' column='1' id='type-id-32'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-33' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='55' column='1' id='type-id-85'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='56' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='function' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='57' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='device' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='58' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_pci' type-id='type-id-85' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='59' column='1' id='type-id-33'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-34' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='64' column='1' id='type-id-86'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='65' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='function' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='66' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_pccard' type-id='type-id-86' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='67' column='1' id='type-id-34'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-35' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='70' column='1' id='type-id-87'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='71' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='memory_type' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='72' column='1'/>
+        <var-decl name='name' type-id='type-id-2' visibility='default' filepath='src/linux.h' line='207' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='starting_address' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='73' column='1'/>
+        <var-decl name='iftypes' type-id='type-id-3' visibility='default' filepath='src/linux.h' line='208' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='ending_address' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='74' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='__uint64_t' type-id='type-id-12' filepath='/usr/include/bits/types.h' line='44' column='1' id='type-id-89'/>
-    <typedef-decl name='uint64_t' type-id='type-id-89' filepath='/usr/include/bits/stdint-uintn.h' line='27' column='1' id='type-id-88'/>
-    <typedef-decl name='efidp_mmio' type-id='type-id-87' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='75' column='1' id='type-id-35'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-36' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='78' column='1' id='type-id-90'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='79' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='80' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='vendor_data' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='81' column='1'/>
-      </data-member>
-    </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='33' column='1' id='type-id-93'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='a' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='34' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='b' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='35' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='c' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='36' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='d' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='37' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='e' type-id='type-id-94' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='38' column='1'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-21' size-in-bits='48' id='type-id-94'>
-      <subrange length='6' type-id='type-id-12' id='type-id-95'/>
-
-    </array-type-def>
-    <typedef-decl name='efi_guid_t' type-id='type-id-93' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='39' column='1' id='type-id-91'/>
-
-    <array-type-def dimensions='1' type-id='type-id-21' size-in-bits='8' id='type-id-92'>
-      <subrange length='1' type-id='type-id-12' id='type-id-13'/>
-
-    </array-type-def>
-    <typedef-decl name='efidp_hw_vendor' type-id='type-id-90' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='82' column='1' id='type-id-36'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-37' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='99' column='1' id='type-id-96'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='100' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='controller' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='101' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_controller' type-id='type-id-96' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='102' column='1' id='type-id-37'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='104' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-38' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='105' column='1' id='type-id-97'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='interface_type' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='107' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='base_addr' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='108' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_bmc' type-id='type-id-97' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='109' column='1' id='type-id-38'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='96' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-39' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='119' column='1' id='type-id-98'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='120' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='hid' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='121' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='uid' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='122' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_acpi_hid' type-id='type-id-98' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='123' column='1' id='type-id-39'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-40' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='128' column='1' id='type-id-99'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='129' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='hid' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='130' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='uid' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='131' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='cid' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='132' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='hidstr' type-id='type-id-100' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='134' column='1'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='8' id='type-id-100'>
-      <subrange length='1' type-id='type-id-12' id='type-id-13'/>
-
-    </array-type-def>
-    <typedef-decl name='efidp_acpi_hid_ex' type-id='type-id-99' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='135' column='1' id='type-id-40'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-41' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='165' column='1' id='type-id-101'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='166' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='adr' type-id='type-id-102' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='167' column='1'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='32' id='type-id-102'>
-      <subrange length='1' type-id='type-id-12' id='type-id-13'/>
-
-    </array-type-def>
-    <typedef-decl name='efidp_acpi_adr' type-id='type-id-101' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='168' column='1' id='type-id-41'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-42' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='326' column='1' id='type-id-103'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='327' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='primary' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='328' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='slave' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='329' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='lun' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='330' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_atapi' type-id='type-id-103' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='331' column='1' id='type-id-42'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-43' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='336' column='1' id='type-id-104'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='337' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='target' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='338' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='lun' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='339' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_scsi' type-id='type-id-104' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='340' column='1' id='type-id-43'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-44' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='345' column='1' id='type-id-105'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='346' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='347' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='wwn' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='348' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='lun' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='349' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_fc' type-id='type-id-105' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='350' column='1' id='type-id-44'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-45' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='353' column='1' id='type-id-106'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='354' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='355' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='wwn' type-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='356' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='lun' type-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='357' column='1'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-21' size-in-bits='64' id='type-id-107'>
-      <subrange length='8' type-id='type-id-12' id='type-id-108'/>
-
-    </array-type-def>
-    <typedef-decl name='efidp_fcex' type-id='type-id-106' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='358' column='1' id='type-id-45'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-46' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='361' column='1' id='type-id-109'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='362' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='363' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='guid' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='364' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_1394' type-id='type-id-109' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='365' column='1' id='type-id-46'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-47' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='368' column='1' id='type-id-110'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='369' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='parent_port' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='370' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='interface' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='371' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_usb' type-id='type-id-110' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='372' column='1' id='type-id-47'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-48' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='375' column='1' id='type-id-111'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='376' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_id' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='377' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='product_id' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='378' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='device_class' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='379' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='72'>
-        <var-decl name='device_subclass' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='380' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='device_protocol' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='381' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_usb_class' type-id='type-id-111' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='382' column='1' id='type-id-48'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-49' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='402' column='1' id='type-id-112'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='403' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='interface' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='404' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='vendor_id' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='405' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='product_id' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='406' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='serial_number' type-id='type-id-7' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='407' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_usb_wwid' type-id='type-id-112' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='408' column='1' id='type-id-49'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-50' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='411' column='1' id='type-id-113'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='412' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='lun' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='413' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_lun' type-id='type-id-113' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='414' column='1' id='type-id-50'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='417' column='1' id='type-id-114'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='418' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='hba_port' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='419' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='port_multiplier_port' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='420' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='lun' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='421' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_sata' type-id='type-id-114' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='422' column='1' id='type-id-51'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-52' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='428' column='1' id='type-id-115'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='429' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='target' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='430' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_i2o' type-id='type-id-115' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='431' column='1' id='type-id-52'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='296' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='434' column='1' id='type-id-116'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='435' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='mac_addr' type-id='type-id-117' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='436' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='if_type' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='437' column='1'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-21' size-in-bits='256' id='type-id-117'>
-      <subrange length='32' type-id='type-id-12' id='type-id-118'/>
-
-    </array-type-def>
-    <typedef-decl name='efidp_mac_addr' type-id='type-id-116' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='438' column='1' id='type-id-53'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='216' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='446' column='1' id='type-id-119'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='447' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='local_ipv4_addr' type-id='type-id-120' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='448' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='remote_ipv4_addr' type-id='type-id-120' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='449' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='local_port' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='450' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='112'>
-        <var-decl name='remote_port' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='451' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='protocol' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='452' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='static_ip_addr' type-id='type-id-121' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='453' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='152'>
-        <var-decl name='gateway' type-id='type-id-120' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='454' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='184'>
-        <var-decl name='netmask' type-id='type-id-120' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='455' column='1'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-21' size-in-bits='32' id='type-id-120'>
-      <subrange length='4' type-id='type-id-12' id='type-id-122'/>
-
-    </array-type-def>
-    <typedef-decl name='efidp_boolean' type-id='type-id-21' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='43' column='1' id='type-id-121'/>
-    <typedef-decl name='efidp_ipv4_addr' type-id='type-id-119' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='456' column='1' id='type-id-54'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='360' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-55' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='468' column='1' id='type-id-123'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='469' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='local_ipv6_addr' type-id='type-id-124' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='470' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='remote_ipv6_addr' type-id='type-id-124' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='471' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='local_port' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='472' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='304'>
-        <var-decl name='remote_port' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='473' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='protocol' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='474' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='336'>
-        <var-decl name='ip_addr_origin' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='475' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='344'>
-        <var-decl name='prefix_length' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='476' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='gateway_ipv6_addr' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='477' column='1'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-21' size-in-bits='128' id='type-id-124'>
-      <subrange length='16' type-id='type-id-12' id='type-id-125'/>
-
-    </array-type-def>
-    <typedef-decl name='efidp_ipv6_addr' type-id='type-id-123' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='478' column='1' id='type-id-55'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-56' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='485' column='1' id='type-id-126'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='486' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vlan_id' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='487' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_vlan' type-id='type-id-126' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='488' column='1' id='type-id-56'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='384' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-57' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='491' column='1' id='type-id-127'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='492' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='resource_flags' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='493' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='port_gid' type-id='type-id-128' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='494' column='1'/>
+        <var-decl name='flags' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='209' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='' type-id='type-id-129' visibility='default'/>
+        <var-decl name='parse' type-id='type-id-5' visibility='default' filepath='src/linux.h' line='210' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='target_port_id' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='499' column='1'/>
+        <var-decl name='create' type-id='type-id-6' visibility='default' filepath='src/linux.h' line='211' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='device_id' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='500' column='1'/>
+        <var-decl name='make_part_name' type-id='type-id-7' visibility='default' filepath='src/linux.h' line='213' column='1'/>
       </data-member>
     </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-88' size-in-bits='128' id='type-id-128'>
-      <subrange length='2' type-id='type-id-12' id='type-id-130'/>
-
-    </array-type-def>
-    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='495' column='1' id='type-id-129'>
-      <data-member access='private'>
-        <var-decl name='ioc_guid' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='496' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='service_id' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='497' column='1'/>
-      </data-member>
-    </union-decl>
-    <typedef-decl name='efidp_infiniband' type-id='type-id-127' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='501' column='1' id='type-id-57'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='152' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-58' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='510' column='1' id='type-id-131'>
+    <type-decl name='char' size-in-bits='8' id='type-id-8'/>
+    <pointer-type-def type-id='type-id-8' size-in-bits='64' id='type-id-2'/>
+    <type-decl name='unnamed-enum-underlying-type' is-anonymous='yes' size-in-bits='32' alignment-in-bits='32' id='type-id-9'/>
+    <enum-decl name='interface_type' filepath='src/linux.h' line='75' column='1' id='type-id-10'>
+      <underlying-type type-id='type-id-9'/>
+      <enumerator name='unknown' value='0'/>
+      <enumerator name='isa' value='1'/>
+      <enumerator name='pci' value='2'/>
+      <enumerator name='network' value='3'/>
+      <enumerator name='ata' value='4'/>
+      <enumerator name='atapi' value='5'/>
+      <enumerator name='scsi' value='6'/>
+      <enumerator name='sata' value='7'/>
+      <enumerator name='sas' value='8'/>
+      <enumerator name='usb' value='9'/>
+      <enumerator name='i1394' value='10'/>
+      <enumerator name='fibre' value='11'/>
+      <enumerator name='i2o' value='12'/>
+      <enumerator name='md' value='13'/>
+      <enumerator name='virtblk' value='14'/>
+      <enumerator name='nvme' value='15'/>
+      <enumerator name='nd_pmem' value='16'/>
+    </enum-decl>
+    <pointer-type-def type-id='type-id-10' size-in-bits='64' id='type-id-3'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-11'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-11' filepath='/usr/include/bits/types.h' line='41' column='1' id='type-id-12'/>
+    <typedef-decl name='uint32_t' type-id='type-id-12' filepath='/usr/include/bits/stdint-uintn.h' line='26' column='1' id='type-id-4'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-13'/>
+    <typedef-decl name='__ssize_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='181' column='1' id='type-id-14'/>
+    <typedef-decl name='ssize_t' type-id='type-id-14' filepath='/usr/include/unistd.h' line='220' column='1' id='type-id-15'/>
+    <class-decl name='device' size-in-bits='2560' is-struct='yes' visibility='default' filepath='src/linux.h' line='86' column='1' id='type-id-16'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='511' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='512' column='1'/>
+        <var-decl name='interface_type' type-id='type-id-10' visibility='default' filepath='src/linux.h' line='87' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='baud_rate' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='513' column='1'/>
+        <var-decl name='link' type-id='type-id-2' visibility='default' filepath='src/linux.h' line='88' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='data_bits' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='514' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='136'>
-        <var-decl name='parity' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='515' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='stop_bits' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='516' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_uart' type-id='type-id-131' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='517' column='1' id='type-id-58'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-59' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='541' column='1' id='type-id-132'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='542' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='543' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='vendor_data' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='544' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_msg_vendor' type-id='type-id-132' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='545' column='1' id='type-id-59'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-60' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='554' column='1' id='type-id-133'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='555' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='556' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='flow_control_map' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='557' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_uart_flow_control' type-id='type-id-133' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='558' column='1' id='type-id-60'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='352' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-61' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='565' column='1' id='type-id-134'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='566' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='567' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='reserved' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='568' column='1'/>
+        <var-decl name='device' type-id='type-id-2' visibility='default' filepath='src/linux.h' line='89' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='sas_address' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='569' column='1'/>
+        <var-decl name='driver' type-id='type-id-2' visibility='default' filepath='src/linux.h' line='90' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='lun' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='570' column='1'/>
+        <var-decl name='probes' type-id='type-id-17' visibility='default' filepath='src/linux.h' line='92' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='device_topology_info' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='571' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='drive_bay_id' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='572' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='336'>
-        <var-decl name='rtp' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='573' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_sas' type-id='type-id-134' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='574' column='1' id='type-id-61'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-62' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='598' column='1' id='type-id-135'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='599' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='sas_address' type-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='600' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='lun' type-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='601' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='device_topology_info' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='602' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='168'>
-        <var-decl name='drive_bay_id' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='603' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='176'>
-        <var-decl name='rtp' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='604' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_sas_ex' type-id='type-id-135' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='605' column='1' id='type-id-62'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='144' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-63' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='611' column='1' id='type-id-136'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='612' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='protocol' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='613' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='options' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='614' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='lun' type-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='615' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='tpgt' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='616' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='target_name' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='617' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_iscsi' type-id='type-id-136' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='618' column='1' id='type-id-63'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-64' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='646' column='1' id='type-id-137'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='647' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='namespace_id' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='648' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='ieee_eui_64' type-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='649' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_nvme' type-id='type-id-137' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='650' column='1' id='type-id-64'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-65' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='655' column='1' id='type-id-138'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='656' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='uri' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='657' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_uri' type-id='type-id-138' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='658' column='1' id='type-id-65'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-66' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='661' column='1' id='type-id-139'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='662' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='target_id' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='663' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='lun' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='664' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_ufs' type-id='type-id-139' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='665' column='1' id='type-id-66'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-67' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='668' column='1' id='type-id-140'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='669' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='slot_number' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='670' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_sd' type-id='type-id-140' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='671' column='1' id='type-id-67'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-68' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='674' column='1' id='type-id-141'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='675' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='addr' type-id='type-id-94' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='676' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_bt' type-id='type-id-141' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='677' column='1' id='type-id-68'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='288' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-69' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='680' column='1' id='type-id-142'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='681' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='ssid' type-id='type-id-117' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='682' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_wifi' type-id='type-id-142' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='683' column='1' id='type-id-69'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-70' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='686' column='1' id='type-id-143'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='687' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='slot' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='688' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_emmc' type-id='type-id-143' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='689' column='1' id='type-id-70'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-71' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='692' column='1' id='type-id-144'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='693' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='addr' type-id='type-id-94' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='694' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='addr_type' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='695' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_btle' type-id='type-id-144' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='696' column='1' id='type-id-71'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-72' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='702' column='1' id='type-id-145'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='703' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='is_ipv6' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='704' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='addrs' type-id='type-id-146' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='705' column='1'/>
-      </data-member>
-    </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='49' column='1' id='type-id-147'>
-      <data-member access='private'>
-        <var-decl name='addr' type-id='type-id-148' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='50' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='v4' type-id='type-id-149' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='51' column='1'/>
-      </data-member>
-      <data-member access='private'>
-        <var-decl name='v6' type-id='type-id-150' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='52' column='1'/>
-      </data-member>
-    </union-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-5' size-in-bits='128' id='type-id-148'>
-      <subrange length='4' type-id='type-id-12' id='type-id-122'/>
-
-    </array-type-def>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-149' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='41' column='1' id='type-id-151'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='addr' type-id='type-id-120' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='42' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efi_ipv4_addr_t' type-id='type-id-151' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='43' column='1' id='type-id-149'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-150' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='45' column='1' id='type-id-152'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='addr' type-id='type-id-124' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='46' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efi_ipv6_addr_t' type-id='type-id-152' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='47' column='1' id='type-id-150'/>
-    <typedef-decl name='efi_ip_addr_t' type-id='type-id-147' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='53' column='1' id='type-id-153'/>
-
-    <array-type-def dimensions='1' type-id='type-id-153' size-in-bits='128' id='type-id-146'>
-      <subrange length='1' type-id='type-id-12' id='type-id-13'/>
-
-    </array-type-def>
-    <typedef-decl name='efidp_dns' type-id='type-id-145' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='706' column='1' id='type-id-72'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-73' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='709' column='1' id='type-id-154'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='710' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='uuid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='711' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_nvdimm' type-id='type-id-154' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='712' column='1' id='type-id-73'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='336' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-74' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='717' column='1' id='type-id-155'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='718' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='partition_number' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='719' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='start' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='720' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='size' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='721' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='signature' type-id='type-id-124' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='722' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='format' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='723' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='signature_type' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='724' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_hd' type-id='type-id-155' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='728' column='1' id='type-id-74'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='742' column='1' id='type-id-156'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='743' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='boot_catalog_entry' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='744' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='partition_rba' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='745' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='sectors' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='746' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_cdrom' type-id='type-id-156' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='747' column='1' id='type-id-75'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-76' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='750' column='1' id='type-id-157'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='751' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='752' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='vendor_data' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='753' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_media_vendor' type-id='type-id-157' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='754' column='1' id='type-id-76'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-77' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='761' column='1' id='type-id-158'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='762' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='name' type-id='type-id-7' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='763' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_file' type-id='type-id-158' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='764' column='1' id='type-id-77'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-78' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='768' column='1' id='type-id-159'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='769' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='protocol_guid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='770' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_protocol' type-id='type-id-159' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='771' column='1' id='type-id-78'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-79' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='774' column='1' id='type-id-160'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='775' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='pi_info' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='776' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_firmware_file' type-id='type-id-160' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='777' column='1' id='type-id-79'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-80' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='780' column='1' id='type-id-161'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='781' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='pi_info' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='782' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_firmware_volume' type-id='type-id-161' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='783' column='1' id='type-id-80'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-81' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='786' column='1' id='type-id-162'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='787' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='788' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='first_byte' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='789' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='last_byte' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='790' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_relative_offset' type-id='type-id-162' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='791' column='1' id='type-id-81'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='304' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-82' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='794' column='1' id='type-id-163'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='795' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='start_addr' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='796' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='end_addr' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='797' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='disk_type_guid' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='798' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='instance_number' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='799' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_ramdisk' type-id='type-id-163' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='800' column='1' id='type-id-82'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-83' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='813' column='1' id='type-id-164'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='814' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='device_type' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='815' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='status' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='816' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='description' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='817' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_bios_boot' type-id='type-id-164' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='818' column='1' id='type-id-83'/>
-    <typedef-decl name='efidp_data' type-id='type-id-30' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='890' column='1' id='type-id-165'/>
-    <pointer-type-def type-id='type-id-165' size-in-bits='64' id='type-id-166'/>
-    <typedef-decl name='efidp' type-id='type-id-166' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='891' column='1' id='type-id-167'/>
-    <function-decl name='efi_loadopt_path' mangled-name='efi_loadopt_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_path@@libefiboot.so.0'>
-      <parameter type-id='type-id-15' name='opt'/>
-      <parameter type-id='type-id-18' name='limit'/>
-      <return type-id='type-id-167'/>
-    </function-decl>
-    <function-decl name='efi_loadopt_pathlen' mangled-name='efi_loadopt_pathlen' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_pathlen@@libefiboot.so.0'>
-      <parameter type-id='type-id-15' name='opt'/>
-      <parameter type-id='type-id-18' name='limit'/>
-      <return type-id='type-id-6'/>
-    </function-decl>
-    <type-decl name='void' id='type-id-168'/>
-    <function-decl name='efi_loadopt_attr_clear' mangled-name='efi_loadopt_attr_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_attr_clear@@libefiboot.so.0'>
-      <parameter type-id='type-id-15' name='opt'/>
-      <parameter type-id='type-id-6' name='attr'/>
-      <return type-id='type-id-168'/>
-    </function-decl>
-    <function-decl name='efi_loadopt_attr_set' mangled-name='efi_loadopt_attr_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_attr_set@@libefiboot.so.0'>
-      <parameter type-id='type-id-15' name='opt'/>
-      <parameter type-id='type-id-6' name='attr'/>
-      <return type-id='type-id-168'/>
-    </function-decl>
-    <function-decl name='efi_loadopt_attrs' mangled-name='efi_loadopt_attrs' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_attrs@@libefiboot.so.0'>
-      <parameter type-id='type-id-15' name='opt'/>
-      <return type-id='type-id-5'/>
-    </function-decl>
-    <function-decl name='efi_loadopt_is_valid' mangled-name='efi_loadopt_is_valid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_is_valid@@libefiboot.so.0'>
-      <parameter type-id='type-id-15' name='opt'/>
-      <parameter type-id='type-id-26' name='size'/>
-      <return type-id='type-id-25'/>
-    </function-decl>
-    <function-decl name='efi_loadopt_optional_data_size' mangled-name='efi_loadopt_optional_data_size' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_optional_data_size@@libefiboot.so.0'>
-      <parameter type-id='type-id-15' name='opt'/>
-      <parameter type-id='type-id-26' name='size'/>
-      <return type-id='type-id-18'/>
-    </function-decl>
-    <function-decl name='efi_loadopt_create' mangled-name='efi_loadopt_create' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_create@@libefiboot.so.0'>
-      <parameter type-id='type-id-22' name='buf'/>
-      <parameter type-id='type-id-18' name='size'/>
-      <parameter type-id='type-id-5' name='attributes'/>
-      <parameter type-id='type-id-167' name='dp'/>
-      <parameter type-id='type-id-18' name='dp_size'/>
-      <parameter type-id='type-id-27' name='description'/>
-      <parameter type-id='type-id-22' name='optional_data'/>
-      <parameter type-id='type-id-26' name='optional_data_size'/>
-      <return type-id='type-id-18'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-23' const='yes' id='type-id-169'/>
-    <pointer-type-def type-id='type-id-169' size-in-bits='64' id='type-id-170'/>
-    <qualified-type-def type-id='type-id-170' const='yes' id='type-id-171'/>
-    <function-decl name='efi_generate_ipv4_device_path' mangled-name='efi_generate_ipv4_device_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_generate_ipv4_device_path@@libefiboot.so.0'>
-      <parameter type-id='type-id-22' name='buf'/>
-      <parameter type-id='type-id-18' name='size'/>
-      <parameter type-id='type-id-171' name='ifname'/>
-      <parameter type-id='type-id-171' name='local_addr'/>
-      <parameter type-id='type-id-171' name='remote_addr'/>
-      <parameter type-id='type-id-171' name='gateway_addr'/>
-      <parameter type-id='type-id-171' name='netmask'/>
-      <parameter type-id='type-id-6' name='local_port'/>
-      <parameter type-id='type-id-6' name='remote_port'/>
-      <parameter type-id='type-id-6' name='protocol'/>
-      <parameter type-id='type-id-21' name='addr_origin'/>
-      <return type-id='type-id-18'/>
-    </function-decl>
-    <function-decl name='efi_generate_file_device_path' mangled-name='efi_generate_file_device_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_generate_file_device_path@@libefiboot.so.0'>
-      <parameter type-id='type-id-22' name='buf'/>
-      <parameter type-id='type-id-18' name='size'/>
-      <parameter type-id='type-id-171' name='filepath'/>
-      <parameter type-id='type-id-5' name='options'/>
-      <return type-id='type-id-18'/>
-    </function-decl>
-    <function-decl name='efi_generate_file_device_path_from_esp' mangled-name='efi_generate_file_device_path_from_esp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_generate_file_device_path_from_esp@@libefiboot.so.0'>
-      <parameter type-id='type-id-22' name='buf'/>
-      <parameter type-id='type-id-18' name='size'/>
-      <parameter type-id='type-id-170' name='devpath'/>
-      <parameter type-id='type-id-25' name='partition'/>
-      <parameter type-id='type-id-170' name='relpath'/>
-      <parameter type-id='type-id-5' name='options'/>
-      <return type-id='type-id-18'/>
-    </function-decl>
-    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/bits/libio.h' line='245' column='1' id='type-id-172'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_flags' type-id='type-id-25' visibility='default' filepath='/usr/include/bits/libio.h' line='246' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_IO_read_ptr' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='251' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_IO_read_end' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='252' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='_IO_read_base' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='253' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='_IO_write_base' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='254' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='_IO_write_ptr' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='255' column='1'/>
+        <var-decl name='n_probes' type-id='type-id-11' visibility='default' filepath='src/linux.h' line='93' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='384'>
-        <var-decl name='_IO_write_end' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='256' column='1'/>
+        <var-decl name='' type-id='type-id-18' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='448'>
-        <var-decl name='_IO_buf_base' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='257' column='1'/>
+    </class-decl>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-19'/>
+    <pointer-type-def type-id='type-id-19' size-in-bits='64' id='type-id-17'/>
+    <union-decl name='__anonymous_union__' size-in-bits='2176' is-anonymous='yes' visibility='default' filepath='src/linux.h' line='95' column='1' id='type-id-18'>
+      <data-member access='private'>
+        <var-decl name='' type-id='type-id-20' visibility='default'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='512'>
-        <var-decl name='_IO_buf_end' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='258' column='1'/>
+      <data-member access='private'>
+        <var-decl name='ifname' type-id='type-id-2' visibility='default' filepath='src/linux.h' line='121' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='576'>
-        <var-decl name='_IO_save_base' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='260' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='640'>
-        <var-decl name='_IO_backup_base' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='261' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='704'>
-        <var-decl name='_IO_save_end' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='262' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='768'>
-        <var-decl name='_markers' type-id='type-id-173' visibility='default' filepath='/usr/include/bits/libio.h' line='264' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='832'>
-        <var-decl name='_chain' type-id='type-id-174' visibility='default' filepath='/usr/include/bits/libio.h' line='266' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='896'>
-        <var-decl name='_fileno' type-id='type-id-25' visibility='default' filepath='/usr/include/bits/libio.h' line='268' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='928'>
-        <var-decl name='_flags2' type-id='type-id-25' visibility='default' filepath='/usr/include/bits/libio.h' line='272' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='960'>
-        <var-decl name='_old_offset' type-id='type-id-175' visibility='default' filepath='/usr/include/bits/libio.h' line='274' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1024'>
-        <var-decl name='_cur_column' type-id='type-id-10' visibility='default' filepath='/usr/include/bits/libio.h' line='278' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1040'>
-        <var-decl name='_vtable_offset' type-id='type-id-176' visibility='default' filepath='/usr/include/bits/libio.h' line='279' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='1048'>
-        <var-decl name='_shortbuf' type-id='type-id-100' visibility='default' filepath='/usr/include/bits/libio.h' line='280' column='1'/>
+    </union-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='2176' is-struct='yes' is-anonymous='yes' visibility='default' filepath='src/linux.h' line='96' column='1' id='type-id-20'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='stat' type-id='type-id-21' visibility='default' filepath='src/linux.h' line='97' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1152'>
-        <var-decl name='_offset' type-id='type-id-177' visibility='default' filepath='/usr/include/bits/libio.h' line='293' column='1'/>
+        <var-decl name='controllernum' type-id='type-id-11' visibility='default' filepath='src/linux.h' line='99' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1184'>
+        <var-decl name='disknum' type-id='type-id-11' visibility='default' filepath='src/linux.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1216'>
-        <var-decl name='__pad1' type-id='type-id-178' visibility='default' filepath='/usr/include/bits/libio.h' line='301' column='1'/>
+        <var-decl name='part' type-id='type-id-22' visibility='default' filepath='src/linux.h' line='101' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1280'>
-        <var-decl name='__pad2' type-id='type-id-178' visibility='default' filepath='/usr/include/bits/libio.h' line='302' column='1'/>
+        <var-decl name='major' type-id='type-id-23' visibility='default' filepath='src/linux.h' line='102' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1344'>
-        <var-decl name='__pad3' type-id='type-id-178' visibility='default' filepath='/usr/include/bits/libio.h' line='303' column='1'/>
+        <var-decl name='minor' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='103' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1376'>
+        <var-decl name='edd10_devicenum' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='104' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1408'>
-        <var-decl name='__pad4' type-id='type-id-178' visibility='default' filepath='/usr/include/bits/libio.h' line='304' column='1'/>
+        <var-decl name='disk_name' type-id='type-id-2' visibility='default' filepath='src/linux.h' line='106' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1472'>
-        <var-decl name='__pad5' type-id='type-id-26' visibility='default' filepath='/usr/include/bits/libio.h' line='306' column='1'/>
+        <var-decl name='part_name' type-id='type-id-2' visibility='default' filepath='src/linux.h' line='107' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='1536'>
-        <var-decl name='_mode' type-id='type-id-25' visibility='default' filepath='/usr/include/bits/libio.h' line='307' column='1'/>
+        <var-decl name='pci_root' type-id='type-id-24' visibility='default' filepath='src/linux.h' line='109' column='1'/>
       </data-member>
-      <data-member access='public' layout-offset-in-bits='1568'>
-        <var-decl name='_unused2' type-id='type-id-179' visibility='default' filepath='/usr/include/bits/libio.h' line='309' column='1'/>
+      <data-member access='public' layout-offset-in-bits='1728'>
+        <var-decl name='n_pci_devs' type-id='type-id-11' visibility='default' filepath='src/linux.h' line='110' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1792'>
+        <var-decl name='pci_dev' type-id='type-id-25' visibility='default' filepath='src/linux.h' line='111' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1856'>
+        <var-decl name='' type-id='type-id-26' visibility='default'/>
       </data-member>
     </class-decl>
-    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' filepath='/usr/include/bits/libio.h' line='160' column='1' id='type-id-180'>
+    <class-decl name='stat' size-in-bits='1152' is-struct='yes' visibility='default' filepath='/usr/include/bits/stat.h' line='46' column='1' id='type-id-21'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='_next' type-id='type-id-173' visibility='default' filepath='/usr/include/bits/libio.h' line='161' column='1'/>
+        <var-decl name='st_dev' type-id='type-id-27' visibility='default' filepath='/usr/include/bits/stat.h' line='48' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='_sbuf' type-id='type-id-174' visibility='default' filepath='/usr/include/bits/libio.h' line='162' column='1'/>
+        <var-decl name='st_ino' type-id='type-id-28' visibility='default' filepath='/usr/include/bits/stat.h' line='53' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='_pos' type-id='type-id-25' visibility='default' filepath='/usr/include/bits/libio.h' line='166' column='1'/>
+        <var-decl name='st_nlink' type-id='type-id-29' visibility='default' filepath='/usr/include/bits/stat.h' line='61' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='st_mode' type-id='type-id-30' visibility='default' filepath='/usr/include/bits/stat.h' line='62' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='st_uid' type-id='type-id-31' visibility='default' filepath='/usr/include/bits/stat.h' line='64' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='st_gid' type-id='type-id-32' visibility='default' filepath='/usr/include/bits/stat.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='__pad0' type-id='type-id-22' visibility='default' filepath='/usr/include/bits/stat.h' line='67' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='st_rdev' type-id='type-id-27' visibility='default' filepath='/usr/include/bits/stat.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='st_size' type-id='type-id-33' visibility='default' filepath='/usr/include/bits/stat.h' line='74' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='st_blksize' type-id='type-id-34' visibility='default' filepath='/usr/include/bits/stat.h' line='78' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='st_blocks' type-id='type-id-35' visibility='default' filepath='/usr/include/bits/stat.h' line='80' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='st_atim' type-id='type-id-36' visibility='default' filepath='/usr/include/bits/stat.h' line='91' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='st_mtim' type-id='type-id-36' visibility='default' filepath='/usr/include/bits/stat.h' line='92' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='st_ctim' type-id='type-id-36' visibility='default' filepath='/usr/include/bits/stat.h' line='93' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='__glibc_reserved' type-id='type-id-37' visibility='default' filepath='/usr/include/bits/stat.h' line='106' column='1'/>
       </data-member>
     </class-decl>
-    <pointer-type-def type-id='type-id-180' size-in-bits='64' id='type-id-173'/>
-    <pointer-type-def type-id='type-id-172' size-in-bits='64' id='type-id-174'/>
-    <typedef-decl name='__off_t' type-id='type-id-16' filepath='/usr/include/bits/types.h' line='140' column='1' id='type-id-175'/>
-    <type-decl name='signed char' size-in-bits='8' id='type-id-176'/>
-    <typedef-decl name='__off64_t' type-id='type-id-16' filepath='/usr/include/bits/types.h' line='141' column='1' id='type-id-177'/>
-    <pointer-type-def type-id='type-id-168' size-in-bits='64' id='type-id-178'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-38'/>
+    <typedef-decl name='__dev_t' type-id='type-id-38' filepath='/usr/include/bits/types.h' line='133' column='1' id='type-id-27'/>
+    <typedef-decl name='__ino_t' type-id='type-id-38' filepath='/usr/include/bits/types.h' line='136' column='1' id='type-id-28'/>
+    <typedef-decl name='__nlink_t' type-id='type-id-38' filepath='/usr/include/bits/types.h' line='139' column='1' id='type-id-29'/>
+    <typedef-decl name='__mode_t' type-id='type-id-11' filepath='/usr/include/bits/types.h' line='138' column='1' id='type-id-30'/>
+    <typedef-decl name='__uid_t' type-id='type-id-11' filepath='/usr/include/bits/types.h' line='134' column='1' id='type-id-31'/>
+    <typedef-decl name='__gid_t' type-id='type-id-11' filepath='/usr/include/bits/types.h' line='135' column='1' id='type-id-32'/>
+    <type-decl name='int' size-in-bits='32' id='type-id-22'/>
+    <typedef-decl name='__off_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='140' column='1' id='type-id-33'/>
+    <typedef-decl name='__blksize_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='162' column='1' id='type-id-34'/>
+    <typedef-decl name='__blkcnt_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='167' column='1' id='type-id-35'/>
+    <class-decl name='timespec' size-in-bits='128' is-struct='yes' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='8' column='1' id='type-id-36'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='tv_sec' type-id='type-id-39' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='10' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='tv_nsec' type-id='type-id-40' visibility='default' filepath='/usr/include/bits/types/struct_timespec.h' line='11' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__time_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='148' column='1' id='type-id-39'/>
+    <typedef-decl name='__syscall_slong_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='184' column='1' id='type-id-40'/>
 
-    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='160' id='type-id-179'>
-      <subrange length='20' type-id='type-id-12' id='type-id-181'/>
+    <array-type-def dimensions='1' type-id='type-id-40' size-in-bits='192' id='type-id-37'>
+      <subrange length='3' type-id='type-id-38' id='type-id-41'/>
 
     </array-type-def>
-    <var-decl name='stderr' type-id='type-id-174' visibility='default' filepath='/usr/include/stdio.h' line='137' column='1'/>
-    <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-168'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-38' filepath='/usr/include/bits/types.h' line='44' column='1' id='type-id-42'/>
+    <typedef-decl name='uint64_t' type-id='type-id-42' filepath='/usr/include/bits/stdint-uintn.h' line='27' column='1' id='type-id-23'/>
+    <class-decl name='pci_root_info' size-in-bits='192' is-struct='yes' visibility='default' filepath='src/linux.h' line='24' column='1' id='type-id-24'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pci_root_domain' type-id='type-id-43' visibility='default' filepath='src/linux.h' line='25' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='pci_root_bus' type-id='type-id-44' visibility='default' filepath='src/linux.h' line='26' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='pci_root_acpi_hid' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='27' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='pci_root_acpi_uid' type-id='type-id-23' visibility='default' filepath='src/linux.h' line='28' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='pci_root_acpi_uid_str' type-id='type-id-2' visibility='default' filepath='src/linux.h' line='29' column='1'/>
+      </data-member>
+    </class-decl>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-45'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-45' filepath='/usr/include/bits/types.h' line='39' column='1' id='type-id-46'/>
+    <typedef-decl name='uint16_t' type-id='type-id-46' filepath='/usr/include/bits/stdint-uintn.h' line='25' column='1' id='type-id-43'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-47'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-47' filepath='/usr/include/bits/types.h' line='37' column='1' id='type-id-48'/>
+    <typedef-decl name='uint8_t' type-id='type-id-48' filepath='/usr/include/bits/stdint-uintn.h' line='24' column='1' id='type-id-44'/>
+    <class-decl name='pci_dev_info' size-in-bits='48' is-struct='yes' visibility='default' filepath='src/linux.h' line='32' column='1' id='type-id-49'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='pci_domain' type-id='type-id-43' visibility='default' filepath='src/linux.h' line='33' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='pci_bus' type-id='type-id-44' visibility='default' filepath='src/linux.h' line='34' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='24'>
+        <var-decl name='pci_device' type-id='type-id-44' visibility='default' filepath='src/linux.h' line='35' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='pci_function' type-id='type-id-44' visibility='default' filepath='src/linux.h' line='36' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-49' size-in-bits='64' id='type-id-25'/>
+    <union-decl name='__anonymous_union__' size-in-bits='320' is-anonymous='yes' visibility='default' filepath='src/linux.h' line='113' column='1' id='type-id-26'>
+      <data-member access='private'>
+        <var-decl name='scsi_info' type-id='type-id-50' visibility='default' filepath='src/linux.h' line='114' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='sas_info' type-id='type-id-51' visibility='default' filepath='src/linux.h' line='115' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='sata_info' type-id='type-id-52' visibility='default' filepath='src/linux.h' line='116' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='nvme_info' type-id='type-id-53' visibility='default' filepath='src/linux.h' line='117' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='nvdimm_label' type-id='type-id-54' visibility='default' filepath='src/linux.h' line='118' column='1'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='scsi_info' size-in-bits='192' is-struct='yes' visibility='default' filepath='src/linux.h' line='39' column='1' id='type-id-50'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='scsi_bus' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='40' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='scsi_device' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='41' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='scsi_target' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='42' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='scsi_lun' type-id='type-id-23' visibility='default' filepath='src/linux.h' line='43' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='sas_info' size-in-bits='256' is-struct='yes' visibility='default' filepath='src/linux.h' line='46' column='1' id='type-id-51'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='scsi_bus' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='47' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='scsi_device' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='48' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='scsi_target' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='49' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='scsi_lun' type-id='type-id-23' visibility='default' filepath='src/linux.h' line='50' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='sas_address' type-id='type-id-23' visibility='default' filepath='src/linux.h' line='52' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='sata_info' size-in-bits='320' is-struct='yes' visibility='default' filepath='src/linux.h' line='55' column='1' id='type-id-52'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='scsi_bus' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='scsi_device' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='scsi_target' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='58' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='scsi_lun' type-id='type-id-23' visibility='default' filepath='src/linux.h' line='59' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='ata_devno' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='61' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='224'>
+        <var-decl name='ata_port' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='62' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='ata_pmp' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='63' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='ata_print_id' type-id='type-id-4' visibility='default' filepath='src/linux.h' line='65' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='nvme_info' size-in-bits='160' is-struct='yes' visibility='default' filepath='src/linux.h' line='68' column='1' id='type-id-53'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='ctrl_id' type-id='type-id-55' visibility='default' filepath='src/linux.h' line='69' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='ns_id' type-id='type-id-55' visibility='default' filepath='src/linux.h' line='70' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='has_eui' type-id='type-id-22' visibility='default' filepath='src/linux.h' line='71' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='eui' type-id='type-id-56' visibility='default' filepath='src/linux.h' line='72' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='__int32_t' type-id='type-id-22' filepath='/usr/include/bits/types.h' line='40' column='1' id='type-id-57'/>
+    <typedef-decl name='int32_t' type-id='type-id-57' filepath='/usr/include/bits/stdint-intn.h' line='26' column='1' id='type-id-55'/>
+
+    <array-type-def dimensions='1' type-id='type-id-44' size-in-bits='64' id='type-id-56'>
+      <subrange length='8' type-id='type-id-38' id='type-id-58'/>
+
+    </array-type-def>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar.h' line='33' column='1' id='type-id-59'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='a' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar.h' line='34' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='b' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar.h' line='35' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='c' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar.h' line='36' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='d' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar.h' line='37' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='e' type-id='type-id-60' visibility='default' filepath='src/include/efivar/efivar.h' line='38' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-44' size-in-bits='48' id='type-id-60'>
+      <subrange length='6' type-id='type-id-38' id='type-id-61'/>
+
+    </array-type-def>
+    <typedef-decl name='efi_guid_t' type-id='type-id-59' filepath='src/include/efivar/efivar.h' line='39' column='1' id='type-id-54'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-62'/>
+    <qualified-type-def type-id='type-id-8' const='yes' id='type-id-63'/>
+    <pointer-type-def type-id='type-id-63' size-in-bits='64' id='type-id-64'/>
+    <qualified-type-def type-id='type-id-64' const='yes' id='type-id-65'/>
+    <pointer-type-def type-id='type-id-66' size-in-bits='64' id='type-id-5'/>
+    <pointer-type-def type-id='type-id-44' size-in-bits='64' id='type-id-67'/>
+    <pointer-type-def type-id='type-id-68' size-in-bits='64' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-7'/>
+    <var-decl name='sas_parser' type-id='type-id-1' visibility='default' filepath='src/linux.h' line='223' column='1'/>
+    <function-type size-in-bits='64' id='type-id-69'>
+      <parameter type-id='type-id-62'/>
+      <return type-id='type-id-2'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-66'>
+      <parameter type-id='type-id-62'/>
+      <parameter type-id='type-id-65'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-68'>
+      <parameter type-id='type-id-62'/>
+      <parameter type-id='type-id-67'/>
+      <parameter type-id='type-id-15'/>
+      <parameter type-id='type-id-15'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='linux-virtblk.c' comp-dir-path='src' language='LANG_C99'>
+    <var-decl name='virtblk_parser' type-id='type-id-1' visibility='default' filepath='src/linux.h' line='226' column='1'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='linux-pmem.c' comp-dir-path='src' language='LANG_C99'>
+    <var-decl name='pmem_parser' type-id='type-id-1' visibility='default' filepath='src/linux.h' line='221' column='1'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='linux-sata.c' comp-dir-path='src' language='LANG_C99'>
+    <var-decl name='sata_parser' type-id='type-id-1' visibility='default' filepath='src/linux.h' line='224' column='1'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='linux-pci.c' comp-dir-path='src' language='LANG_C99'>
+    <var-decl name='pci_parser' type-id='type-id-1' visibility='default' filepath='src/linux.h' line='222' column='1'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='linux-nvme.c' comp-dir-path='src' language='LANG_C99'>
+    <var-decl name='nvme_parser' type-id='type-id-1' visibility='default' filepath='src/linux.h' line='225' column='1'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='linux-scsi.c' comp-dir-path='src' language='LANG_C99'>
+    <var-decl name='scsi_parser' type-id='type-id-1' visibility='default' filepath='src/linux.h' line='228' column='1'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='linux-ata.c' comp-dir-path='src' language='LANG_C99'>
+    <var-decl name='ata_parser' type-id='type-id-1' visibility='default' filepath='src/linux.h' line='229' column='1'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='linux-i2o.c' comp-dir-path='src' language='LANG_C99'>
+    <var-decl name='i2o_parser' type-id='type-id-1' visibility='default' filepath='src/linux.h' line='227' column='1'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='&lt;artificial&gt;' comp-dir-path='src' language='LANG_C99'>
+    <qualified-type-def type-id='type-id-47' const='yes' id='type-id-70'/>
+    <pointer-type-def type-id='type-id-70' size-in-bits='64' id='type-id-71'/>
+    <class-decl name='efi_load_option_s' size-in-bits='48' is-struct='yes' visibility='default' filepath='src/loadopt.c' line='31' column='1' id='type-id-72'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='attributes' type-id='type-id-4' visibility='default' filepath='src/loadopt.c' line='32' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='file_path_list_length' type-id='type-id-43' visibility='default' filepath='src/loadopt.c' line='33' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='description' type-id='type-id-73' visibility='default' filepath='src/loadopt.c' line='34' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-43' size-in-bits='16' id='type-id-73'>
+      <subrange length='1' type-id='type-id-38' id='type-id-74'/>
+
+    </array-type-def>
+    <typedef-decl name='efi_load_option' type-id='type-id-72' filepath='src/include/efivar/efiboot-loadopt.h' line='24' column='1' id='type-id-75'/>
+    <pointer-type-def type-id='type-id-75' size-in-bits='64' id='type-id-76'/>
+    <function-decl name='efi_loadopt_desc' mangled-name='efi_loadopt_desc' filepath='src/&lt;built-in&gt;' line='368' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_desc@@libefiboot.so.0'>
+      <parameter type-id='type-id-76' name='opt' filepath='src/&lt;built-in&gt;' line='368' column='1'/>
+      <parameter type-id='type-id-15' name='limit' filepath='src/&lt;built-in&gt;' line='368' column='1'/>
+      <return type-id='type-id-71'/>
     </function-decl>
-    <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-168'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-77'/>
+    <function-decl name='efi_loadopt_args_as_ucs2' mangled-name='efi_loadopt_args_as_ucs2' filepath='src/&lt;built-in&gt;' line='337' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_args_as_ucs2@@libefiboot.so.0'>
+      <parameter type-id='type-id-77' name='buf' filepath='src/&lt;built-in&gt;' line='337' column='1'/>
+      <parameter type-id='type-id-15' name='size' filepath='src/&lt;built-in&gt;' line='337' column='1'/>
+      <parameter type-id='type-id-67' name='utf8' filepath='src/&lt;built-in&gt;' line='337' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_loadopt_args_as_utf8' mangled-name='efi_loadopt_args_as_utf8' filepath='src/&lt;built-in&gt;' line='312' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_args_as_utf8@@libefiboot.so.0'>
+      <parameter type-id='type-id-67' name='buf' filepath='src/&lt;built-in&gt;' line='312' column='1'/>
+      <parameter type-id='type-id-15' name='size' filepath='src/&lt;built-in&gt;' line='312' column='1'/>
+      <parameter type-id='type-id-67' name='utf8' filepath='src/&lt;built-in&gt;' line='312' column='1'/>
+      <parameter type-id='type-id-67' name='buf' filepath='src/&lt;built-in&gt;' line='312' column='1'/>
+      <parameter type-id='type-id-15' name='size' filepath='src/&lt;built-in&gt;' line='312' column='1'/>
+      <parameter type-id='type-id-67' name='utf8' filepath='src/&lt;built-in&gt;' line='312' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_loadopt_args_from_file' mangled-name='efi_loadopt_args_from_file' filepath='src/&lt;built-in&gt;' line='269' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_args_from_file@@libefiboot.so.0'>
+      <parameter type-id='type-id-67' name='buf' filepath='src/&lt;built-in&gt;' line='269' column='1'/>
+      <parameter type-id='type-id-15' name='size' filepath='src/&lt;built-in&gt;' line='269' column='1'/>
+      <parameter type-id='type-id-2' name='filename' filepath='src/&lt;built-in&gt;' line='269' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <typedef-decl name='size_t' type-id='type-id-38' filepath='/usr/lib/gcc/x86_64-redhat-linux/8/include/stddef.h' line='216' column='1' id='type-id-78'/>
+    <pointer-type-def type-id='type-id-47' size-in-bits='64' id='type-id-79'/>
+    <pointer-type-def type-id='type-id-79' size-in-bits='64' id='type-id-80'/>
+    <pointer-type-def type-id='type-id-78' size-in-bits='64' id='type-id-81'/>
+    <function-decl name='efi_loadopt_optional_data' mangled-name='efi_loadopt_optional_data' filepath='src/&lt;built-in&gt;' line='236' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_optional_data@@libefiboot.so.0'>
+      <parameter type-id='type-id-76' name='opt' filepath='src/&lt;built-in&gt;' line='236' column='1'/>
+      <parameter type-id='type-id-78' name='opt_size' filepath='src/&lt;built-in&gt;' line='236' column='1'/>
+      <parameter type-id='type-id-80' name='datap' filepath='src/&lt;built-in&gt;' line='237' column='1'/>
+      <parameter type-id='type-id-81' name='len' filepath='src/&lt;built-in&gt;' line='237' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='833' column='1' id='type-id-82'>
+      <data-member access='private'>
+        <var-decl name='' type-id='type-id-83' visibility='default'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='839' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='pci' type-id='type-id-85' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='840' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='pccard' type-id='type-id-86' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='841' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='mmio' type-id='type-id-87' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='842' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='hw_vendor' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='843' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='controller' type-id='type-id-89' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='844' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='bmc' type-id='type-id-90' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='845' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='acpi_hid' type-id='type-id-91' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='846' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='acpi_hid_ex' type-id='type-id-92' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='847' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='acpi_adr' type-id='type-id-93' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='848' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='atapi' type-id='type-id-94' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='849' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='scsi' type-id='type-id-95' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='850' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='fc' type-id='type-id-96' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='851' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='fcex' type-id='type-id-97' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='852' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='firewire' type-id='type-id-98' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='853' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='usb' type-id='type-id-99' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='854' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='usb_class' type-id='type-id-100' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='855' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='usb_wwid' type-id='type-id-101' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='856' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='lun' type-id='type-id-102' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='857' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='sata' type-id='type-id-103' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='858' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='i2o' type-id='type-id-104' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='859' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='mac_addr' type-id='type-id-105' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='860' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='ipv4_addr' type-id='type-id-106' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='861' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='ipv6_addr' type-id='type-id-107' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='862' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='vlan' type-id='type-id-108' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='863' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='infiniband' type-id='type-id-109' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='864' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='uart' type-id='type-id-110' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='865' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='msg_vendor' type-id='type-id-111' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='866' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='uart_flow_control' type-id='type-id-112' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='867' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='sas' type-id='type-id-113' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='868' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='sas_ex' type-id='type-id-114' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='869' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='iscsi' type-id='type-id-115' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='870' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='nvme' type-id='type-id-116' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='871' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='uri' type-id='type-id-117' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='872' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='ufs' type-id='type-id-118' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='873' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='sd' type-id='type-id-119' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='874' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='bt' type-id='type-id-120' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='875' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='wifi' type-id='type-id-121' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='876' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='emmc' type-id='type-id-122' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='877' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='btle' type-id='type-id-123' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='878' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='dns' type-id='type-id-124' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='879' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='nvdimm' type-id='type-id-125' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='880' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='hd' type-id='type-id-126' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='881' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='cdrom' type-id='type-id-127' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='882' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='media_vendor' type-id='type-id-128' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='883' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='file' type-id='type-id-129' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='884' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='protocol' type-id='type-id-130' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='885' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='firmware_file' type-id='type-id-131' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='886' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='firmware_volume' type-id='type-id-132' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='887' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='relative_offset' type-id='type-id-133' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='888' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='ramdisk' type-id='type-id-134' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='889' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='bios_boot' type-id='type-id-135' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='890' column='1'/>
+      </data-member>
+    </union-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='834' column='1' id='type-id-83'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='835' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='subtype' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='836' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='length' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='837' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='36' column='1' id='type-id-136'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='type' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='37' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='8'>
+        <var-decl name='subtype' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='38' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='16'>
+        <var-decl name='length' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='39' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_header' type-id='type-id-136' filepath='src/include/efivar/efivar-dp.h' line='40' column='1' id='type-id-84'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-85' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='55' column='1' id='type-id-137'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='56' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='function' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='57' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='40'>
+        <var-decl name='device' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='58' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_pci' type-id='type-id-137' filepath='src/include/efivar/efivar-dp.h' line='59' column='1' id='type-id-85'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-86' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='64' column='1' id='type-id-138'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='65' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='function' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='66' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_pccard' type-id='type-id-138' filepath='src/include/efivar/efivar-dp.h' line='67' column='1' id='type-id-86'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-87' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='70' column='1' id='type-id-139'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='71' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='memory_type' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='72' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='starting_address' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='73' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='ending_address' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='74' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_mmio' type-id='type-id-139' filepath='src/include/efivar/efivar-dp.h' line='75' column='1' id='type-id-87'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='78' column='1' id='type-id-140'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='79' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='vendor_guid' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='80' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='vendor_data' type-id='type-id-141' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='81' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-44' size-in-bits='8' id='type-id-141'>
+      <subrange length='1' type-id='type-id-38' id='type-id-74'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_hw_vendor' type-id='type-id-140' filepath='src/include/efivar/efivar-dp.h' line='82' column='1' id='type-id-88'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-89' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='99' column='1' id='type-id-142'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='100' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='controller' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='101' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_controller' type-id='type-id-142' filepath='src/include/efivar/efivar-dp.h' line='102' column='1' id='type-id-89'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='104' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-90' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='105' column='1' id='type-id-143'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='106' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='interface_type' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='107' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='40'>
+        <var-decl name='base_addr' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='108' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_bmc' type-id='type-id-143' filepath='src/include/efivar/efivar-dp.h' line='109' column='1' id='type-id-90'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='96' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-91' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='119' column='1' id='type-id-144'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='120' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='hid' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='121' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uid' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='122' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_acpi_hid' type-id='type-id-144' filepath='src/include/efivar/efivar-dp.h' line='123' column='1' id='type-id-91'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-92' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='128' column='1' id='type-id-145'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='129' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='hid' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='130' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='uid' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='131' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='cid' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='132' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='hidstr' type-id='type-id-146' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='134' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-8' size-in-bits='8' id='type-id-146'>
+      <subrange length='1' type-id='type-id-38' id='type-id-74'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_acpi_hid_ex' type-id='type-id-145' filepath='src/include/efivar/efivar-dp.h' line='135' column='1' id='type-id-92'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-93' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='166' column='1' id='type-id-147'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='167' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='adr' type-id='type-id-148' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='168' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-4' size-in-bits='32' id='type-id-148'>
+      <subrange length='1' type-id='type-id-38' id='type-id-74'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_acpi_adr' type-id='type-id-147' filepath='src/include/efivar/efivar-dp.h' line='169' column='1' id='type-id-93'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-94' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='327' column='1' id='type-id-149'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='328' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='primary' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='329' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='40'>
+        <var-decl name='slave' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='330' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='lun' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='331' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_atapi' type-id='type-id-149' filepath='src/include/efivar/efivar-dp.h' line='332' column='1' id='type-id-94'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-95' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='337' column='1' id='type-id-150'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='338' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='target' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='339' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='lun' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='340' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_scsi' type-id='type-id-150' filepath='src/include/efivar/efivar-dp.h' line='341' column='1' id='type-id-95'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-96' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='346' column='1' id='type-id-151'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='347' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='reserved' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='348' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='wwn' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='349' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lun' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='350' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_fc' type-id='type-id-151' filepath='src/include/efivar/efivar-dp.h' line='351' column='1' id='type-id-96'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-97' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='354' column='1' id='type-id-152'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='355' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='reserved' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='356' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='wwn' type-id='type-id-56' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='357' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lun' type-id='type-id-56' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='358' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_fcex' type-id='type-id-152' filepath='src/include/efivar/efivar-dp.h' line='359' column='1' id='type-id-97'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-98' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='362' column='1' id='type-id-153'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='363' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='reserved' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='364' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='guid' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='365' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_1394' type-id='type-id-153' filepath='src/include/efivar/efivar-dp.h' line='366' column='1' id='type-id-98'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-99' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='369' column='1' id='type-id-154'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='370' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='parent_port' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='371' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='40'>
+        <var-decl name='interface' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='372' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_usb' type-id='type-id-154' filepath='src/include/efivar/efivar-dp.h' line='373' column='1' id='type-id-99'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-100' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='376' column='1' id='type-id-155'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='377' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='vendor_id' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='378' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='product_id' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='379' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='device_class' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='380' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='72'>
+        <var-decl name='device_subclass' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='381' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='device_protocol' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='382' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_usb_class' type-id='type-id-155' filepath='src/include/efivar/efivar-dp.h' line='383' column='1' id='type-id-100'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-101' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='403' column='1' id='type-id-156'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='404' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='interface' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='405' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='vendor_id' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='406' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='product_id' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='407' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='serial_number' type-id='type-id-73' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='408' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_usb_wwid' type-id='type-id-156' filepath='src/include/efivar/efivar-dp.h' line='409' column='1' id='type-id-101'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-102' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='412' column='1' id='type-id-157'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='413' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='lun' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='414' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_lun' type-id='type-id-157' filepath='src/include/efivar/efivar-dp.h' line='415' column='1' id='type-id-102'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-103' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='418' column='1' id='type-id-158'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='419' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='hba_port' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='420' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='port_multiplier_port' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='421' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='lun' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='422' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_sata' type-id='type-id-158' filepath='src/include/efivar/efivar-dp.h' line='423' column='1' id='type-id-103'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-104' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='429' column='1' id='type-id-159'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='430' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='target' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='431' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_i2o' type-id='type-id-159' filepath='src/include/efivar/efivar-dp.h' line='432' column='1' id='type-id-104'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='296' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-105' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='435' column='1' id='type-id-160'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='436' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='mac_addr' type-id='type-id-161' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='437' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='if_type' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='438' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-44' size-in-bits='256' id='type-id-161'>
+      <subrange length='32' type-id='type-id-38' id='type-id-162'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_mac_addr' type-id='type-id-160' filepath='src/include/efivar/efivar-dp.h' line='439' column='1' id='type-id-105'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='216' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-106' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='447' column='1' id='type-id-163'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='448' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='local_ipv4_addr' type-id='type-id-164' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='449' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='remote_ipv4_addr' type-id='type-id-164' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='450' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='local_port' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='451' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='112'>
+        <var-decl name='remote_port' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='452' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='protocol' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='453' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='144'>
+        <var-decl name='static_ip_addr' type-id='type-id-165' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='454' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='152'>
+        <var-decl name='gateway' type-id='type-id-164' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='455' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='184'>
+        <var-decl name='netmask' type-id='type-id-164' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='456' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-44' size-in-bits='32' id='type-id-164'>
+      <subrange length='4' type-id='type-id-38' id='type-id-166'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_boolean' type-id='type-id-44' filepath='src/include/efivar/efivar-dp.h' line='43' column='1' id='type-id-165'/>
+    <typedef-decl name='efidp_ipv4_addr' type-id='type-id-163' filepath='src/include/efivar/efivar-dp.h' line='457' column='1' id='type-id-106'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='360' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-107' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='469' column='1' id='type-id-167'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='470' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='local_ipv6_addr' type-id='type-id-168' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='471' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='remote_ipv6_addr' type-id='type-id-168' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='472' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='local_port' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='473' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='304'>
+        <var-decl name='remote_port' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='474' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='protocol' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='475' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='ip_addr_origin' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='476' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='344'>
+        <var-decl name='prefix_length' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='477' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='352'>
+        <var-decl name='gateway_ipv6_addr' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='478' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-44' size-in-bits='128' id='type-id-168'>
+      <subrange length='16' type-id='type-id-38' id='type-id-169'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_ipv6_addr' type-id='type-id-167' filepath='src/include/efivar/efivar-dp.h' line='479' column='1' id='type-id-107'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-108' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='486' column='1' id='type-id-170'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='487' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='vlan_id' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='488' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_vlan' type-id='type-id-170' filepath='src/include/efivar/efivar-dp.h' line='489' column='1' id='type-id-108'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='384' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-109' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='492' column='1' id='type-id-171'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='493' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='resource_flags' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='494' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='port_gid' type-id='type-id-172' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='495' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='' type-id='type-id-173' visibility='default'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='target_port_id' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='500' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='device_id' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='501' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-23' size-in-bits='128' id='type-id-172'>
+      <subrange length='2' type-id='type-id-38' id='type-id-174'/>
+
+    </array-type-def>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='496' column='1' id='type-id-173'>
+      <data-member access='private'>
+        <var-decl name='ioc_guid' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='497' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='service_id' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='498' column='1'/>
+      </data-member>
+    </union-decl>
+    <typedef-decl name='efidp_infiniband' type-id='type-id-171' filepath='src/include/efivar/efivar-dp.h' line='502' column='1' id='type-id-109'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='152' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-110' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='511' column='1' id='type-id-175'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='512' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='reserved' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='513' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='baud_rate' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='514' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='data_bits' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='515' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='136'>
+        <var-decl name='parity' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='516' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='144'>
+        <var-decl name='stop_bits' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='517' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_uart' type-id='type-id-175' filepath='src/include/efivar/efivar-dp.h' line='518' column='1' id='type-id-110'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-111' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='542' column='1' id='type-id-176'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='543' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='vendor_guid' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='544' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='vendor_data' type-id='type-id-141' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='545' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_msg_vendor' type-id='type-id-176' filepath='src/include/efivar/efivar-dp.h' line='546' column='1' id='type-id-111'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-112' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='555' column='1' id='type-id-177'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='556' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='vendor_guid' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='557' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='flow_control_map' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='558' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_uart_flow_control' type-id='type-id-177' filepath='src/include/efivar/efivar-dp.h' line='559' column='1' id='type-id-112'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='352' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-113' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='566' column='1' id='type-id-178'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='567' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='vendor_guid' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='568' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='reserved' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='569' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='sas_address' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='570' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='lun' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='571' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='device_topology_info' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='572' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='328'>
+        <var-decl name='drive_bay_id' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='573' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='336'>
+        <var-decl name='rtp' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='574' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_sas' type-id='type-id-178' filepath='src/include/efivar/efivar-dp.h' line='575' column='1' id='type-id-113'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-114' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='599' column='1' id='type-id-179'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='600' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='sas_address' type-id='type-id-56' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='601' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='lun' type-id='type-id-56' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='602' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='device_topology_info' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='603' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='168'>
+        <var-decl name='drive_bay_id' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='604' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='176'>
+        <var-decl name='rtp' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='605' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_sas_ex' type-id='type-id-179' filepath='src/include/efivar/efivar-dp.h' line='606' column='1' id='type-id-114'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='144' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-115' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='612' column='1' id='type-id-180'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='613' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='protocol' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='614' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='options' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='615' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='lun' type-id='type-id-56' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='616' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='tpgt' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='617' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='144'>
+        <var-decl name='target_name' type-id='type-id-141' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='618' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_iscsi' type-id='type-id-180' filepath='src/include/efivar/efivar-dp.h' line='619' column='1' id='type-id-115'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-116' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='647' column='1' id='type-id-181'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='648' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='namespace_id' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='649' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='ieee_eui_64' type-id='type-id-56' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='650' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_nvme' type-id='type-id-181' filepath='src/include/efivar/efivar-dp.h' line='651' column='1' id='type-id-116'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-117' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='656' column='1' id='type-id-182'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='657' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='uri' type-id='type-id-141' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='658' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_uri' type-id='type-id-182' filepath='src/include/efivar/efivar-dp.h' line='659' column='1' id='type-id-117'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-118' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='662' column='1' id='type-id-183'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='663' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='target_id' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='664' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='40'>
+        <var-decl name='lun' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='665' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_ufs' type-id='type-id-183' filepath='src/include/efivar/efivar-dp.h' line='666' column='1' id='type-id-118'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-119' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='669' column='1' id='type-id-184'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='670' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='slot_number' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='671' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_sd' type-id='type-id-184' filepath='src/include/efivar/efivar-dp.h' line='672' column='1' id='type-id-119'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-120' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='675' column='1' id='type-id-185'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='676' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='addr' type-id='type-id-60' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='677' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_bt' type-id='type-id-185' filepath='src/include/efivar/efivar-dp.h' line='678' column='1' id='type-id-120'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='288' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-121' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='681' column='1' id='type-id-186'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='682' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='ssid' type-id='type-id-161' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='683' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_wifi' type-id='type-id-186' filepath='src/include/efivar/efivar-dp.h' line='684' column='1' id='type-id-121'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-122' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='687' column='1' id='type-id-187'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='688' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='slot' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='689' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_emmc' type-id='type-id-187' filepath='src/include/efivar/efivar-dp.h' line='690' column='1' id='type-id-122'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-123' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='693' column='1' id='type-id-188'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='694' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='addr' type-id='type-id-60' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='695' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='80'>
+        <var-decl name='addr_type' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='696' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_btle' type-id='type-id-188' filepath='src/include/efivar/efivar-dp.h' line='697' column='1' id='type-id-123'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-124' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='703' column='1' id='type-id-189'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='704' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='is_ipv6' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='705' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='40'>
+        <var-decl name='addrs' type-id='type-id-190' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='706' column='1'/>
+      </data-member>
+    </class-decl>
+    <union-decl name='__anonymous_union__' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='src/include/efivar/efivar.h' line='49' column='1' id='type-id-191'>
+      <data-member access='private'>
+        <var-decl name='addr' type-id='type-id-192' visibility='default' filepath='src/include/efivar/efivar.h' line='50' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='v4' type-id='type-id-193' visibility='default' filepath='src/include/efivar/efivar.h' line='51' column='1'/>
+      </data-member>
+      <data-member access='private'>
+        <var-decl name='v6' type-id='type-id-194' visibility='default' filepath='src/include/efivar/efivar.h' line='52' column='1'/>
+      </data-member>
+    </union-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-4' size-in-bits='128' id='type-id-192'>
+      <subrange length='4' type-id='type-id-38' id='type-id-166'/>
+
+    </array-type-def>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-193' visibility='default' filepath='src/include/efivar/efivar.h' line='41' column='1' id='type-id-195'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='addr' type-id='type-id-164' visibility='default' filepath='src/include/efivar/efivar.h' line='42' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efi_ipv4_addr_t' type-id='type-id-195' filepath='src/include/efivar/efivar.h' line='43' column='1' id='type-id-193'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-194' visibility='default' filepath='src/include/efivar/efivar.h' line='45' column='1' id='type-id-196'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='addr' type-id='type-id-168' visibility='default' filepath='src/include/efivar/efivar.h' line='46' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efi_ipv6_addr_t' type-id='type-id-196' filepath='src/include/efivar/efivar.h' line='47' column='1' id='type-id-194'/>
+    <typedef-decl name='efi_ip_addr_t' type-id='type-id-191' filepath='src/include/efivar/efivar.h' line='53' column='1' id='type-id-197'/>
+
+    <array-type-def dimensions='1' type-id='type-id-197' size-in-bits='128' id='type-id-190'>
+      <subrange length='1' type-id='type-id-38' id='type-id-74'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_dns' type-id='type-id-189' filepath='src/include/efivar/efivar-dp.h' line='707' column='1' id='type-id-124'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-125' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='710' column='1' id='type-id-198'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='711' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='uuid' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='712' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_nvdimm' type-id='type-id-198' filepath='src/include/efivar/efivar-dp.h' line='713' column='1' id='type-id-125'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='336' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-126' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='718' column='1' id='type-id-199'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='719' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='partition_number' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='720' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='start' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='721' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='size' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='722' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='signature' type-id='type-id-168' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='723' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='format' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='724' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='328'>
+        <var-decl name='signature_type' type-id='type-id-44' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='725' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_hd' type-id='type-id-199' filepath='src/include/efivar/efivar-dp.h' line='729' column='1' id='type-id-126'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-127' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='743' column='1' id='type-id-200'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='744' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='boot_catalog_entry' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='745' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='partition_rba' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='746' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='sectors' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='747' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_cdrom' type-id='type-id-200' filepath='src/include/efivar/efivar-dp.h' line='748' column='1' id='type-id-127'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-128' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='751' column='1' id='type-id-201'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='752' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='vendor_guid' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='753' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='vendor_data' type-id='type-id-141' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='754' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_media_vendor' type-id='type-id-201' filepath='src/include/efivar/efivar-dp.h' line='755' column='1' id='type-id-128'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-129' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='762' column='1' id='type-id-202'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='763' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='name' type-id='type-id-73' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='764' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_file' type-id='type-id-202' filepath='src/include/efivar/efivar-dp.h' line='765' column='1' id='type-id-129'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-130' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='769' column='1' id='type-id-203'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='770' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='protocol_guid' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='771' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_protocol' type-id='type-id-203' filepath='src/include/efivar/efivar-dp.h' line='772' column='1' id='type-id-130'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-131' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='775' column='1' id='type-id-204'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='776' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='pi_info' type-id='type-id-141' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='777' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_firmware_file' type-id='type-id-204' filepath='src/include/efivar/efivar-dp.h' line='778' column='1' id='type-id-131'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-132' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='781' column='1' id='type-id-205'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='782' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='pi_info' type-id='type-id-141' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='783' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_firmware_volume' type-id='type-id-205' filepath='src/include/efivar/efivar-dp.h' line='784' column='1' id='type-id-132'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-133' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='787' column='1' id='type-id-206'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='788' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='reserved' type-id='type-id-4' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='789' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='first_byte' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='790' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='last_byte' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='791' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_relative_offset' type-id='type-id-206' filepath='src/include/efivar/efivar-dp.h' line='792' column='1' id='type-id-133'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='304' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-134' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='795' column='1' id='type-id-207'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='796' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='start_addr' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='797' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='end_addr' type-id='type-id-23' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='798' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='disk_type_guid' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='799' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='instance_number' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='800' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_ramdisk' type-id='type-id-207' filepath='src/include/efivar/efivar-dp.h' line='801' column='1' id='type-id-134'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-135' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='814' column='1' id='type-id-208'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-84' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='815' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='device_type' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='816' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='status' type-id='type-id-43' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='817' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='description' type-id='type-id-141' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='818' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_bios_boot' type-id='type-id-208' filepath='src/include/efivar/efivar-dp.h' line='819' column='1' id='type-id-135'/>
+    <typedef-decl name='efidp_data' type-id='type-id-82' filepath='src/include/efivar/efivar-dp.h' line='891' column='1' id='type-id-209'/>
+    <pointer-type-def type-id='type-id-209' size-in-bits='64' id='type-id-210'/>
+    <typedef-decl name='efidp' type-id='type-id-210' filepath='src/include/efivar/efivar-dp.h' line='892' column='1' id='type-id-211'/>
+    <function-decl name='efi_loadopt_path' mangled-name='efi_loadopt_path' filepath='src/&lt;built-in&gt;' line='207' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_path@@libefiboot.so.0'>
+      <parameter type-id='type-id-76' name='opt' filepath='src/&lt;built-in&gt;' line='207' column='1'/>
+      <parameter type-id='type-id-15' name='limit' filepath='src/&lt;built-in&gt;' line='207' column='1'/>
+      <return type-id='type-id-211'/>
+    </function-decl>
+    <function-decl name='efi_loadopt_pathlen' mangled-name='efi_loadopt_pathlen' filepath='src/&lt;built-in&gt;' line='193' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_pathlen@@libefiboot.so.0'>
+      <parameter type-id='type-id-76' name='opt' filepath='src/&lt;built-in&gt;' line='193' column='1'/>
+      <parameter type-id='type-id-15' name='limit' filepath='src/&lt;built-in&gt;' line='193' column='1'/>
+      <return type-id='type-id-43'/>
+    </function-decl>
+    <type-decl name='void' id='type-id-212'/>
+    <function-decl name='efi_loadopt_attr_clear' mangled-name='efi_loadopt_attr_clear' filepath='src/&lt;built-in&gt;' line='186' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_attr_clear@@libefiboot.so.0'>
+      <parameter type-id='type-id-76' name='opt' filepath='src/&lt;built-in&gt;' line='186' column='1'/>
+      <parameter type-id='type-id-43' name='attr' filepath='src/&lt;built-in&gt;' line='186' column='1'/>
+      <return type-id='type-id-212'/>
+    </function-decl>
+    <function-decl name='efi_loadopt_attr_set' mangled-name='efi_loadopt_attr_set' filepath='src/&lt;built-in&gt;' line='180' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_attr_set@@libefiboot.so.0'>
+      <parameter type-id='type-id-76' name='opt' filepath='src/&lt;built-in&gt;' line='186' column='1'/>
+      <parameter type-id='type-id-43' name='attr' filepath='src/&lt;built-in&gt;' line='186' column='1'/>
+      <return type-id='type-id-212'/>
+    </function-decl>
+    <function-decl name='efi_loadopt_attrs' mangled-name='efi_loadopt_attrs' filepath='src/&lt;built-in&gt;' line='174' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_attrs@@libefiboot.so.0'>
+      <parameter type-id='type-id-76' name='opt' filepath='src/&lt;built-in&gt;' line='174' column='1'/>
+      <return type-id='type-id-4'/>
+    </function-decl>
+    <function-decl name='efi_loadopt_is_valid' mangled-name='efi_loadopt_is_valid' filepath='src/&lt;built-in&gt;' line='165' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_is_valid@@libefiboot.so.0'>
+      <parameter type-id='type-id-76' name='opt' filepath='src/&lt;built-in&gt;' line='165' column='1'/>
+      <parameter type-id='type-id-78' name='size' filepath='src/&lt;built-in&gt;' line='165' column='1'/>
+      <return type-id='type-id-22'/>
+    </function-decl>
+    <function-decl name='efi_loadopt_optional_data_size' mangled-name='efi_loadopt_optional_data_size' filepath='src/&lt;built-in&gt;' line='117' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_optional_data_size@@libefiboot.so.0'>
+      <parameter type-id='type-id-76' name='opt' filepath='src/&lt;built-in&gt;' line='117' column='1'/>
+      <parameter type-id='type-id-78' name='size' filepath='src/&lt;built-in&gt;' line='117' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_loadopt_create' mangled-name='efi_loadopt_create' filepath='src/&lt;built-in&gt;' line='40' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_loadopt_create@@libefiboot.so.0'>
+      <parameter type-id='type-id-67' name='buf' filepath='src/&lt;built-in&gt;' line='40' column='1'/>
+      <parameter type-id='type-id-15' name='size' filepath='src/&lt;built-in&gt;' line='40' column='1'/>
+      <parameter type-id='type-id-4' name='attributes' filepath='src/&lt;built-in&gt;' line='40' column='1'/>
+      <parameter type-id='type-id-211' name='dp' filepath='src/&lt;built-in&gt;' line='41' column='1'/>
+      <parameter type-id='type-id-15' name='dp_size' filepath='src/&lt;built-in&gt;' line='41' column='1'/>
+      <parameter type-id='type-id-79' name='description' filepath='src/&lt;built-in&gt;' line='41' column='1'/>
+      <parameter type-id='type-id-67' name='optional_data' filepath='src/&lt;built-in&gt;' line='42' column='1'/>
+      <parameter type-id='type-id-78' name='optional_data_size' filepath='src/&lt;built-in&gt;' line='42' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_generate_ipv4_device_path' mangled-name='efi_generate_ipv4_device_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_generate_ipv4_device_path@@libefiboot.so.0'>
+      <parameter type-id='type-id-67' name='buf'/>
+      <parameter type-id='type-id-15' name='size'/>
+      <parameter type-id='type-id-65' name='ifname'/>
+      <parameter type-id='type-id-65' name='local_addr'/>
+      <parameter type-id='type-id-65' name='remote_addr'/>
+      <parameter type-id='type-id-65' name='gateway_addr'/>
+      <parameter type-id='type-id-65' name='netmask'/>
+      <parameter type-id='type-id-43' name='local_port'/>
+      <parameter type-id='type-id-43' name='remote_port'/>
+      <parameter type-id='type-id-43' name='protocol'/>
+      <parameter type-id='type-id-44' name='addr_origin'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_generate_file_device_path' mangled-name='efi_generate_file_device_path' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_generate_file_device_path@@libefiboot.so.0'>
+      <parameter type-id='type-id-67' name='buf'/>
+      <parameter type-id='type-id-15' name='size'/>
+      <parameter type-id='type-id-65' name='filepath'/>
+      <parameter type-id='type-id-4' name='options'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_generate_file_device_path_from_esp' mangled-name='efi_generate_file_device_path_from_esp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_generate_file_device_path_from_esp@@libefiboot.so.0'>
+      <parameter type-id='type-id-67' name='buf'/>
+      <parameter type-id='type-id-15' name='size'/>
+      <parameter type-id='type-id-64' name='devpath'/>
+      <parameter type-id='type-id-22' name='partition'/>
+      <parameter type-id='type-id-64' name='relpath'/>
+      <parameter type-id='type-id-4' name='options'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-10' size-in-bits='64' alignment-in-bits='32' id='type-id-213'>
+      <subrange length='2' type-id='type-id-38' id='type-id-174'/>
+
+    </array-type-def>
+    <var-decl name='pci_iftypes' type-id='type-id-213' visibility='default' filepath='src/linux-pci.c' line='199' column='1'/>
+    <var-decl name='pmem_iftypes' type-id='type-id-213' visibility='default' filepath='src/linux-pmem.c' line='143' column='1'/>
+    <var-decl name='sas_iftypes' type-id='type-id-213' visibility='default' filepath='src/linux-sas.c' line='113' column='1'/>
+    <var-decl name='sata_iftypes' type-id='type-id-213' visibility='default' filepath='src/linux-sata.c' line='224' column='1'/>
+    <var-decl name='virtblk_iftypes' type-id='type-id-213' visibility='default' filepath='src/linux-virtblk.c' line='65' column='1'/>
+
+    <array-type-def dimensions='1' type-id='type-id-10' size-in-bits='96' alignment-in-bits='32' id='type-id-214'>
+      <subrange length='3' type-id='type-id-38' id='type-id-41'/>
+
+    </array-type-def>
+    <var-decl name='ata_iftypes' type-id='type-id-214' visibility='default' filepath='src/linux-ata.c' line='89' column='1'/>
+    <var-decl name='scsi_iftypes' type-id='type-id-213' visibility='default' filepath='src/linux-scsi.c' line='188' column='1'/>
+    <var-decl name='i2o_iftypes' type-id='type-id-213' visibility='default' filepath='src/linux-i2o.c' line='54' column='1'/>
+    <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-212'/>
     </function-decl>
     <function-decl name='__builtin_calloc' mangled-name='calloc' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-168'/>
+      <return type-id='type-id-212'/>
+    </function-decl>
+    <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-212'/>
     </function-decl>
   </abi-instr>
 </abi-corpus>

--- a/src/libefivar.abixml
+++ b/src/libefivar.abixml
@@ -104,1424 +104,1754 @@
     <elf-symbol name='efi_well_known_guids' size='18480' version='libefivar.so.0' is-default-version='yes' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_well_known_guids_end' size='1' version='libefivar.so.0' is-default-version='yes' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='&lt;artificial&gt;' comp-dir-path='/home/pjones/devel/github.com/efivar/master/src' language='LANG_C99'>
-    <type-decl name='int' size-in-bits='32' id='type-id-1'/>
-    <function-decl name='efi_variables_supported' mangled-name='efi_variables_supported' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='246' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variables_supported@@libefivar.so.0'>
-      <return type-id='type-id-1'/>
-    </function-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-2' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='33' column='1' id='type-id-3'>
+  <abi-instr version='1.0' address-size='64' path='efivarfs.c' comp-dir-path='/home/pjones/devel/github.com/efivar/master/src' language='LANG_C99'>
+    <class-decl name='efi_var_operations' size-in-bits='2624' is-struct='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='31' column='1' id='type-id-1'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='a' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='34' column='1'/>
+        <var-decl name='name' type-id='type-id-2' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='32' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2048'>
+        <var-decl name='probe' type-id='type-id-3' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='33' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2112'>
+        <var-decl name='set_variable' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='34' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='del_variable' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='36' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2240'>
+        <var-decl name='get_variable' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='37' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2304'>
+        <var-decl name='get_variable_attributes' type-id='type-id-7' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='39' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2368'>
+        <var-decl name='get_variable_size' type-id='type-id-8' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='41' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2432'>
+        <var-decl name='get_next_variable_name' type-id='type-id-9' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='43' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2496'>
+        <var-decl name='append_variable' type-id='type-id-10' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='44' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2560'>
+        <var-decl name='chmod_variable' type-id='type-id-11' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='47' column='1'/>
+      </data-member>
+    </class-decl>
+    <type-decl name='char' size-in-bits='8' id='type-id-12'/>
+    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-13'/>
+
+    <array-type-def dimensions='1' type-id='type-id-12' size-in-bits='2040' id='type-id-2'>
+      <subrange length='255' type-id='type-id-13' id='type-id-14'/>
+
+    </array-type-def>
+    <type-decl name='int' size-in-bits='32' id='type-id-15'/>
+    <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-3'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='33' column='1' id='type-id-18'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='a' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='34' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='b' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='35' column='1'/>
+        <var-decl name='b' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='35' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='c' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='36' column='1'/>
+        <var-decl name='c' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='36' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='d' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='37' column='1'/>
+        <var-decl name='d' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='37' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='e' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='38' column='1'/>
+        <var-decl name='e' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='38' column='1'/>
       </data-member>
     </class-decl>
-    <type-decl name='unsigned int' size-in-bits='32' id='type-id-7'/>
-    <typedef-decl name='__uint32_t' type-id='type-id-7' filepath='/usr/include/bits/types.h' line='41' column='1' id='type-id-8'/>
-    <typedef-decl name='uint32_t' type-id='type-id-8' filepath='/usr/include/bits/stdint-uintn.h' line='26' column='1' id='type-id-4'/>
-    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-9'/>
-    <typedef-decl name='__uint16_t' type-id='type-id-9' filepath='/usr/include/bits/types.h' line='39' column='1' id='type-id-10'/>
-    <typedef-decl name='uint16_t' type-id='type-id-10' filepath='/usr/include/bits/stdint-uintn.h' line='25' column='1' id='type-id-5'/>
-    <type-decl name='unsigned char' size-in-bits='8' id='type-id-11'/>
-    <typedef-decl name='__uint8_t' type-id='type-id-11' filepath='/usr/include/bits/types.h' line='37' column='1' id='type-id-12'/>
-    <typedef-decl name='uint8_t' type-id='type-id-12' filepath='/usr/include/bits/stdint-uintn.h' line='24' column='1' id='type-id-13'/>
-    <array-type-def dimensions='1' type-id='type-id-13' size-in-bits='48' id='type-id-6'>
-      <subrange length='6'/>
+    <type-decl name='unsigned int' size-in-bits='32' id='type-id-22'/>
+    <typedef-decl name='__uint32_t' type-id='type-id-22' filepath='/usr/include/bits/types.h' line='41' column='1' id='type-id-23'/>
+    <typedef-decl name='uint32_t' type-id='type-id-23' filepath='/usr/include/bits/stdint-uintn.h' line='26' column='1' id='type-id-19'/>
+    <type-decl name='unsigned short int' size-in-bits='16' id='type-id-24'/>
+    <typedef-decl name='__uint16_t' type-id='type-id-24' filepath='/usr/include/bits/types.h' line='39' column='1' id='type-id-25'/>
+    <typedef-decl name='uint16_t' type-id='type-id-25' filepath='/usr/include/bits/stdint-uintn.h' line='25' column='1' id='type-id-20'/>
+    <type-decl name='unsigned char' size-in-bits='8' id='type-id-26'/>
+    <typedef-decl name='__uint8_t' type-id='type-id-26' filepath='/usr/include/bits/types.h' line='37' column='1' id='type-id-27'/>
+    <typedef-decl name='uint8_t' type-id='type-id-27' filepath='/usr/include/bits/stdint-uintn.h' line='24' column='1' id='type-id-28'/>
+
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='48' id='type-id-21'>
+      <subrange length='6' type-id='type-id-13' id='type-id-29'/>
+
     </array-type-def>
-    <qualified-type-def type-id='type-id-3' const='yes' id='type-id-14'/>
-    <pointer-type-def type-id='type-id-14' size-in-bits='64' id='type-id-15'/>
-    <function-decl name='efi_guid_cmp' mangled-name='efi_guid_cmp' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='35' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_cmp@@LIBEFIVAR_0.24'>
-      <parameter type-id='type-id-15' name='a' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='35' column='1'/>
-      <parameter type-id='type-id-15' name='b' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='35' column='1'/>
-      <return type-id='type-id-1'/>
+    <typedef-decl name='efi_guid_t' type-id='type-id-18' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='39' column='1' id='type-id-17'/>
+    <qualified-type-def type-id='type-id-12' const='yes' id='type-id-30'/>
+    <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-31'/>
+    <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-32'/>
+    <typedef-decl name='size_t' type-id='type-id-13' filepath='/usr/lib/gcc/x86_64-redhat-linux/8/include/stddef.h' line='216' column='1' id='type-id-33'/>
+    <typedef-decl name='__mode_t' type-id='type-id-22' filepath='/usr/include/bits/types.h' line='138' column='1' id='type-id-34'/>
+    <typedef-decl name='mode_t' type-id='type-id-34' filepath='/usr/include/fcntl.h' line='50' column='1' id='type-id-35'/>
+    <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-4'/>
+    <pointer-type-def type-id='type-id-37' size-in-bits='64' id='type-id-5'/>
+    <pointer-type-def type-id='type-id-32' size-in-bits='64' id='type-id-38'/>
+    <pointer-type-def type-id='type-id-33' size-in-bits='64' id='type-id-39'/>
+    <pointer-type-def type-id='type-id-19' size-in-bits='64' id='type-id-40'/>
+    <pointer-type-def type-id='type-id-41' size-in-bits='64' id='type-id-6'/>
+    <pointer-type-def type-id='type-id-42' size-in-bits='64' id='type-id-7'/>
+    <pointer-type-def type-id='type-id-43' size-in-bits='64' id='type-id-8'/>
+    <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-44'/>
+    <pointer-type-def type-id='type-id-44' size-in-bits='64' id='type-id-45'/>
+    <pointer-type-def type-id='type-id-12' size-in-bits='64' id='type-id-46'/>
+    <pointer-type-def type-id='type-id-46' size-in-bits='64' id='type-id-47'/>
+    <pointer-type-def type-id='type-id-48' size-in-bits='64' id='type-id-9'/>
+    <pointer-type-def type-id='type-id-49' size-in-bits='64' id='type-id-10'/>
+    <pointer-type-def type-id='type-id-50' size-in-bits='64' id='type-id-11'/>
+    <var-decl name='efivarfs_ops' type-id='type-id-1' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='53' column='1'/>
+    <function-type size-in-bits='64' id='type-id-16'>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-48'>
+      <parameter type-id='type-id-45'/>
+      <parameter type-id='type-id-47'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-37'>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-31'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-43'>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-39'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-50'>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-42'>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-41'>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-38'/>
+      <parameter type-id='type-id-39'/>
+      <parameter type-id='type-id-40'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-49'>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-33'/>
+      <parameter type-id='type-id-19'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+    <function-type size-in-bits='64' id='type-id-36'>
+      <parameter type-id='type-id-17'/>
+      <parameter type-id='type-id-31'/>
+      <parameter type-id='type-id-32'/>
+      <parameter type-id='type-id-33'/>
+      <parameter type-id='type-id-19'/>
+      <parameter type-id='type-id-35'/>
+      <return type-id='type-id-15'/>
+    </function-type>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='guid-symbols.c' comp-dir-path='/home/pjones/devel/github.com/efivar/master/src' language='LANG_C99'>
+    <qualified-type-def type-id='type-id-17' const='yes' id='type-id-51'/>
+    <var-decl name='efi_guid_empty' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='4' column='1'/>
+    <var-decl name='efi_guid_zero' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='5' column='1'/>
+    <var-decl name='efi_guid_sha512' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='6' column='1'/>
+    <var-decl name='efi_guid_redhat' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='7' column='1'/>
+    <var-decl name='efi_guid_fwupdate' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='8' column='1'/>
+    <var-decl name='efi_guid_sha224' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='9' column='1'/>
+    <var-decl name='efi_guid_lenovo_boot_menu' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='10' column='1'/>
+    <var-decl name='efi_guid_ux_capsule' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='11' column='1'/>
+    <var-decl name='efi_guid_x509_sha256' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='12' column='1'/>
+    <var-decl name='efi_guid_rsa2048' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='13' column='1'/>
+    <var-decl name='efi_guid_lenovo' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='14' column='1'/>
+    <var-decl name='efi_guid_lenovo_diag' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='15' column='1'/>
+    <var-decl name='efi_guid_x509_sha512' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='16' column='1'/>
+    <var-decl name='efi_guid_external_management' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='17' column='1'/>
+    <var-decl name='efi_guid_pkcs7_cert' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='18' column='1'/>
+    <var-decl name='efi_guid_shim' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='19' column='1'/>
+    <var-decl name='efi_guid_lenovo_rescue' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='20' column='1'/>
+    <var-decl name='efi_guid_rsa2048_sha1' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='21' column='1'/>
+    <var-decl name='efi_guid_x509_sha384' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='22' column='1'/>
+    <var-decl name='efi_guid_lenovo_setup' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='23' column='1'/>
+    <var-decl name='efi_guid_microsoft' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='24' column='1'/>
+    <var-decl name='efi_guid_lenovo_2' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='25' column='1'/>
+    <var-decl name='efi_guid_sha1' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='26' column='1'/>
+    <var-decl name='efi_guid_lenovo_me_config' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='27' column='1'/>
+    <var-decl name='efi_guid_global' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='28' column='1'/>
+    <var-decl name='efi_guid_x509_cert' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='29' column='1'/>
+    <var-decl name='efi_guid_rsa2048_sha256_cert' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='30' column='1'/>
+    <var-decl name='efi_guid_lenovo_diag_splash' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='31' column='1'/>
+    <var-decl name='efi_guid_redhat_2' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='32' column='1'/>
+    <var-decl name='efi_guid_lenovo_msg' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='33' column='1'/>
+    <var-decl name='efi_guid_sha256' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='34' column='1'/>
+    <var-decl name='efi_guid_shell' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='35' column='1'/>
+    <var-decl name='efi_guid_security' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='36' column='1'/>
+    <var-decl name='efi_guid_rsa2048_sha256' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='37' column='1'/>
+    <var-decl name='efi_guid_sha384' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='38' column='1'/>
+    <var-decl name='efi_guid_lenovo_startup_interrupt' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='39' column='1'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='vars.c' comp-dir-path='/home/pjones/devel/github.com/efivar/master/src' language='LANG_C99'>
+    <var-decl name='vars_ops' type-id='type-id-1' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='52' column='1'/>
+  </abi-instr>
+  <abi-instr version='1.0' address-size='64' path='&lt;artificial&gt;' comp-dir-path='/home/pjones/devel/github.com/efivar/master/src' language='LANG_C99'>
+    <function-decl name='efi_variables_supported' mangled-name='efi_variables_supported' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='246' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variables_supported@@libefivar.so.0'>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <class-decl name='efi_variable' size-in-bits='320' is-struct='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='34' column='1' id='type-id-16'>
+    <function-decl name='efi_chmod_variable' mangled-name='efi_chmod_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='228' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_chmod_variable@@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='228' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='228' column='1'/>
+      <parameter type-id='type-id-35' name='mode' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='228' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='228' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='228' column='1'/>
+      <parameter type-id='type-id-35' name='mode' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='228' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_get_next_variable_name' mangled-name='efi_get_next_variable_name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='209' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_next_variable_name@@libefivar.so.0'>
+      <parameter type-id='type-id-45' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='209' column='1'/>
+      <parameter type-id='type-id-47' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='209' column='1'/>
+      <parameter type-id='type-id-45' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='209' column='1'/>
+      <parameter type-id='type-id-47' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='209' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_get_variable_size' mangled-name='efi_get_variable_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='190' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable_size@@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='190' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='190' column='1'/>
+      <parameter type-id='type-id-39' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='190' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='190' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='190' column='1'/>
+      <parameter type-id='type-id-39' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='190' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_get_variable_exists' mangled-name='efi_get_variable_exists' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable_exists@@LIBEFIVAR_1.35'>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='181' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='181' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_get_variable_attributes' mangled-name='efi_get_variable_attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='161' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable_attributes@@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='161' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='161' column='1'/>
+      <parameter type-id='type-id-40' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='162' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='161' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='161' column='1'/>
+      <parameter type-id='type-id-40' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='162' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_get_variable' mangled-name='efi_get_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable@@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='141' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='141' column='1'/>
+      <parameter type-id='type-id-38' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='141' column='1'/>
+      <parameter type-id='type-id-39' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='142' column='1'/>
+      <parameter type-id='type-id-40' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='142' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='141' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='141' column='1'/>
+      <parameter type-id='type-id-38' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='141' column='1'/>
+      <parameter type-id='type-id-39' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='142' column='1'/>
+      <parameter type-id='type-id-40' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='142' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_del_variable' mangled-name='efi_del_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_del_variable@@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='122' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='122' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='122' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='122' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_append_variable' mangled-name='efi_append_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='98' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_append_variable@@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='98' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='98' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='98' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='99' column='1'/>
+      <parameter type-id='type-id-19' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='99' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='_efi_set_variable_mode' mangled-name='efi_set_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='75' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_set_variable@@LIBEFIVAR_0.24'>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='75' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='75' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='75' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='76' column='1'/>
+      <parameter type-id='type-id-19' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='76' column='1'/>
+      <parameter type-id='type-id-35' name='mode' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='76' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='75' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='75' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='75' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='76' column='1'/>
+      <parameter type-id='type-id-19' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='76' column='1'/>
+      <parameter type-id='type-id-35' name='mode' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='76' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='_efi_set_variable_variadic' mangled-name='_efi_set_variable_variadic' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_efi_set_variable_variadic@@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
+      <parameter type-id='type-id-19' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
+      <parameter type-id='type-id-19' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='_efi_set_variable' mangled-name='_efi_set_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='47' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_efi_set_variable@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
+      <parameter type-id='type-id-19' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
+      <parameter type-id='type-id-19' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_name_to_guid' mangled-name='efi_name_to_guid' filepath='/usr/include/sys/stat.h' line='269' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_name_to_guid@@libefivar.so.0'>
+      <parameter type-id='type-id-31' name='name' filepath='/usr/include/sys/stat.h' line='269' column='1'/>
+      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='269' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <pointer-type-def type-id='type-id-51' size-in-bits='64' id='type-id-52'/>
+    <function-decl name='efi_guid_to_id_guid' mangled-name='efi_guid_to_id_guid' filepath='/usr/include/sys/stat.h' line='197' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_id_guid@@libefivar.so.0'>
+      <parameter type-id='type-id-52' name='guid' filepath='/usr/include/sys/stat.h' line='197' column='1'/>
+      <parameter type-id='type-id-47' name='sp' filepath='/usr/include/sys/stat.h' line='197' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_guid_to_symbol' mangled-name='efi_guid_to_symbol' filepath='/usr/include/sys/stat.h' line='181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_symbol@@libefivar.so.0'>
+      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
+      <parameter type-id='type-id-47' name='symbol' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
+      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
+      <parameter type-id='type-id-47' name='symbol' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_guid_to_name' mangled-name='efi_guid_to_name' filepath='/usr/include/sys/stat.h' line='164' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_name@@libefivar.so.0'>
+      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
+      <parameter type-id='type-id-47' name='symbol' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
+      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
+      <parameter type-id='type-id-47' name='symbol' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_guid_to_str' mangled-name='efi_guid_to_str' filepath='/usr/include/sys/stat.h' line='69' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_str@@libefivar.so.0'>
+      <parameter type-id='type-id-52' name='guid' filepath='/usr/include/sys/stat.h' line='69' column='1'/>
+      <parameter type-id='type-id-47' name='sp' filepath='/usr/include/sys/stat.h' line='69' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_str_to_guid' mangled-name='efi_str_to_guid' filepath='/usr/include/sys/stat.h' line='57' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_str_to_guid@@libefivar.so.0'>
+      <parameter type-id='type-id-31' name='s' filepath='/usr/include/sys/stat.h' line='57' column='1'/>
+      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='57' column='1'/>
+      <parameter type-id='type-id-31' name='s' filepath='/usr/include/sys/stat.h' line='57' column='1'/>
+      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='57' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_guid_is_zero' mangled-name='efi_guid_is_empty' filepath='/usr/include/sys/stat.h' line='43' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_is_empty@@libefivar.so.0'>
+      <parameter type-id='type-id-52' name='guid' filepath='/usr/include/sys/stat.h' line='43' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <function-decl name='efi_guid_cmp' mangled-name='efi_guid_cmp' filepath='/usr/include/sys/stat.h' line='35' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_cmp@@LIBEFIVAR_0.24'>
+      <parameter type-id='type-id-52' name='a' filepath='/usr/include/sys/stat.h' line='35' column='1'/>
+      <parameter type-id='type-id-52' name='b' filepath='/usr/include/sys/stat.h' line='35' column='1'/>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <class-decl name='efi_variable' size-in-bits='320' is-struct='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='34' column='1' id='type-id-53'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='attrs' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='35' column='1'/>
+        <var-decl name='attrs' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='35' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='guid' type-id='type-id-18' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='36' column='1'/>
+        <var-decl name='guid' type-id='type-id-44' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='36' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='name' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='37' column='1'/>
+        <var-decl name='name' type-id='type-id-46' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='37' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='data' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='38' column='1'/>
+        <var-decl name='data' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='38' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='data_size' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='39' column='1'/>
+        <var-decl name='data_size' type-id='type-id-33' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='39' column='1'/>
       </data-member>
     </class-decl>
-    <type-decl name='unsigned long int' size-in-bits='64' id='type-id-22'/>
-    <typedef-decl name='__uint64_t' type-id='type-id-22' filepath='/usr/include/bits/types.h' line='44' column='1' id='type-id-23'/>
-    <typedef-decl name='uint64_t' type-id='type-id-23' filepath='/usr/include/bits/stdint-uintn.h' line='27' column='1' id='type-id-17'/>
-    <typedef-decl name='efi_guid_t' type-id='type-id-3' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='39' column='1' id='type-id-2'/>
-    <pointer-type-def type-id='type-id-2' size-in-bits='64' id='type-id-18'/>
-    <type-decl name='char' size-in-bits='8' id='type-id-24'/>
-    <pointer-type-def type-id='type-id-24' size-in-bits='64' id='type-id-19'/>
-    <pointer-type-def type-id='type-id-13' size-in-bits='64' id='type-id-20'/>
-    <typedef-decl name='size_t' type-id='type-id-22' filepath='/usr/lib/gcc/x86_64-redhat-linux/7/include/stddef.h' line='216' column='1' id='type-id-21'/>
-    <typedef-decl name='efi_variable_t' type-id='type-id-16' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='133' column='1' id='type-id-25'/>
-    <pointer-type-def type-id='type-id-25' size-in-bits='64' id='type-id-26'/>
-    <pointer-type-def type-id='type-id-17' size-in-bits='64' id='type-id-27'/>
-    <function-decl name='efi_variable_get_attributes' mangled-name='efi_variable_get_attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='337' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_attributes@@libefivar.so.0'>
-      <parameter type-id='type-id-26' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='337' column='1'/>
-      <parameter type-id='type-id-27' name='attrs' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='337' column='1'/>
-      <return type-id='type-id-1'/>
+    <typedef-decl name='__uint64_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='44' column='1' id='type-id-55'/>
+    <typedef-decl name='uint64_t' type-id='type-id-55' filepath='/usr/include/bits/stdint-uintn.h' line='27' column='1' id='type-id-54'/>
+    <typedef-decl name='efi_variable_t' type-id='type-id-53' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='133' column='1' id='type-id-56'/>
+    <pointer-type-def type-id='type-id-56' size-in-bits='64' id='type-id-57'/>
+    <function-decl name='efi_variable_realize' mangled-name='efi_variable_realize' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='351' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_realize@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='351' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_variable_set_attributes' mangled-name='efi_variable_set_attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_attributes@@libefivar.so.0'>
-      <parameter type-id='type-id-26' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='328' column='1'/>
-      <parameter type-id='type-id-17' name='attrs' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='328' column='1'/>
-      <return type-id='type-id-1'/>
+    <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-58'/>
+    <function-decl name='efi_variable_get_attributes' mangled-name='efi_variable_get_attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='337' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_attributes@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='337' column='1'/>
+      <parameter type-id='type-id-58' name='attrs' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='337' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <type-decl name='long int' size-in-bits='64' id='type-id-28'/>
-    <typedef-decl name='__ssize_t' type-id='type-id-28' filepath='/usr/include/bits/types.h' line='181' column='1' id='type-id-29'/>
-    <typedef-decl name='ssize_t' type-id='type-id-29' filepath='/usr/include/sys/types.h' line='109' column='1' id='type-id-30'/>
-    <pointer-type-def type-id='type-id-20' size-in-bits='64' id='type-id-31'/>
-    <pointer-type-def type-id='type-id-21' size-in-bits='64' id='type-id-32'/>
-    <function-decl name='efi_variable_get_data' mangled-name='efi_variable_get_data' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='313' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_data@@libefivar.so.0'>
-      <parameter type-id='type-id-26' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='313' column='1'/>
-      <parameter type-id='type-id-31' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='313' column='1'/>
-      <parameter type-id='type-id-32' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='313' column='1'/>
-      <return type-id='type-id-30'/>
+    <function-decl name='efi_variable_get_guid' mangled-name='efi_variable_get_guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='284' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_guid@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='284' column='1'/>
+      <parameter type-id='type-id-45' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='284' column='1'/>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='284' column='1'/>
+      <parameter type-id='type-id-45' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='284' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_variable_set_data' mangled-name='efi_variable_set_data' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='298' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_data@@libefivar.so.0'>
-      <parameter type-id='type-id-26' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='298' column='1'/>
-      <parameter type-id='type-id-20' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='298' column='1'/>
-      <parameter type-id='type-id-21' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='298' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efi_variable_set_attributes' mangled-name='efi_variable_set_attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_attributes@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='328' column='1'/>
+      <parameter type-id='type-id-54' name='attrs' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='328' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-18' size-in-bits='64' id='type-id-33'/>
-    <function-decl name='efi_variable_get_guid' mangled-name='efi_variable_get_guid' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='284' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_guid@@libefivar.so.0'>
-      <parameter type-id='type-id-26' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='284' column='1'/>
-      <parameter type-id='type-id-33' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='284' column='1'/>
-      <return type-id='type-id-1'/>
+    <type-decl name='long int' size-in-bits='64' id='type-id-59'/>
+    <typedef-decl name='__ssize_t' type-id='type-id-59' filepath='/usr/include/bits/types.h' line='181' column='1' id='type-id-60'/>
+    <typedef-decl name='ssize_t' type-id='type-id-60' filepath='/usr/include/sys/types.h' line='109' column='1' id='type-id-61'/>
+    <function-decl name='efi_variable_get_data' mangled-name='efi_variable_get_data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='313' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_data@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='313' column='1'/>
+      <parameter type-id='type-id-38' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='313' column='1'/>
+      <parameter type-id='type-id-39' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='313' column='1'/>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='313' column='1'/>
+      <parameter type-id='type-id-38' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='313' column='1'/>
+      <parameter type-id='type-id-39' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='313' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_variable_set_guid' mangled-name='efi_variable_set_guid' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='275' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_guid@@libefivar.so.0'>
-      <parameter type-id='type-id-26' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='275' column='1'/>
-      <parameter type-id='type-id-18' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='275' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efi_variable_set_data' mangled-name='efi_variable_set_data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_data@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='298' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='298' column='1'/>
+      <parameter type-id='type-id-33' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='298' column='1'/>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='298' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='298' column='1'/>
+      <parameter type-id='type-id-33' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='298' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_variable_get_name' mangled-name='efi_variable_get_name' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='262' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_name@@libefivar.so.0'>
-      <parameter type-id='type-id-26' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='262' column='1'/>
-      <return type-id='type-id-19'/>
+    <function-decl name='efi_variable_set_guid' mangled-name='efi_variable_set_guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='275' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_guid@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='275' column='1'/>
+      <parameter type-id='type-id-44' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='275' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_variable_set_name' mangled-name='efi_variable_set_name' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='248' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_name@@libefivar.so.0'>
-      <parameter type-id='type-id-26' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='248' column='1'/>
-      <parameter type-id='type-id-19' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='248' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efi_variable_get_name' mangled-name='efi_variable_get_name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='262' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_name@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='262' column='1'/>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='262' column='1'/>
+      <return type-id='type-id-46'/>
     </function-decl>
-    <type-decl name='void' id='type-id-34'/>
-    <function-decl name='efi_variable_free' mangled-name='efi_variable_free' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='225' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_free@@libefivar.so.0'>
-      <parameter type-id='type-id-26' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='225' column='1'/>
-      <parameter type-id='type-id-1' name='free_data' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='225' column='1'/>
-      <return type-id='type-id-34'/>
+    <function-decl name='efi_variable_set_name' mangled-name='efi_variable_set_name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='248' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_name@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='248' column='1'/>
+      <parameter type-id='type-id-46' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='248' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_variable_export' mangled-name='efi_variable_export' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='153' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_export@@libefivar.so.0'>
-      <parameter type-id='type-id-26' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='153' column='1'/>
-      <parameter type-id='type-id-20' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='153' column='1'/>
-      <parameter type-id='type-id-21' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='153' column='1'/>
-      <return type-id='type-id-30'/>
+    <type-decl name='void' id='type-id-62'/>
+    <function-decl name='efi_variable_free' mangled-name='efi_variable_free' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='225' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_free@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='225' column='1'/>
+      <parameter type-id='type-id-15' name='free_data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='225' column='1'/>
+      <return type-id='type-id-62'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-26' size-in-bits='64' id='type-id-35'/>
-    <function-decl name='efi_variable_import' mangled-name='efi_variable_import' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='59' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_import@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='59' column='1'/>
-      <parameter type-id='type-id-21' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='59' column='1'/>
-      <parameter type-id='type-id-35' name='var_out' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='59' column='1'/>
-      <return type-id='type-id-30'/>
+    <function-decl name='efi_variable_export' mangled-name='efi_variable_export' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='153' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_export@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='153' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='153' column='1'/>
+      <parameter type-id='type-id-33' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='153' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_error_clear' mangled-name='efi_error_clear' filepath='/home/pjones/devel/github.com/efivar/master/src/error.c' line='142' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_error_clear@@LIBEFIVAR_1.30'>
-      <return type-id='type-id-34'/>
+    <pointer-type-def type-id='type-id-57' size-in-bits='64' id='type-id-63'/>
+    <function-decl name='efi_variable_import' mangled-name='efi_variable_import' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='59' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_import@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='59' column='1'/>
+      <parameter type-id='type-id-33' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='59' column='1'/>
+      <parameter type-id='type-id-63' name='var_out' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='59' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-24' const='yes' id='type-id-36'/>
-    <pointer-type-def type-id='type-id-36' size-in-bits='64' id='type-id-37'/>
-    <function-decl name='efi_error_set' mangled-name='efi_error_set' filepath='/home/pjones/devel/github.com/efivar/master/src/error.c' line='82' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_error_set@@LIBEFIVAR_1.30'>
-      <parameter type-id='type-id-37' name='filename' filepath='/home/pjones/devel/github.com/efivar/master/src/error.c' line='82' column='1'/>
-      <parameter type-id='type-id-37' name='function' filepath='/home/pjones/devel/github.com/efivar/master/src/error.c' line='83' column='1'/>
-      <parameter type-id='type-id-1' name='line' filepath='/home/pjones/devel/github.com/efivar/master/src/error.c' line='84' column='1'/>
-      <parameter type-id='type-id-1' name='error' filepath='/home/pjones/devel/github.com/efivar/master/src/error.c' line='85' column='1'/>
-      <parameter type-id='type-id-37' name='fmt' filepath='/home/pjones/devel/github.com/efivar/master/src/error.c' line='86' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efi_error_clear' mangled-name='efi_error_clear' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='142' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_error_clear@@LIBEFIVAR_1.30'>
+      <return type-id='type-id-62'/>
     </function-decl>
-    <typedef-decl name='__mode_t' type-id='type-id-7' filepath='/usr/include/bits/types.h' line='138' column='1' id='type-id-38'/>
-    <typedef-decl name='mode_t' type-id='type-id-38' filepath='/usr/include/fcntl.h' line='50' column='1' id='type-id-39'/>
-    <function-decl name='efi_chmod_variable' mangled-name='efi_chmod_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='228' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_chmod_variable@@libefivar.so.0'>
-      <parameter type-id='type-id-2' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='228' column='1'/>
-      <parameter type-id='type-id-37' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='228' column='1'/>
-      <parameter type-id='type-id-39' name='mode' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='228' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efi_error_set' mangled-name='efi_error_set' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='82' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_error_set@@LIBEFIVAR_1.30'>
+      <parameter type-id='type-id-31' name='filename' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='82' column='1'/>
+      <parameter type-id='type-id-31' name='function' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='83' column='1'/>
+      <parameter type-id='type-id-15' name='line' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='84' column='1'/>
+      <parameter type-id='type-id-15' name='error' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='85' column='1'/>
+      <parameter type-id='type-id-31' name='fmt' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='86' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-19' size-in-bits='64' id='type-id-40'/>
-    <function-decl name='efi_get_next_variable_name' mangled-name='efi_get_next_variable_name' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='209' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_next_variable_name@@libefivar.so.0'>
-      <parameter type-id='type-id-33' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='209' column='1'/>
-      <parameter type-id='type-id-40' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='209' column='1'/>
-      <return type-id='type-id-1'/>
+    <qualified-type-def type-id='type-id-47' const='yes' id='type-id-64'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-65'/>
+    <function-decl name='efi_error_get' mangled-name='efi_error_get' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='53' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_error_get@@LIBEFIVAR_1.30'>
+      <parameter type-id='type-id-22' name='n' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='53' column='1'/>
+      <parameter type-id='type-id-64' name='filename' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='54' column='1'/>
+      <parameter type-id='type-id-64' name='function' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='55' column='1'/>
+      <parameter type-id='type-id-65' name='line' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='56' column='1'/>
+      <parameter type-id='type-id-64' name='message' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='57' column='1'/>
+      <parameter type-id='type-id-65' name='error' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='58' column='1'/>
+      <parameter type-id='type-id-22' name='n' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='53' column='1'/>
+      <parameter type-id='type-id-64' name='filename' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='54' column='1'/>
+      <parameter type-id='type-id-64' name='function' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='55' column='1'/>
+      <parameter type-id='type-id-65' name='line' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='56' column='1'/>
+      <parameter type-id='type-id-64' name='message' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='57' column='1'/>
+      <parameter type-id='type-id-65' name='error' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='58' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_get_variable_size' mangled-name='efi_get_variable_size' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='190' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable_size@@libefivar.so.0'>
-      <parameter type-id='type-id-2' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='190' column='1'/>
-      <parameter type-id='type-id-37' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='190' column='1'/>
-      <parameter type-id='type-id-32' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='190' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_make_nvdimm' mangled-name='efidp_make_nvdimm' filepath='/usr/include/bits/byteswap.h' line='813' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_nvdimm@@LIBEFIVAR_1.33'>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='813' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='813' column='1'/>
+      <parameter type-id='type-id-44' name='uuid' filepath='/usr/include/bits/byteswap.h' line='813' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='813' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='813' column='1'/>
+      <parameter type-id='type-id-44' name='uuid' filepath='/usr/include/bits/byteswap.h' line='813' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-4' size-in-bits='64' id='type-id-41'/>
-    <function-decl name='efi_get_variable_attributes' mangled-name='efi_get_variable_attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='161' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable_attributes@@libefivar.so.0'>
-      <parameter type-id='type-id-2' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='161' column='1'/>
-      <parameter type-id='type-id-37' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='161' column='1'/>
-      <parameter type-id='type-id-41' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='162' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_make_sas' mangled-name='efidp_make_sas' filepath='/usr/include/bits/byteswap.h' line='787' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_sas@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='787' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='787' column='1'/>
+      <parameter type-id='type-id-54' name='sas_address' filepath='/usr/include/bits/byteswap.h' line='787' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='787' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='787' column='1'/>
+      <parameter type-id='type-id-54' name='sas_address' filepath='/usr/include/bits/byteswap.h' line='787' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_get_variable_exists' mangled-name='efi_get_variable_exists' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable_exists@@LIBEFIVAR_1.35'>
-      <parameter type-id='type-id-2' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='181' column='1'/>
-      <parameter type-id='type-id-37' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='181' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_make_atapi' mangled-name='efidp_make_atapi' filepath='/usr/include/bits/byteswap.h' line='763' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_atapi@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='763' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='763' column='1'/>
+      <parameter type-id='type-id-20' name='primary' filepath='/usr/include/bits/byteswap.h' line='763' column='1'/>
+      <parameter type-id='type-id-20' name='slave' filepath='/usr/include/bits/byteswap.h' line='764' column='1'/>
+      <parameter type-id='type-id-20' name='lun' filepath='/usr/include/bits/byteswap.h' line='764' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='763' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='763' column='1'/>
+      <parameter type-id='type-id-20' name='primary' filepath='/usr/include/bits/byteswap.h' line='763' column='1'/>
+      <parameter type-id='type-id-20' name='slave' filepath='/usr/include/bits/byteswap.h' line='764' column='1'/>
+      <parameter type-id='type-id-20' name='lun' filepath='/usr/include/bits/byteswap.h' line='764' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_get_variable' mangled-name='efi_get_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable@@libefivar.so.0'>
-      <parameter type-id='type-id-2' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='141' column='1'/>
-      <parameter type-id='type-id-37' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='141' column='1'/>
-      <parameter type-id='type-id-31' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='141' column='1'/>
-      <parameter type-id='type-id-32' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='142' column='1'/>
-      <parameter type-id='type-id-41' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='142' column='1'/>
-      <return type-id='type-id-1'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-66'/>
+    <typedef-decl name='__int16_t' type-id='type-id-66' filepath='/usr/include/bits/types.h' line='38' column='1' id='type-id-67'/>
+    <typedef-decl name='int16_t' type-id='type-id-67' filepath='/usr/include/bits/stdint-intn.h' line='25' column='1' id='type-id-68'/>
+    <function-decl name='efidp_make_sata' mangled-name='efidp_make_sata' filepath='/usr/include/bits/byteswap.h' line='740' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_sata@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='740' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='740' column='1'/>
+      <parameter type-id='type-id-20' name='hba_port' filepath='/usr/include/bits/byteswap.h' line='740' column='1'/>
+      <parameter type-id='type-id-68' name='port_multiplier_port' filepath='/usr/include/bits/byteswap.h' line='741' column='1'/>
+      <parameter type-id='type-id-20' name='lun' filepath='/usr/include/bits/byteswap.h' line='741' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='740' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='740' column='1'/>
+      <parameter type-id='type-id-20' name='hba_port' filepath='/usr/include/bits/byteswap.h' line='740' column='1'/>
+      <parameter type-id='type-id-68' name='port_multiplier_port' filepath='/usr/include/bits/byteswap.h' line='741' column='1'/>
+      <parameter type-id='type-id-20' name='lun' filepath='/usr/include/bits/byteswap.h' line='741' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_del_variable' mangled-name='efi_del_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_del_variable@@libefivar.so.0'>
-      <parameter type-id='type-id-2' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='122' column='1'/>
-      <parameter type-id='type-id-37' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='122' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_make_nvme' mangled-name='efidp_make_nvme' filepath='/usr/include/bits/byteswap.h' line='713' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_nvme@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='713' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='713' column='1'/>
+      <parameter type-id='type-id-19' name='namespace_id' filepath='/usr/include/bits/byteswap.h' line='713' column='1'/>
+      <parameter type-id='type-id-32' name='ieee_eui_64' filepath='/usr/include/bits/byteswap.h' line='714' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='713' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='713' column='1'/>
+      <parameter type-id='type-id-19' name='namespace_id' filepath='/usr/include/bits/byteswap.h' line='713' column='1'/>
+      <parameter type-id='type-id-32' name='ieee_eui_64' filepath='/usr/include/bits/byteswap.h' line='714' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_append_variable' mangled-name='efi_append_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='98' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_append_variable@@libefivar.so.0'>
-      <parameter type-id='type-id-2' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='98' column='1'/>
-      <parameter type-id='type-id-37' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='98' column='1'/>
-      <parameter type-id='type-id-20' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='98' column='1'/>
-      <parameter type-id='type-id-21' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='99' column='1'/>
-      <parameter type-id='type-id-4' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='99' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_make_scsi' mangled-name='efidp_make_scsi' filepath='/usr/include/bits/byteswap.h' line='694' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_scsi@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
+      <parameter type-id='type-id-20' name='target' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
+      <parameter type-id='type-id-20' name='lun' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
+      <parameter type-id='type-id-20' name='target' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
+      <parameter type-id='type-id-20' name='lun' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_variable_realize' mangled-name='efi_variable_realize' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='351' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_realize@@libefivar.so.0'>
-      <parameter type-id='type-id-26' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='351' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_make_ipv4' mangled-name='efidp_make_ipv4' filepath='/usr/include/bits/byteswap.h' line='664' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_ipv4@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='664' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='664' column='1'/>
+      <parameter type-id='type-id-19' name='local' filepath='/usr/include/bits/byteswap.h' line='664' column='1'/>
+      <parameter type-id='type-id-19' name='remote' filepath='/usr/include/bits/byteswap.h' line='664' column='1'/>
+      <parameter type-id='type-id-19' name='gateway' filepath='/usr/include/bits/byteswap.h' line='665' column='1'/>
+      <parameter type-id='type-id-19' name='netmask' filepath='/usr/include/bits/byteswap.h' line='665' column='1'/>
+      <parameter type-id='type-id-20' name='local_port' filepath='/usr/include/bits/byteswap.h' line='666' column='1'/>
+      <parameter type-id='type-id-20' name='remote_port' filepath='/usr/include/bits/byteswap.h' line='666' column='1'/>
+      <parameter type-id='type-id-20' name='protocol' filepath='/usr/include/bits/byteswap.h' line='667' column='1'/>
+      <parameter type-id='type-id-15' name='is_static' filepath='/usr/include/bits/byteswap.h' line='667' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='_efi_set_variable_variadic' mangled-name='_efi_set_variable_variadic' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='61' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_efi_set_variable_variadic@@libefivar.so.0'>
-      <parameter type-id='type-id-2' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='61' column='1'/>
-      <parameter type-id='type-id-37' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='61' column='1'/>
-      <parameter type-id='type-id-20' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='61' column='1'/>
-      <parameter type-id='type-id-21' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='62' column='1'/>
-      <parameter type-id='type-id-4' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='62' column='1'/>
-      <return type-id='type-id-1'/>
+    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-69'/>
+    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-70'/>
+    <qualified-type-def type-id='type-id-70' const='yes' id='type-id-71'/>
+    <function-decl name='efidp_make_mac_addr' mangled-name='efidp_make_mac_addr' filepath='/usr/include/bits/byteswap.h' line='642' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_mac_addr@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='642' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='642' column='1'/>
+      <parameter type-id='type-id-28' name='if_type' filepath='/usr/include/bits/byteswap.h' line='642' column='1'/>
+      <parameter type-id='type-id-71' name='mac_addr' filepath='/usr/include/bits/byteswap.h' line='643' column='1'/>
+      <parameter type-id='type-id-61' name='mac_addr_size' filepath='/usr/include/bits/byteswap.h' line='643' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='642' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='642' column='1'/>
+      <parameter type-id='type-id-28' name='if_type' filepath='/usr/include/bits/byteswap.h' line='642' column='1'/>
+      <parameter type-id='type-id-71' name='mac_addr' filepath='/usr/include/bits/byteswap.h' line='643' column='1'/>
+      <parameter type-id='type-id-61' name='mac_addr_size' filepath='/usr/include/bits/byteswap.h' line='643' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='_efi_set_variable' mangled-name='_efi_set_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='47' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_efi_set_variable@libefivar.so.0'>
-      <parameter type-id='type-id-2' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='61' column='1'/>
-      <parameter type-id='type-id-37' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='61' column='1'/>
-      <parameter type-id='type-id-20' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='61' column='1'/>
-      <parameter type-id='type-id-21' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='62' column='1'/>
-      <parameter type-id='type-id-4' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='62' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_make_hd' mangled-name='efidp_make_hd' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_hd@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
+      <parameter type-id='type-id-19' name='num' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
+      <parameter type-id='type-id-54' name='part_start' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
+      <parameter type-id='type-id-54' name='part_size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='180' column='1'/>
+      <parameter type-id='type-id-32' name='signature' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='180' column='1'/>
+      <parameter type-id='type-id-28' name='format' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='180' column='1'/>
+      <parameter type-id='type-id-28' name='signature_type' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='181' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
+      <parameter type-id='type-id-19' name='num' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
+      <parameter type-id='type-id-54' name='part_start' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
+      <parameter type-id='type-id-54' name='part_size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='180' column='1'/>
+      <parameter type-id='type-id-32' name='signature' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='180' column='1'/>
+      <parameter type-id='type-id-28' name='format' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='180' column='1'/>
+      <parameter type-id='type-id-28' name='signature_type' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='181' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_guid_to_id_guid' mangled-name='efi_guid_to_id_guid' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='197' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_id_guid@@libefivar.so.0'>
-      <parameter type-id='type-id-15' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='197' column='1'/>
-      <parameter type-id='type-id-40' name='sp' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='197' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_make_file' mangled-name='efidp_make_file' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_file@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='157' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='157' column='1'/>
+      <parameter type-id='type-id-46' name='filepath' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='157' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='157' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='157' column='1'/>
+      <parameter type-id='type-id-46' name='filepath' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='157' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_guid_to_symbol' mangled-name='efi_guid_to_symbol' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_symbol@@libefivar.so.0'>
-      <parameter type-id='type-id-18' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='181' column='1'/>
-      <parameter type-id='type-id-40' name='symbol' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='181' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_make_edd10' mangled-name='efidp_make_edd10' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_edd10@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
+      <parameter type-id='type-id-19' name='hardware_device' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
+      <parameter type-id='type-id-19' name='hardware_device' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_guid_to_str' mangled-name='efi_guid_to_str' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='69' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_str@@libefivar.so.0'>
-      <parameter type-id='type-id-15' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='69' column='1'/>
-      <parameter type-id='type-id-40' name='sp' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='69' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_make_pci' mangled-name='efidp_make_pci' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_pci@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
+      <parameter type-id='type-id-28' name='device' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
+      <parameter type-id='type-id-28' name='function' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
+      <parameter type-id='type-id-28' name='device' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
+      <parameter type-id='type-id-28' name='function' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_guid_to_name' mangled-name='efi_guid_to_name' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='164' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_name@@libefivar.so.0'>
-      <parameter type-id='type-id-18' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='181' column='1'/>
-      <parameter type-id='type-id-40' name='symbol' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='181' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_make_acpi_hid_ex' mangled-name='efidp_make_acpi_hid_ex' filepath='/usr/include/sys/stat.h' line='239' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_acpi_hid_ex@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/sys/stat.h' line='239' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/sys/stat.h' line='239' column='1'/>
+      <parameter type-id='type-id-19' name='hid' filepath='/usr/include/sys/stat.h' line='240' column='1'/>
+      <parameter type-id='type-id-19' name='uid' filepath='/usr/include/sys/stat.h' line='240' column='1'/>
+      <parameter type-id='type-id-19' name='cid' filepath='/usr/include/sys/stat.h' line='240' column='1'/>
+      <parameter type-id='type-id-46' name='hidstr' filepath='/usr/include/sys/stat.h' line='241' column='1'/>
+      <parameter type-id='type-id-46' name='uidstr' filepath='/usr/include/sys/stat.h' line='241' column='1'/>
+      <parameter type-id='type-id-46' name='cidstr' filepath='/usr/include/sys/stat.h' line='241' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_str_to_guid' mangled-name='efi_str_to_guid' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='57' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_str_to_guid@@libefivar.so.0'>
-      <parameter type-id='type-id-37' name='s' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='57' column='1'/>
-      <parameter type-id='type-id-18' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='57' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_make_acpi_hid' mangled-name='efidp_make_acpi_hid' filepath='/usr/include/sys/stat.h' line='217' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_acpi_hid@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
+      <parameter type-id='type-id-19' name='hid' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
+      <parameter type-id='type-id-19' name='uid' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
+      <parameter type-id='type-id-19' name='hid' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
+      <parameter type-id='type-id-19' name='uid' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_name_to_guid' mangled-name='efi_name_to_guid' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='269' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_name_to_guid@@libefivar.so.0'>
-      <parameter type-id='type-id-37' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='269' column='1'/>
-      <parameter type-id='type-id-18' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='269' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_make_generic' mangled-name='efidp_make_generic' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_generic@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
+      <parameter type-id='type-id-28' name='type' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
+      <parameter type-id='type-id-28' name='subtype' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
+      <parameter type-id='type-id-61' name='total_size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='452' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
+      <parameter type-id='type-id-28' name='type' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
+      <parameter type-id='type-id-28' name='subtype' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
+      <parameter type-id='type-id-61' name='total_size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='452' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-40' const='yes' id='type-id-42'/>
-    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-43'/>
-    <function-decl name='efi_error_get' mangled-name='efi_error_get' filepath='/home/pjones/devel/github.com/efivar/master/src/error.c' line='53' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_error_get@@LIBEFIVAR_1.30'>
-      <parameter type-id='type-id-7' name='n' filepath='/home/pjones/devel/github.com/efivar/master/src/error.c' line='53' column='1'/>
-      <parameter type-id='type-id-42' name='filename' filepath='/home/pjones/devel/github.com/efivar/master/src/error.c' line='54' column='1'/>
-      <parameter type-id='type-id-42' name='function' filepath='/home/pjones/devel/github.com/efivar/master/src/error.c' line='55' column='1'/>
-      <parameter type-id='type-id-43' name='line' filepath='/home/pjones/devel/github.com/efivar/master/src/error.c' line='56' column='1'/>
-      <parameter type-id='type-id-42' name='message' filepath='/home/pjones/devel/github.com/efivar/master/src/error.c' line='57' column='1'/>
-      <parameter type-id='type-id-43' name='error' filepath='/home/pjones/devel/github.com/efivar/master/src/error.c' line='58' column='1'/>
-      <return type-id='type-id-1'/>
+    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-72'/>
+    <function-decl name='efidp_make_vendor' mangled-name='efidp_make_vendor' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_vendor@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='434' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='434' column='1'/>
+      <parameter type-id='type-id-28' name='type' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='434' column='1'/>
+      <parameter type-id='type-id-28' name='subtype' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='434' column='1'/>
+      <parameter type-id='type-id-17' name='vendor_guid' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='435' column='1'/>
+      <parameter type-id='type-id-72' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='435' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='435' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_make_generic' mangled-name='efidp_make_generic' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='451' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_generic@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='451' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='451' column='1'/>
-      <parameter type-id='type-id-13' name='type' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='451' column='1'/>
-      <parameter type-id='type-id-13' name='subtype' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='451' column='1'/>
-      <parameter type-id='type-id-30' name='total_size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='452' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <function-decl name='efidp_make_nvdimm' mangled-name='efidp_make_nvdimm' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='813' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_nvdimm@@LIBEFIVAR_1.33'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='813' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='813' column='1'/>
-      <parameter type-id='type-id-18' name='uuid' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='813' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <function-decl name='efidp_make_sas' mangled-name='efidp_make_sas' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='787' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_sas@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='787' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='787' column='1'/>
-      <parameter type-id='type-id-17' name='sas_address' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='787' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <function-decl name='efidp_make_atapi' mangled-name='efidp_make_atapi' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='763' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_atapi@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='763' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='763' column='1'/>
-      <parameter type-id='type-id-5' name='primary' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='763' column='1'/>
-      <parameter type-id='type-id-5' name='slave' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='764' column='1'/>
-      <parameter type-id='type-id-5' name='lun' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='764' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <type-decl name='short int' size-in-bits='16' id='type-id-44'/>
-    <typedef-decl name='__int16_t' type-id='type-id-44' filepath='/usr/include/bits/types.h' line='38' column='1' id='type-id-45'/>
-    <typedef-decl name='int16_t' type-id='type-id-45' filepath='/usr/include/bits/stdint-intn.h' line='25' column='1' id='type-id-46'/>
-    <function-decl name='efidp_make_sata' mangled-name='efidp_make_sata' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='740' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_sata@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='740' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='740' column='1'/>
-      <parameter type-id='type-id-5' name='hba_port' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='740' column='1'/>
-      <parameter type-id='type-id-46' name='port_multiplier_port' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='741' column='1'/>
-      <parameter type-id='type-id-5' name='lun' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='741' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <function-decl name='efidp_make_nvme' mangled-name='efidp_make_nvme' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='713' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_nvme@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='713' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='713' column='1'/>
-      <parameter type-id='type-id-4' name='namespace_id' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='713' column='1'/>
-      <parameter type-id='type-id-20' name='ieee_eui_64' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='714' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <function-decl name='efidp_make_scsi' mangled-name='efidp_make_scsi' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='694' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_scsi@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='694' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='694' column='1'/>
-      <parameter type-id='type-id-5' name='target' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='694' column='1'/>
-      <parameter type-id='type-id-5' name='lun' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='694' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <function-decl name='efidp_make_ipv4' mangled-name='efidp_make_ipv4' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='664' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_ipv4@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='664' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='664' column='1'/>
-      <parameter type-id='type-id-4' name='local' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='664' column='1'/>
-      <parameter type-id='type-id-4' name='remote' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='664' column='1'/>
-      <parameter type-id='type-id-4' name='gateway' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='665' column='1'/>
-      <parameter type-id='type-id-4' name='netmask' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='665' column='1'/>
-      <parameter type-id='type-id-5' name='local_port' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='666' column='1'/>
-      <parameter type-id='type-id-5' name='remote_port' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='666' column='1'/>
-      <parameter type-id='type-id-5' name='protocol' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='667' column='1'/>
-      <parameter type-id='type-id-1' name='is_static' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='667' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <qualified-type-def type-id='type-id-13' const='yes' id='type-id-47'/>
-    <pointer-type-def type-id='type-id-47' size-in-bits='64' id='type-id-48'/>
-    <qualified-type-def type-id='type-id-48' const='yes' id='type-id-49'/>
-    <function-decl name='efidp_make_mac_addr' mangled-name='efidp_make_mac_addr' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='642' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_mac_addr@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='642' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='642' column='1'/>
-      <parameter type-id='type-id-13' name='if_type' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='642' column='1'/>
-      <parameter type-id='type-id-49' name='mac_addr' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='643' column='1'/>
-      <parameter type-id='type-id-30' name='mac_addr_size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-message.c' line='643' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <function-decl name='efidp_make_hd' mangled-name='efidp_make_hd' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='179' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_hd@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='179' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='179' column='1'/>
-      <parameter type-id='type-id-4' name='num' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='179' column='1'/>
-      <parameter type-id='type-id-17' name='part_start' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='179' column='1'/>
-      <parameter type-id='type-id-17' name='part_size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='180' column='1'/>
-      <parameter type-id='type-id-20' name='signature' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='180' column='1'/>
-      <parameter type-id='type-id-13' name='format' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='180' column='1'/>
-      <parameter type-id='type-id-13' name='signature_type' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='181' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <function-decl name='efidp_make_file' mangled-name='efidp_make_file' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_file@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='157' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='157' column='1'/>
-      <parameter type-id='type-id-19' name='filepath' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='157' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <function-decl name='efidp_make_edd10' mangled-name='efidp_make_edd10' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-hw.c' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_edd10@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-hw.c' line='106' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-hw.c' line='106' column='1'/>
-      <parameter type-id='type-id-4' name='hardware_device' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-hw.c' line='106' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <function-decl name='efidp_make_pci' mangled-name='efidp_make_pci' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-hw.c' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_pci@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-hw.c' line='86' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-hw.c' line='86' column='1'/>
-      <parameter type-id='type-id-13' name='device' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-hw.c' line='86' column='1'/>
-      <parameter type-id='type-id-13' name='function' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-hw.c' line='86' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <function-decl name='efidp_make_acpi_hid_ex' mangled-name='efidp_make_acpi_hid_ex' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-acpi.c' line='239' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_acpi_hid_ex@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-acpi.c' line='239' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-acpi.c' line='239' column='1'/>
-      <parameter type-id='type-id-4' name='hid' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-acpi.c' line='240' column='1'/>
-      <parameter type-id='type-id-4' name='uid' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-acpi.c' line='240' column='1'/>
-      <parameter type-id='type-id-4' name='cid' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-acpi.c' line='240' column='1'/>
-      <parameter type-id='type-id-19' name='hidstr' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-acpi.c' line='241' column='1'/>
-      <parameter type-id='type-id-19' name='uidstr' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-acpi.c' line='241' column='1'/>
-      <parameter type-id='type-id-19' name='cidstr' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-acpi.c' line='241' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <function-decl name='efidp_make_acpi_hid' mangled-name='efidp_make_acpi_hid' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-acpi.c' line='217' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_acpi_hid@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-acpi.c' line='217' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-acpi.c' line='217' column='1'/>
-      <parameter type-id='type-id-4' name='hid' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-acpi.c' line='217' column='1'/>
-      <parameter type-id='type-id-4' name='uid' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-acpi.c' line='217' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <pointer-type-def type-id='type-id-34' size-in-bits='64' id='type-id-50'/>
-    <function-decl name='efidp_make_vendor' mangled-name='efidp_make_vendor' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_vendor@@libefivar.so.0'>
-      <parameter type-id='type-id-20' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='434' column='1'/>
-      <parameter type-id='type-id-30' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='434' column='1'/>
-      <parameter type-id='type-id-13' name='type' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='434' column='1'/>
-      <parameter type-id='type-id-13' name='subtype' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='434' column='1'/>
-      <parameter type-id='type-id-2' name='vendor_guid' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='435' column='1'/>
-      <parameter type-id='type-id-50' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='435' column='1'/>
-      <parameter type-id='type-id-21' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='435' column='1'/>
-      <return type-id='type-id-30'/>
-    </function-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='832' column='1' id='type-id-51'>
+    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='832' column='1' id='type-id-73'>
       <data-member access='private'>
-        <var-decl name='' type-id='type-id-52' visibility='default'/>
+        <var-decl name='' type-id='type-id-74' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='838' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='838' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='pci' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='839' column='1'/>
+        <var-decl name='pci' type-id='type-id-76' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='839' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='pccard' type-id='type-id-55' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='840' column='1'/>
+        <var-decl name='pccard' type-id='type-id-77' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='840' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='mmio' type-id='type-id-56' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='841' column='1'/>
+        <var-decl name='mmio' type-id='type-id-78' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='841' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='hw_vendor' type-id='type-id-57' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='842' column='1'/>
+        <var-decl name='hw_vendor' type-id='type-id-79' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='842' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='controller' type-id='type-id-58' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='843' column='1'/>
+        <var-decl name='controller' type-id='type-id-80' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='843' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='bmc' type-id='type-id-59' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='844' column='1'/>
+        <var-decl name='bmc' type-id='type-id-81' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='844' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='acpi_hid' type-id='type-id-60' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='845' column='1'/>
+        <var-decl name='acpi_hid' type-id='type-id-82' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='845' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='acpi_hid_ex' type-id='type-id-61' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='846' column='1'/>
+        <var-decl name='acpi_hid_ex' type-id='type-id-83' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='846' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='acpi_adr' type-id='type-id-62' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='847' column='1'/>
+        <var-decl name='acpi_adr' type-id='type-id-84' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='847' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='atapi' type-id='type-id-63' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='848' column='1'/>
+        <var-decl name='atapi' type-id='type-id-85' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='848' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='scsi' type-id='type-id-64' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='849' column='1'/>
+        <var-decl name='scsi' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='849' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='fc' type-id='type-id-65' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='850' column='1'/>
+        <var-decl name='fc' type-id='type-id-87' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='850' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='fcex' type-id='type-id-66' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='851' column='1'/>
+        <var-decl name='fcex' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='851' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='firewire' type-id='type-id-67' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='852' column='1'/>
+        <var-decl name='firewire' type-id='type-id-89' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='852' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='usb' type-id='type-id-68' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='853' column='1'/>
+        <var-decl name='usb' type-id='type-id-90' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='853' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='usb_class' type-id='type-id-69' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='854' column='1'/>
+        <var-decl name='usb_class' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='854' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='usb_wwid' type-id='type-id-70' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='855' column='1'/>
+        <var-decl name='usb_wwid' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='855' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='lun' type-id='type-id-71' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='856' column='1'/>
+        <var-decl name='lun' type-id='type-id-93' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='856' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sata' type-id='type-id-72' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='857' column='1'/>
+        <var-decl name='sata' type-id='type-id-94' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='857' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='i2o' type-id='type-id-73' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='858' column='1'/>
+        <var-decl name='i2o' type-id='type-id-95' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='858' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='mac_addr' type-id='type-id-74' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='859' column='1'/>
+        <var-decl name='mac_addr' type-id='type-id-96' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='859' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='ipv4_addr' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='860' column='1'/>
+        <var-decl name='ipv4_addr' type-id='type-id-97' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='860' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='ipv6_addr' type-id='type-id-76' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='861' column='1'/>
+        <var-decl name='ipv6_addr' type-id='type-id-98' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='861' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='vlan' type-id='type-id-77' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='862' column='1'/>
+        <var-decl name='vlan' type-id='type-id-99' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='862' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='infiniband' type-id='type-id-78' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='863' column='1'/>
+        <var-decl name='infiniband' type-id='type-id-100' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='863' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='uart' type-id='type-id-79' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='864' column='1'/>
+        <var-decl name='uart' type-id='type-id-101' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='864' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='msg_vendor' type-id='type-id-80' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='865' column='1'/>
+        <var-decl name='msg_vendor' type-id='type-id-102' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='865' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='uart_flow_control' type-id='type-id-81' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='866' column='1'/>
+        <var-decl name='uart_flow_control' type-id='type-id-103' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='866' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sas' type-id='type-id-82' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='867' column='1'/>
+        <var-decl name='sas' type-id='type-id-104' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='867' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sas_ex' type-id='type-id-83' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='868' column='1'/>
+        <var-decl name='sas_ex' type-id='type-id-105' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='868' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='iscsi' type-id='type-id-84' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='869' column='1'/>
+        <var-decl name='iscsi' type-id='type-id-106' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='869' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='nvme' type-id='type-id-85' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='870' column='1'/>
+        <var-decl name='nvme' type-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='870' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='uri' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='871' column='1'/>
+        <var-decl name='uri' type-id='type-id-108' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='871' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='ufs' type-id='type-id-87' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='872' column='1'/>
+        <var-decl name='ufs' type-id='type-id-109' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='872' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sd' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='873' column='1'/>
+        <var-decl name='sd' type-id='type-id-110' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='873' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='bt' type-id='type-id-89' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='874' column='1'/>
+        <var-decl name='bt' type-id='type-id-111' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='874' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='wifi' type-id='type-id-90' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='875' column='1'/>
+        <var-decl name='wifi' type-id='type-id-112' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='875' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='emmc' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='876' column='1'/>
+        <var-decl name='emmc' type-id='type-id-113' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='876' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='btle' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='877' column='1'/>
+        <var-decl name='btle' type-id='type-id-114' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='877' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='dns' type-id='type-id-93' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='878' column='1'/>
+        <var-decl name='dns' type-id='type-id-115' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='878' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='nvdimm' type-id='type-id-94' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='879' column='1'/>
+        <var-decl name='nvdimm' type-id='type-id-116' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='879' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='hd' type-id='type-id-95' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='880' column='1'/>
+        <var-decl name='hd' type-id='type-id-117' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='880' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='cdrom' type-id='type-id-96' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='881' column='1'/>
+        <var-decl name='cdrom' type-id='type-id-118' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='881' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='media_vendor' type-id='type-id-97' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='882' column='1'/>
+        <var-decl name='media_vendor' type-id='type-id-119' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='882' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='file' type-id='type-id-98' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='883' column='1'/>
+        <var-decl name='file' type-id='type-id-120' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='883' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='protocol' type-id='type-id-99' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='884' column='1'/>
+        <var-decl name='protocol' type-id='type-id-121' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='884' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='firmware_file' type-id='type-id-100' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='885' column='1'/>
+        <var-decl name='firmware_file' type-id='type-id-122' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='885' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='firmware_volume' type-id='type-id-101' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='886' column='1'/>
+        <var-decl name='firmware_volume' type-id='type-id-123' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='886' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='relative_offset' type-id='type-id-102' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='887' column='1'/>
+        <var-decl name='relative_offset' type-id='type-id-124' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='887' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='ramdisk' type-id='type-id-103' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='888' column='1'/>
+        <var-decl name='ramdisk' type-id='type-id-125' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='888' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='bios_boot' type-id='type-id-104' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='889' column='1'/>
+        <var-decl name='bios_boot' type-id='type-id-126' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='889' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='833' column='1' id='type-id-52'>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='833' column='1' id='type-id-74'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='type' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='834' column='1'/>
+        <var-decl name='type' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='834' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8'>
-        <var-decl name='subtype' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='835' column='1'/>
+        <var-decl name='subtype' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='835' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='length' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='836' column='1'/>
+        <var-decl name='length' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='836' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='36' column='1' id='type-id-105'>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='36' column='1' id='type-id-127'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='type' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='37' column='1'/>
+        <var-decl name='type' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='37' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8'>
-        <var-decl name='subtype' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='38' column='1'/>
+        <var-decl name='subtype' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='38' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='length' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='39' column='1'/>
+        <var-decl name='length' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='39' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_header' type-id='type-id-105' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='40' column='1' id='type-id-53'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='55' column='1' id='type-id-106'>
+    <typedef-decl name='efidp_header' type-id='type-id-127' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='40' column='1' id='type-id-75'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-76' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='55' column='1' id='type-id-128'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='56' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='56' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='function' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='57' column='1'/>
+        <var-decl name='function' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='57' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='device' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='58' column='1'/>
+        <var-decl name='device' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='58' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_pci' type-id='type-id-106' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='59' column='1' id='type-id-54'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-55' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='64' column='1' id='type-id-107'>
+    <typedef-decl name='efidp_pci' type-id='type-id-128' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='59' column='1' id='type-id-76'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-77' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='64' column='1' id='type-id-129'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='65' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='65' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='function' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='66' column='1'/>
+        <var-decl name='function' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='66' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_pccard' type-id='type-id-107' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='67' column='1' id='type-id-55'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-56' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='70' column='1' id='type-id-108'>
+    <typedef-decl name='efidp_pccard' type-id='type-id-129' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='67' column='1' id='type-id-77'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-78' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='70' column='1' id='type-id-130'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='71' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='71' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='memory_type' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='72' column='1'/>
+        <var-decl name='memory_type' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='starting_address' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='73' column='1'/>
+        <var-decl name='starting_address' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='73' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='ending_address' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='74' column='1'/>
+        <var-decl name='ending_address' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='74' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_mmio' type-id='type-id-108' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='75' column='1' id='type-id-56'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-57' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='750' column='1' id='type-id-109'>
+    <typedef-decl name='efidp_mmio' type-id='type-id-130' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='75' column='1' id='type-id-78'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-79' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='78' column='1' id='type-id-131'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='751' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='79' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-2' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='752' column='1'/>
+        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='80' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='vendor_data' type-id='type-id-110' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='753' column='1'/>
+        <var-decl name='vendor_data' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='81' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='0' type-id='type-id-13' size-in-bits='infinite' id='type-id-110'/>
-    <typedef-decl name='efidp_hw_vendor' type-id='type-id-109' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='82' column='1' id='type-id-57'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-58' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='99' column='1' id='type-id-111'>
+
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='8' id='type-id-132'>
+      <subrange length='1' type-id='type-id-13' id='type-id-133'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_hw_vendor' type-id='type-id-131' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='82' column='1' id='type-id-79'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-80' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='99' column='1' id='type-id-134'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='100' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='controller' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='101' column='1'/>
+        <var-decl name='controller' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='101' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_controller' type-id='type-id-111' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='102' column='1' id='type-id-58'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='104' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-59' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='105' column='1' id='type-id-112'>
+    <typedef-decl name='efidp_controller' type-id='type-id-134' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='102' column='1' id='type-id-80'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='104' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-81' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='105' column='1' id='type-id-135'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='interface_type' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='107' column='1'/>
+        <var-decl name='interface_type' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='107' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='base_addr' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='108' column='1'/>
+        <var-decl name='base_addr' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='108' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_bmc' type-id='type-id-112' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='109' column='1' id='type-id-59'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='96' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-60' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='119' column='1' id='type-id-113'>
+    <typedef-decl name='efidp_bmc' type-id='type-id-135' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='109' column='1' id='type-id-81'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='96' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-82' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='119' column='1' id='type-id-136'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='120' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='hid' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='121' column='1'/>
+        <var-decl name='hid' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='uid' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='122' column='1'/>
+        <var-decl name='uid' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='122' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_acpi_hid' type-id='type-id-113' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='123' column='1' id='type-id-60'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-61' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='128' column='1' id='type-id-114'>
+    <typedef-decl name='efidp_acpi_hid' type-id='type-id-136' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='123' column='1' id='type-id-82'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-83' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='128' column='1' id='type-id-137'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='129' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='129' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='hid' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='130' column='1'/>
+        <var-decl name='hid' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='130' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='uid' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='131' column='1'/>
+        <var-decl name='uid' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='131' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='cid' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='132' column='1'/>
+        <var-decl name='cid' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='132' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='hidstr' type-id='type-id-115' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='134' column='1'/>
+        <var-decl name='hidstr' type-id='type-id-138' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='134' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='0' type-id='type-id-24' size-in-bits='infinite' id='type-id-115'/>
-    <typedef-decl name='efidp_acpi_hid_ex' type-id='type-id-114' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='135' column='1' id='type-id-61'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-62' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='165' column='1' id='type-id-116'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='166' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='adr' type-id='type-id-117' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='167' column='1'/>
-      </data-member>
-    </class-decl>
-    <array-type-def dimensions='0' type-id='type-id-4' size-in-bits='infinite' id='type-id-117'/>
-    <typedef-decl name='efidp_acpi_adr' type-id='type-id-116' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='168' column='1' id='type-id-62'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-63' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='326' column='1' id='type-id-118'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='327' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='primary' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='328' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='slave' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='329' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='lun' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='330' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_atapi' type-id='type-id-118' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='331' column='1' id='type-id-63'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-64' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='336' column='1' id='type-id-119'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='337' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='target' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='338' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='lun' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='339' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_scsi' type-id='type-id-119' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='340' column='1' id='type-id-64'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-65' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='345' column='1' id='type-id-120'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='346' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='347' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='wwn' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='348' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='lun' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='349' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_fc' type-id='type-id-120' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='350' column='1' id='type-id-65'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-66' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='353' column='1' id='type-id-121'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='354' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='355' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='wwn' type-id='type-id-122' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='356' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='lun' type-id='type-id-122' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='357' column='1'/>
-      </data-member>
-    </class-decl>
-    <array-type-def dimensions='1' type-id='type-id-13' size-in-bits='64' id='type-id-122'>
-      <subrange length='8'/>
+
+    <array-type-def dimensions='1' type-id='type-id-12' size-in-bits='8' id='type-id-138'>
+      <subrange length='1' type-id='type-id-13' id='type-id-133'/>
+
     </array-type-def>
-    <typedef-decl name='efidp_fcex' type-id='type-id-121' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='358' column='1' id='type-id-66'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-67' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='361' column='1' id='type-id-123'>
+    <typedef-decl name='efidp_acpi_hid_ex' type-id='type-id-137' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='135' column='1' id='type-id-83'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-84' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='165' column='1' id='type-id-139'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='362' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='166' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='363' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='364' column='1'/>
+        <var-decl name='adr' type-id='type-id-140' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='167' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_1394' type-id='type-id-123' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='365' column='1' id='type-id-67'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-68' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='368' column='1' id='type-id-124'>
+
+    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='32' id='type-id-140'>
+      <subrange length='1' type-id='type-id-13' id='type-id-133'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_acpi_adr' type-id='type-id-139' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='168' column='1' id='type-id-84'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-85' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='326' column='1' id='type-id-141'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='369' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='327' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='parent_port' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='370' column='1'/>
+        <var-decl name='primary' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='328' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='interface' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='371' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_usb' type-id='type-id-124' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='372' column='1' id='type-id-68'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-69' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='375' column='1' id='type-id-125'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='376' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_id' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='377' column='1'/>
+        <var-decl name='slave' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='329' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='product_id' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='378' column='1'/>
+        <var-decl name='lun' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='330' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_atapi' type-id='type-id-141' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='331' column='1' id='type-id-85'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='336' column='1' id='type-id-142'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='337' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='target' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='338' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='lun' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='339' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_scsi' type-id='type-id-142' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='340' column='1' id='type-id-86'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-87' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='345' column='1' id='type-id-143'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='346' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='347' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='device_class' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='379' column='1'/>
+        <var-decl name='wwn' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='348' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lun' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='349' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_fc' type-id='type-id-143' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='350' column='1' id='type-id-87'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='353' column='1' id='type-id-144'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='354' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='355' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='wwn' type-id='type-id-145' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='356' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='lun' type-id='type-id-145' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='357' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='64' id='type-id-145'>
+      <subrange length='8' type-id='type-id-13' id='type-id-146'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_fcex' type-id='type-id-144' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='358' column='1' id='type-id-88'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-89' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='361' column='1' id='type-id-147'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='362' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='363' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='guid' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='364' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_1394' type-id='type-id-147' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='365' column='1' id='type-id-89'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-90' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='368' column='1' id='type-id-148'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='369' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='parent_port' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='370' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='40'>
+        <var-decl name='interface' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='371' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_usb' type-id='type-id-148' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='372' column='1' id='type-id-90'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='375' column='1' id='type-id-149'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='376' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='vendor_id' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='377' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='product_id' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='378' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='device_class' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='379' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='72'>
-        <var-decl name='device_subclass' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='380' column='1'/>
+        <var-decl name='device_subclass' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='380' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='device_protocol' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='381' column='1'/>
+        <var-decl name='device_protocol' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='381' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_usb_class' type-id='type-id-125' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='382' column='1' id='type-id-69'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-70' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='402' column='1' id='type-id-126'>
+    <typedef-decl name='efidp_usb_class' type-id='type-id-149' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='382' column='1' id='type-id-91'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='402' column='1' id='type-id-150'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='403' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='403' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='interface' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='404' column='1'/>
+        <var-decl name='interface' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='404' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='vendor_id' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='405' column='1'/>
+        <var-decl name='vendor_id' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='405' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='product_id' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='406' column='1'/>
+        <var-decl name='product_id' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='406' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='serial_number' type-id='type-id-127' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='407' column='1'/>
+        <var-decl name='serial_number' type-id='type-id-151' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='407' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='0' type-id='type-id-5' size-in-bits='infinite' id='type-id-127'/>
-    <typedef-decl name='efidp_usb_wwid' type-id='type-id-126' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='408' column='1' id='type-id-70'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-71' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='411' column='1' id='type-id-128'>
+
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='16' id='type-id-151'>
+      <subrange length='1' type-id='type-id-13' id='type-id-133'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_usb_wwid' type-id='type-id-150' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='408' column='1' id='type-id-92'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-93' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='411' column='1' id='type-id-152'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='412' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='412' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='lun' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='413' column='1'/>
+        <var-decl name='lun' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='413' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_lun' type-id='type-id-128' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='414' column='1' id='type-id-71'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-72' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='417' column='1' id='type-id-129'>
+    <typedef-decl name='efidp_lun' type-id='type-id-152' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='414' column='1' id='type-id-93'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-94' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='417' column='1' id='type-id-153'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='418' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='418' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='hba_port' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='419' column='1'/>
+        <var-decl name='hba_port' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='419' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='port_multiplier_port' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='420' column='1'/>
+        <var-decl name='port_multiplier_port' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='420' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='lun' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='421' column='1'/>
+        <var-decl name='lun' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='421' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_sata' type-id='type-id-129' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='422' column='1' id='type-id-72'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-73' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='428' column='1' id='type-id-130'>
+    <typedef-decl name='efidp_sata' type-id='type-id-153' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='422' column='1' id='type-id-94'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-95' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='428' column='1' id='type-id-154'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='429' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='429' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='target' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='430' column='1'/>
+        <var-decl name='target' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='430' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_i2o' type-id='type-id-130' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='431' column='1' id='type-id-73'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='296' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-74' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='434' column='1' id='type-id-131'>
+    <typedef-decl name='efidp_i2o' type-id='type-id-154' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='431' column='1' id='type-id-95'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='296' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-96' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='434' column='1' id='type-id-155'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='435' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='435' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='mac_addr' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='436' column='1'/>
+        <var-decl name='mac_addr' type-id='type-id-156' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='436' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='if_type' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='437' column='1'/>
+        <var-decl name='if_type' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='437' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='1' type-id='type-id-13' size-in-bits='256' id='type-id-132'>
-      <subrange length='32'/>
+
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='256' id='type-id-156'>
+      <subrange length='32' type-id='type-id-13' id='type-id-157'/>
+
     </array-type-def>
-    <typedef-decl name='efidp_mac_addr' type-id='type-id-131' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='438' column='1' id='type-id-74'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='216' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='446' column='1' id='type-id-133'>
+    <typedef-decl name='efidp_mac_addr' type-id='type-id-155' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='438' column='1' id='type-id-96'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='216' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-97' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='446' column='1' id='type-id-158'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='447' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='447' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='local_ipv4_addr' type-id='type-id-134' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='448' column='1'/>
+        <var-decl name='local_ipv4_addr' type-id='type-id-159' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='448' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='remote_ipv4_addr' type-id='type-id-134' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='449' column='1'/>
+        <var-decl name='remote_ipv4_addr' type-id='type-id-159' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='449' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='local_port' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='450' column='1'/>
+        <var-decl name='local_port' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='450' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='112'>
-        <var-decl name='remote_port' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='451' column='1'/>
+        <var-decl name='remote_port' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='451' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='protocol' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='452' column='1'/>
+        <var-decl name='protocol' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='452' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='static_ip_addr' type-id='type-id-135' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='453' column='1'/>
+        <var-decl name='static_ip_addr' type-id='type-id-160' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='453' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='152'>
-        <var-decl name='gateway' type-id='type-id-134' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='454' column='1'/>
+        <var-decl name='gateway' type-id='type-id-159' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='454' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='184'>
-        <var-decl name='netmask' type-id='type-id-134' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='455' column='1'/>
+        <var-decl name='netmask' type-id='type-id-159' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='455' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='1' type-id='type-id-13' size-in-bits='32' id='type-id-134'>
-      <subrange length='4'/>
+
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='32' id='type-id-159'>
+      <subrange length='4' type-id='type-id-13' id='type-id-161'/>
+
     </array-type-def>
-    <typedef-decl name='efidp_boolean' type-id='type-id-13' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='43' column='1' id='type-id-135'/>
-    <typedef-decl name='efidp_ipv4_addr' type-id='type-id-133' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='456' column='1' id='type-id-75'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='360' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-76' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='468' column='1' id='type-id-136'>
+    <typedef-decl name='efidp_boolean' type-id='type-id-28' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='43' column='1' id='type-id-160'/>
+    <typedef-decl name='efidp_ipv4_addr' type-id='type-id-158' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='456' column='1' id='type-id-97'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='360' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-98' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='468' column='1' id='type-id-162'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='469' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='469' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='local_ipv6_addr' type-id='type-id-137' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='470' column='1'/>
+        <var-decl name='local_ipv6_addr' type-id='type-id-163' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='470' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='remote_ipv6_addr' type-id='type-id-137' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='471' column='1'/>
+        <var-decl name='remote_ipv6_addr' type-id='type-id-163' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='471' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='local_port' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='472' column='1'/>
+        <var-decl name='local_port' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='472' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='304'>
-        <var-decl name='remote_port' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='473' column='1'/>
+        <var-decl name='remote_port' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='473' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='protocol' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='474' column='1'/>
+        <var-decl name='protocol' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='474' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='336'>
-        <var-decl name='ip_addr_origin' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='475' column='1'/>
+        <var-decl name='ip_addr_origin' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='475' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='344'>
-        <var-decl name='prefix_length' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='476' column='1'/>
+        <var-decl name='prefix_length' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='476' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='gateway_ipv6_addr' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='477' column='1'/>
+        <var-decl name='gateway_ipv6_addr' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='477' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='1' type-id='type-id-13' size-in-bits='128' id='type-id-137'>
-      <subrange length='16'/>
+
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='128' id='type-id-163'>
+      <subrange length='16' type-id='type-id-13' id='type-id-164'/>
+
     </array-type-def>
-    <typedef-decl name='efidp_ipv6_addr' type-id='type-id-136' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='478' column='1' id='type-id-76'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-77' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='485' column='1' id='type-id-138'>
+    <typedef-decl name='efidp_ipv6_addr' type-id='type-id-162' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='478' column='1' id='type-id-98'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-99' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='485' column='1' id='type-id-165'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='486' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='486' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vlan_id' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='487' column='1'/>
+        <var-decl name='vlan_id' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='487' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_vlan' type-id='type-id-138' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='488' column='1' id='type-id-77'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='384' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-78' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='491' column='1' id='type-id-139'>
+    <typedef-decl name='efidp_vlan' type-id='type-id-165' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='488' column='1' id='type-id-99'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='384' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-100' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='491' column='1' id='type-id-166'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='492' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='492' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='resource_flags' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='493' column='1'/>
+        <var-decl name='resource_flags' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='493' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='port_gid' type-id='type-id-140' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='494' column='1'/>
+        <var-decl name='port_gid' type-id='type-id-167' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='494' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='' type-id='type-id-141' visibility='default'/>
+        <var-decl name='' type-id='type-id-168' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='target_port_id' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='499' column='1'/>
+        <var-decl name='target_port_id' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='499' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='device_id' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='500' column='1'/>
+        <var-decl name='device_id' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='500' column='1'/>
       </data-member>
     </class-decl>
-    <array-type-def dimensions='1' type-id='type-id-17' size-in-bits='128' id='type-id-140'>
-      <subrange length='2'/>
+
+    <array-type-def dimensions='1' type-id='type-id-54' size-in-bits='128' id='type-id-167'>
+      <subrange length='2' type-id='type-id-13' id='type-id-169'/>
+
     </array-type-def>
-    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='495' column='1' id='type-id-141'>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='495' column='1' id='type-id-168'>
       <data-member access='private'>
-        <var-decl name='ioc_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='496' column='1'/>
+        <var-decl name='ioc_guid' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='496' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='service_id' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='497' column='1'/>
+        <var-decl name='service_id' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='497' column='1'/>
       </data-member>
     </union-decl>
-    <typedef-decl name='efidp_infiniband' type-id='type-id-139' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='501' column='1' id='type-id-78'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='152' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-79' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='510' column='1' id='type-id-142'>
+    <typedef-decl name='efidp_infiniband' type-id='type-id-166' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='501' column='1' id='type-id-100'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='152' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-101' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='510' column='1' id='type-id-170'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='511' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='511' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='512' column='1'/>
+        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='512' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='baud_rate' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='513' column='1'/>
+        <var-decl name='baud_rate' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='513' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='data_bits' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='514' column='1'/>
+        <var-decl name='data_bits' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='514' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='136'>
-        <var-decl name='parity' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='515' column='1'/>
+        <var-decl name='parity' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='515' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='stop_bits' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='516' column='1'/>
+        <var-decl name='stop_bits' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='516' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_uart' type-id='type-id-142' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='517' column='1' id='type-id-79'/>
-    <typedef-decl name='efidp_msg_vendor' type-id='type-id-109' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='545' column='1' id='type-id-80'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-81' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='554' column='1' id='type-id-143'>
+    <typedef-decl name='efidp_uart' type-id='type-id-170' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='517' column='1' id='type-id-101'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-102' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='541' column='1' id='type-id-171'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='555' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='542' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-2' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='556' column='1'/>
+        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='543' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='flow_control_map' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='557' column='1'/>
+        <var-decl name='vendor_data' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='544' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_uart_flow_control' type-id='type-id-143' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='558' column='1' id='type-id-81'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='352' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-82' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='565' column='1' id='type-id-144'>
+    <typedef-decl name='efidp_msg_vendor' type-id='type-id-171' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='545' column='1' id='type-id-102'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-103' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='554' column='1' id='type-id-172'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='566' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='555' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-2' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='567' column='1'/>
+        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='556' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='reserved' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='568' column='1'/>
+        <var-decl name='flow_control_map' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='557' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_uart_flow_control' type-id='type-id-172' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='558' column='1' id='type-id-103'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='352' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-104' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='565' column='1' id='type-id-173'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='566' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='567' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='568' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='sas_address' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='569' column='1'/>
+        <var-decl name='sas_address' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='569' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='lun' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='570' column='1'/>
+        <var-decl name='lun' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='570' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='device_topology_info' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='571' column='1'/>
+        <var-decl name='device_topology_info' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='571' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='drive_bay_id' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='572' column='1'/>
+        <var-decl name='drive_bay_id' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='572' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='336'>
-        <var-decl name='rtp' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='573' column='1'/>
+        <var-decl name='rtp' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='573' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_sas' type-id='type-id-144' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='574' column='1' id='type-id-82'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-83' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='598' column='1' id='type-id-145'>
+    <typedef-decl name='efidp_sas' type-id='type-id-173' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='574' column='1' id='type-id-104'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-105' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='598' column='1' id='type-id-174'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='599' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='599' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='sas_address' type-id='type-id-122' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='600' column='1'/>
+        <var-decl name='sas_address' type-id='type-id-145' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='600' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='lun' type-id='type-id-122' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='601' column='1'/>
+        <var-decl name='lun' type-id='type-id-145' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='601' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='device_topology_info' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='602' column='1'/>
+        <var-decl name='device_topology_info' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='602' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='168'>
-        <var-decl name='drive_bay_id' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='603' column='1'/>
+        <var-decl name='drive_bay_id' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='603' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='176'>
-        <var-decl name='rtp' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='604' column='1'/>
+        <var-decl name='rtp' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='604' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_sas_ex' type-id='type-id-145' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='605' column='1' id='type-id-83'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='144' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-84' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='611' column='1' id='type-id-146'>
+    <typedef-decl name='efidp_sas_ex' type-id='type-id-174' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='605' column='1' id='type-id-105'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='144' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-106' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='611' column='1' id='type-id-175'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='612' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='612' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='protocol' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='613' column='1'/>
+        <var-decl name='protocol' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='613' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='options' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='614' column='1'/>
+        <var-decl name='options' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='614' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='lun' type-id='type-id-122' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='615' column='1'/>
+        <var-decl name='lun' type-id='type-id-145' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='615' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='tpgt' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='616' column='1'/>
+        <var-decl name='tpgt' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='616' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='target_name' type-id='type-id-110' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='617' column='1'/>
+        <var-decl name='target_name' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='617' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_iscsi' type-id='type-id-146' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='618' column='1' id='type-id-84'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-85' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='646' column='1' id='type-id-147'>
+    <typedef-decl name='efidp_iscsi' type-id='type-id-175' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='618' column='1' id='type-id-106'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='646' column='1' id='type-id-176'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='647' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='647' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='namespace_id' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='648' column='1'/>
+        <var-decl name='namespace_id' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='648' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='ieee_eui_64' type-id='type-id-122' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='649' column='1'/>
+        <var-decl name='ieee_eui_64' type-id='type-id-145' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='649' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_nvme' type-id='type-id-147' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='650' column='1' id='type-id-85'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='655' column='1' id='type-id-148'>
+    <typedef-decl name='efidp_nvme' type-id='type-id-176' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='650' column='1' id='type-id-107'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-108' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='655' column='1' id='type-id-177'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='656' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='656' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='uri' type-id='type-id-110' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='657' column='1'/>
+        <var-decl name='uri' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='657' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_uri' type-id='type-id-148' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='658' column='1' id='type-id-86'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-87' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='661' column='1' id='type-id-149'>
+    <typedef-decl name='efidp_uri' type-id='type-id-177' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='658' column='1' id='type-id-108'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-109' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='661' column='1' id='type-id-178'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='662' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='662' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='target_id' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='663' column='1'/>
+        <var-decl name='target_id' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='663' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='lun' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='664' column='1'/>
+        <var-decl name='lun' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='664' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_ufs' type-id='type-id-149' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='665' column='1' id='type-id-87'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='668' column='1' id='type-id-150'>
+    <typedef-decl name='efidp_ufs' type-id='type-id-178' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='665' column='1' id='type-id-109'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-110' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='668' column='1' id='type-id-179'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='669' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='669' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='slot_number' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='670' column='1'/>
+        <var-decl name='slot_number' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='670' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_sd' type-id='type-id-150' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='671' column='1' id='type-id-88'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-89' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='674' column='1' id='type-id-151'>
+    <typedef-decl name='efidp_sd' type-id='type-id-179' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='671' column='1' id='type-id-110'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-111' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='674' column='1' id='type-id-180'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='675' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='675' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='addr' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='676' column='1'/>
+        <var-decl name='addr' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='676' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_bt' type-id='type-id-151' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='677' column='1' id='type-id-89'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='288' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-90' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='680' column='1' id='type-id-152'>
+    <typedef-decl name='efidp_bt' type-id='type-id-180' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='677' column='1' id='type-id-111'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='288' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-112' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='680' column='1' id='type-id-181'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='681' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='681' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='ssid' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='682' column='1'/>
+        <var-decl name='ssid' type-id='type-id-156' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='682' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_wifi' type-id='type-id-152' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='683' column='1' id='type-id-90'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='686' column='1' id='type-id-153'>
+    <typedef-decl name='efidp_wifi' type-id='type-id-181' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='683' column='1' id='type-id-112'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-113' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='686' column='1' id='type-id-182'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='687' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='687' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='slot' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='688' column='1'/>
+        <var-decl name='slot' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='688' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_emmc' type-id='type-id-153' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='689' column='1' id='type-id-91'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='692' column='1' id='type-id-154'>
+    <typedef-decl name='efidp_emmc' type-id='type-id-182' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='689' column='1' id='type-id-113'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-114' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='692' column='1' id='type-id-183'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='693' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='693' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='addr' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='694' column='1'/>
+        <var-decl name='addr' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='694' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='addr_type' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='695' column='1'/>
+        <var-decl name='addr_type' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='695' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_btle' type-id='type-id-154' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='696' column='1' id='type-id-92'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-93' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='702' column='1' id='type-id-155'>
+    <typedef-decl name='efidp_btle' type-id='type-id-183' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='696' column='1' id='type-id-114'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-115' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='702' column='1' id='type-id-184'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='703' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='703' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='is_ipv6' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='704' column='1'/>
+        <var-decl name='is_ipv6' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='704' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='addrs' type-id='type-id-156' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='705' column='1'/>
+        <var-decl name='addrs' type-id='type-id-185' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='705' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='49' column='1' id='type-id-157'>
+    <union-decl name='__anonymous_union__' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='49' column='1' id='type-id-186'>
       <data-member access='private'>
-        <var-decl name='addr' type-id='type-id-158' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='50' column='1'/>
+        <var-decl name='addr' type-id='type-id-187' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='50' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='v4' type-id='type-id-159' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='51' column='1'/>
+        <var-decl name='v4' type-id='type-id-188' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='51' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='v6' type-id='type-id-160' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='52' column='1'/>
+        <var-decl name='v6' type-id='type-id-189' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='52' column='1'/>
       </data-member>
     </union-decl>
-    <array-type-def dimensions='1' type-id='type-id-4' size-in-bits='128' id='type-id-158'>
-      <subrange length='4'/>
+
+    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='128' id='type-id-187'>
+      <subrange length='4' type-id='type-id-13' id='type-id-161'/>
+
     </array-type-def>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-159' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='41' column='1' id='type-id-161'>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-188' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='41' column='1' id='type-id-190'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='addr' type-id='type-id-134' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='42' column='1'/>
+        <var-decl name='addr' type-id='type-id-159' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='42' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efi_ipv4_addr_t' type-id='type-id-161' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='43' column='1' id='type-id-159'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-160' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='45' column='1' id='type-id-162'>
+    <typedef-decl name='efi_ipv4_addr_t' type-id='type-id-190' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='43' column='1' id='type-id-188'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-189' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='45' column='1' id='type-id-191'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='addr' type-id='type-id-137' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='46' column='1'/>
+        <var-decl name='addr' type-id='type-id-163' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='46' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efi_ipv6_addr_t' type-id='type-id-162' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='47' column='1' id='type-id-160'/>
-    <typedef-decl name='efi_ip_addr_t' type-id='type-id-157' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='53' column='1' id='type-id-163'/>
-    <array-type-def dimensions='0' type-id='type-id-163' size-in-bits='infinite' id='type-id-156'/>
-    <typedef-decl name='efidp_dns' type-id='type-id-155' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='706' column='1' id='type-id-93'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-94' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='709' column='1' id='type-id-164'>
+    <typedef-decl name='efi_ipv6_addr_t' type-id='type-id-191' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='47' column='1' id='type-id-189'/>
+    <typedef-decl name='efi_ip_addr_t' type-id='type-id-186' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='53' column='1' id='type-id-192'/>
+
+    <array-type-def dimensions='1' type-id='type-id-192' size-in-bits='128' id='type-id-185'>
+      <subrange length='1' type-id='type-id-13' id='type-id-133'/>
+
+    </array-type-def>
+    <typedef-decl name='efidp_dns' type-id='type-id-184' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='706' column='1' id='type-id-115'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-116' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='709' column='1' id='type-id-193'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='710' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='710' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='uuid' type-id='type-id-2' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='711' column='1'/>
+        <var-decl name='uuid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='711' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_nvdimm' type-id='type-id-164' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='712' column='1' id='type-id-94'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='336' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-95' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='717' column='1' id='type-id-165'>
+    <typedef-decl name='efidp_nvdimm' type-id='type-id-193' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='712' column='1' id='type-id-116'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='336' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-117' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='717' column='1' id='type-id-194'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='718' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='718' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='partition_number' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='719' column='1'/>
+        <var-decl name='partition_number' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='719' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='start' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='720' column='1'/>
+        <var-decl name='start' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='720' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='size' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='721' column='1'/>
+        <var-decl name='size' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='721' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='signature' type-id='type-id-137' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='722' column='1'/>
+        <var-decl name='signature' type-id='type-id-163' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='722' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='format' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='723' column='1'/>
+        <var-decl name='format' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='723' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='signature_type' type-id='type-id-13' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='724' column='1'/>
+        <var-decl name='signature_type' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='724' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_hd' type-id='type-id-165' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='728' column='1' id='type-id-95'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-96' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='742' column='1' id='type-id-166'>
+    <typedef-decl name='efidp_hd' type-id='type-id-194' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='728' column='1' id='type-id-117'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-118' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='742' column='1' id='type-id-195'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='743' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='743' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='boot_catalog_entry' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='744' column='1'/>
+        <var-decl name='boot_catalog_entry' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='744' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='partition_rba' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='745' column='1'/>
+        <var-decl name='partition_rba' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='745' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='sectors' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='746' column='1'/>
+        <var-decl name='sectors' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='746' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_cdrom' type-id='type-id-166' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='747' column='1' id='type-id-96'/>
-    <typedef-decl name='efidp_media_vendor' type-id='type-id-109' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='754' column='1' id='type-id-97'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-98' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='761' column='1' id='type-id-167'>
+    <typedef-decl name='efidp_cdrom' type-id='type-id-195' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='747' column='1' id='type-id-118'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-119' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='750' column='1' id='type-id-196'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='762' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='751' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='name' type-id='type-id-127' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='763' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_file' type-id='type-id-167' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='764' column='1' id='type-id-98'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-99' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='768' column='1' id='type-id-168'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='769' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='protocol_guid' type-id='type-id-2' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='770' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_protocol' type-id='type-id-168' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='771' column='1' id='type-id-99'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-100' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='780' column='1' id='type-id-169'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='781' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='pi_info' type-id='type-id-110' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='782' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_firmware_file' type-id='type-id-169' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='777' column='1' id='type-id-100'/>
-    <typedef-decl name='efidp_firmware_volume' type-id='type-id-169' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='783' column='1' id='type-id-101'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-102' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='786' column='1' id='type-id-170'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='787' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='788' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='first_byte' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='789' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='last_byte' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='790' column='1'/>
-      </data-member>
-    </class-decl>
-    <typedef-decl name='efidp_relative_offset' type-id='type-id-170' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='791' column='1' id='type-id-102'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='304' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-103' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='794' column='1' id='type-id-171'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='795' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='start_addr' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='796' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='end_addr' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='797' column='1'/>
+        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='752' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='disk_type_guid' type-id='type-id-2' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='798' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='instance_number' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='799' column='1'/>
+        <var-decl name='vendor_data' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='753' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_ramdisk' type-id='type-id-171' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='800' column='1' id='type-id-103'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-104' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='813' column='1' id='type-id-172'>
+    <typedef-decl name='efidp_media_vendor' type-id='type-id-196' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='754' column='1' id='type-id-119'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-120' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='761' column='1' id='type-id-197'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-53' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='814' column='1'/>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='762' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='device_type' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='815' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='status' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='816' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='description' type-id='type-id-110' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='817' column='1'/>
+        <var-decl name='name' type-id='type-id-151' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='763' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_bios_boot' type-id='type-id-172' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='818' column='1' id='type-id-104'/>
-    <typedef-decl name='efidp_data' type-id='type-id-51' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='890' column='1' id='type-id-173'/>
-    <pointer-type-def type-id='type-id-173' size-in-bits='64' id='type-id-174'/>
-    <typedef-decl name='efidp' type-id='type-id-174' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='891' column='1' id='type-id-175'/>
-    <function-decl name='efidp_parse_device_path' mangled-name='efidp_parse_device_path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='423' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_parse_device_path@@libefivar.so.0'>
-      <parameter type-id='type-id-19' name='path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='423' column='1'/>
-      <parameter type-id='type-id-175' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='424' column='1'/>
-      <parameter type-id='type-id-21' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='425' column='1'/>
-      <return type-id='type-id-30'/>
+    <typedef-decl name='efidp_file' type-id='type-id-197' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='764' column='1' id='type-id-120'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-121' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='768' column='1' id='type-id-198'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='769' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='protocol_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='770' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_protocol' type-id='type-id-198' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='771' column='1' id='type-id-121'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-122' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='774' column='1' id='type-id-199'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='775' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='pi_info' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='776' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_firmware_file' type-id='type-id-199' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='777' column='1' id='type-id-122'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-123' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='780' column='1' id='type-id-200'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='781' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='pi_info' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='782' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_firmware_volume' type-id='type-id-200' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='783' column='1' id='type-id-123'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-124' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='786' column='1' id='type-id-201'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='787' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='788' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='first_byte' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='789' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='last_byte' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='790' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_relative_offset' type-id='type-id-201' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='791' column='1' id='type-id-124'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='304' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-125' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='794' column='1' id='type-id-202'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='795' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='start_addr' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='796' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='96'>
+        <var-decl name='end_addr' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='797' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='160'>
+        <var-decl name='disk_type_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='798' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='288'>
+        <var-decl name='instance_number' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='799' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_ramdisk' type-id='type-id-202' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='800' column='1' id='type-id-125'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-126' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='813' column='1' id='type-id-203'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='814' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='device_type' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='815' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='48'>
+        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='816' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='description' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='817' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_bios_boot' type-id='type-id-203' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='818' column='1' id='type-id-126'/>
+    <typedef-decl name='efidp_data' type-id='type-id-73' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='890' column='1' id='type-id-204'/>
+    <pointer-type-def type-id='type-id-204' size-in-bits='64' id='type-id-205'/>
+    <typedef-decl name='efidp' type-id='type-id-205' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='891' column='1' id='type-id-206'/>
+    <function-decl name='efidp_parse_device_path' mangled-name='efidp_parse_device_path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='423' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_parse_device_path@@libefivar.so.0'>
+      <parameter type-id='type-id-46' name='path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='423' column='1'/>
+      <parameter type-id='type-id-206' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='424' column='1'/>
+      <parameter type-id='type-id-33' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='425' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_parse_device_node' mangled-name='efidp_parse_device_node' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_parse_device_node@@libefivar.so.0'>
-      <parameter type-id='type-id-19' name='path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='423' column='1'/>
-      <parameter type-id='type-id-175' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='424' column='1'/>
-      <parameter type-id='type-id-21' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='425' column='1'/>
-      <return type-id='type-id-30'/>
+    <function-decl name='efidp_parse_device_node' mangled-name='efidp_parse_device_node' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_parse_device_node@@libefivar.so.0'>
+      <parameter type-id='type-id-46' name='path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='423' column='1'/>
+      <parameter type-id='type-id-206' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='424' column='1'/>
+      <parameter type-id='type-id-33' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='425' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-173' const='yes' id='type-id-176'/>
-    <pointer-type-def type-id='type-id-176' size-in-bits='64' id='type-id-177'/>
-    <typedef-decl name='const_efidp' type-id='type-id-177' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='892' column='1' id='type-id-178'/>
-    <function-decl name='efidp_format_device_path' mangled-name='efidp_format_device_path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='307' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_format_device_path@@libefivar.so.0'>
-      <parameter type-id='type-id-19' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='307' column='1'/>
-      <parameter type-id='type-id-21' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='307' column='1'/>
-      <parameter type-id='type-id-178' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='307' column='1'/>
-      <parameter type-id='type-id-30' name='limit' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='307' column='1'/>
-      <return type-id='type-id-30'/>
+    <qualified-type-def type-id='type-id-204' const='yes' id='type-id-207'/>
+    <pointer-type-def type-id='type-id-207' size-in-bits='64' id='type-id-208'/>
+    <typedef-decl name='const_efidp' type-id='type-id-208' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='892' column='1' id='type-id-209'/>
+    <function-decl name='efidp_format_device_path' mangled-name='efidp_format_device_path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='307' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_format_device_path@@libefivar.so.0'>
+      <parameter type-id='type-id-46' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='307' column='1'/>
+      <parameter type-id='type-id-33' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='307' column='1'/>
+      <parameter type-id='type-id-209' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='307' column='1'/>
+      <parameter type-id='type-id-61' name='limit' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='307' column='1'/>
+      <return type-id='type-id-61'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-175' size-in-bits='64' id='type-id-179'/>
-    <function-decl name='efidp_append_node' mangled-name='efidp_append_node' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='197' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_append_node@@libefivar.so.0'>
-      <parameter type-id='type-id-178' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='197' column='1'/>
-      <parameter type-id='type-id-178' name='dn' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='197' column='1'/>
-      <parameter type-id='type-id-179' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='197' column='1'/>
-      <return type-id='type-id-1'/>
+    <pointer-type-def type-id='type-id-206' size-in-bits='64' id='type-id-210'/>
+    <function-decl name='efidp_append_instance' mangled-name='efidp_append_instance' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_append_instance@@libefivar.so.0'>
+      <parameter type-id='type-id-209' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='259' column='1'/>
+      <parameter type-id='type-id-209' name='dpi' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='259' column='1'/>
+      <parameter type-id='type-id-210' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='259' column='1'/>
+      <parameter type-id='type-id-209' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='259' column='1'/>
+      <parameter type-id='type-id-209' name='dpi' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='259' column='1'/>
+      <parameter type-id='type-id-210' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='259' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efidp_duplicate_path' mangled-name='efidp_duplicate_path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='103' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_duplicate_path@@libefivar.so.0'>
-      <parameter type-id='type-id-178' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='103' column='1'/>
-      <parameter type-id='type-id-179' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='103' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_append_node' mangled-name='efidp_append_node' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='197' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_append_node@@libefivar.so.0'>
+      <parameter type-id='type-id-209' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='197' column='1'/>
+      <parameter type-id='type-id-209' name='dn' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='197' column='1'/>
+      <parameter type-id='type-id-210' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='197' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efidp_append_instance' mangled-name='efidp_append_instance' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_append_instance@@libefivar.so.0'>
-      <parameter type-id='type-id-178' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='259' column='1'/>
-      <parameter type-id='type-id-178' name='dpi' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='259' column='1'/>
-      <parameter type-id='type-id-179' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='259' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_append_path' mangled-name='efidp_append_path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='114' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_append_path@@libefivar.so.0'>
+      <parameter type-id='type-id-209' name='dp0' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='114' column='1'/>
+      <parameter type-id='type-id-209' name='dp1' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='114' column='1'/>
+      <parameter type-id='type-id-210' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='114' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efidp_append_path' mangled-name='efidp_append_path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='114' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_append_path@@libefivar.so.0'>
-      <parameter type-id='type-id-178' name='dp0' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='114' column='1'/>
-      <parameter type-id='type-id-178' name='dp1' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='114' column='1'/>
-      <parameter type-id='type-id-179' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='114' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_duplicate_path' mangled-name='efidp_duplicate_path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='103' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_duplicate_path@@libefivar.so.0'>
+      <parameter type-id='type-id-209' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='103' column='1'/>
+      <parameter type-id='type-id-210' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='103' column='1'/>
+      <parameter type-id='type-id-209' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='103' column='1'/>
+      <parameter type-id='type-id-210' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='103' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efidp_set_node_data' mangled-name='efidp_set_node_data' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='48' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_set_node_data@@libefivar.so.0'>
-      <parameter type-id='type-id-178' name='dn' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='48' column='1'/>
-      <parameter type-id='type-id-50' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='48' column='1'/>
-      <parameter type-id='type-id-21' name='bufsize' filepath='/home/pjones/devel/github.com/efivar/master/src/dp.c' line='48' column='1'/>
-      <return type-id='type-id-1'/>
+    <function-decl name='efidp_set_node_data' mangled-name='efidp_set_node_data' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='48' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_set_node_data@@libefivar.so.0'>
+      <parameter type-id='type-id-209' name='dn' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='48' column='1'/>
+      <parameter type-id='type-id-72' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='48' column='1'/>
+      <parameter type-id='type-id-33' name='bufsize' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='48' column='1'/>
+      <parameter type-id='type-id-209' name='dn' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='48' column='1'/>
+      <parameter type-id='type-id-72' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='48' column='1'/>
+      <parameter type-id='type-id-33' name='bufsize' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='48' column='1'/>
+      <return type-id='type-id-15'/>
     </function-decl>
-    <var-decl name='efi_guid_sha512' type-id='type-id-14' mangled-name='efi_guid_sha512' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='26' column='1' elf-symbol-id='efi_guid_sha512@@libefivar.so.0'/>
-    <var-decl name='efi_guid_redhat' type-id='type-id-14' mangled-name='efi_guid_redhat' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='31' column='1' elf-symbol-id='efi_guid_redhat@@libefivar.so.0'/>
-    <var-decl name='efi_guid_fwupdate' type-id='type-id-14' mangled-name='efi_guid_fwupdate' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='35' column='1' elf-symbol-id='efi_guid_fwupdate@@LIBEFIVAR_1.35'/>
-    <var-decl name='efi_guid_sha224' type-id='type-id-14' mangled-name='efi_guid_sha224' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='39' column='1' elf-symbol-id='efi_guid_sha224@@libefivar.so.0'/>
-    <var-decl name='efi_guid_lenovo_boot_menu' type-id='type-id-14' mangled-name='efi_guid_lenovo_boot_menu' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='43' column='1' elf-symbol-id='efi_guid_lenovo_boot_menu@@libefivar.so.0'/>
-    <var-decl name='efi_guid_ux_capsule' type-id='type-id-14' mangled-name='efi_guid_ux_capsule' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='47' column='1' elf-symbol-id='efi_guid_ux_capsule@@LIBEFIVAR_1.33'/>
-    <var-decl name='efi_guid_x509_sha256' type-id='type-id-14' mangled-name='efi_guid_x509_sha256' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='51' column='1' elf-symbol-id='efi_guid_x509_sha256@@libefivar.so.0'/>
-    <var-decl name='efi_guid_rsa2048' type-id='type-id-14' mangled-name='efi_guid_rsa2048' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='55' column='1' elf-symbol-id='efi_guid_rsa2048@@libefivar.so.0'/>
-    <var-decl name='efi_guid_lenovo' type-id='type-id-14' mangled-name='efi_guid_lenovo' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='59' column='1' elf-symbol-id='efi_guid_lenovo@@libefivar.so.0'/>
-    <var-decl name='efi_guid_lenovo_diag' type-id='type-id-14' mangled-name='efi_guid_lenovo_diag' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='63' column='1' elf-symbol-id='efi_guid_lenovo_diag@@libefivar.so.0'/>
-    <var-decl name='efi_guid_x509_sha512' type-id='type-id-14' mangled-name='efi_guid_x509_sha512' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='67' column='1' elf-symbol-id='efi_guid_x509_sha512@@libefivar.so.0'/>
-    <var-decl name='efi_guid_pkcs7_cert' type-id='type-id-14' mangled-name='efi_guid_pkcs7_cert' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='75' column='1' elf-symbol-id='efi_guid_pkcs7_cert@@libefivar.so.0'/>
-    <var-decl name='efi_guid_shim' type-id='type-id-14' mangled-name='efi_guid_shim' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='79' column='1' elf-symbol-id='efi_guid_shim@@libefivar.so.0'/>
-    <var-decl name='efi_guid_lenovo_rescue' type-id='type-id-14' mangled-name='efi_guid_lenovo_rescue' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='83' column='1' elf-symbol-id='efi_guid_lenovo_rescue@@libefivar.so.0'/>
-    <var-decl name='efi_guid_rsa2048_sha1' type-id='type-id-14' mangled-name='efi_guid_rsa2048_sha1' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='87' column='1' elf-symbol-id='efi_guid_rsa2048_sha1@@libefivar.so.0'/>
-    <var-decl name='efi_guid_x509_sha384' type-id='type-id-14' mangled-name='efi_guid_x509_sha384' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='91' column='1' elf-symbol-id='efi_guid_x509_sha384@@libefivar.so.0'/>
-    <var-decl name='efi_guid_lenovo_setup' type-id='type-id-14' mangled-name='efi_guid_lenovo_setup' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='95' column='1' elf-symbol-id='efi_guid_lenovo_setup@@libefivar.so.0'/>
-    <var-decl name='efi_guid_microsoft' type-id='type-id-14' mangled-name='efi_guid_microsoft' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='99' column='1' elf-symbol-id='efi_guid_microsoft@@libefivar.so.0'/>
-    <var-decl name='efi_guid_lenovo_2' type-id='type-id-14' mangled-name='efi_guid_lenovo_2' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='103' column='1' elf-symbol-id='efi_guid_lenovo_2@@libefivar.so.0'/>
-    <var-decl name='efi_guid_sha1' type-id='type-id-14' mangled-name='efi_guid_sha1' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='107' column='1' elf-symbol-id='efi_guid_sha1@@libefivar.so.0'/>
-    <var-decl name='efi_guid_lenovo_me_config' type-id='type-id-14' mangled-name='efi_guid_lenovo_me_config' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='111' column='1' elf-symbol-id='efi_guid_lenovo_me_config@@libefivar.so.0'/>
-    <var-decl name='efi_guid_global' type-id='type-id-14' mangled-name='efi_guid_global' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='115' column='1' elf-symbol-id='efi_guid_global@@libefivar.so.0'/>
-    <var-decl name='efi_guid_x509_cert' type-id='type-id-14' mangled-name='efi_guid_x509_cert' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='119' column='1' elf-symbol-id='efi_guid_x509_cert@@libefivar.so.0'/>
-    <var-decl name='efi_guid_rsa2048_sha256_cert' type-id='type-id-14' mangled-name='efi_guid_rsa2048_sha256_cert' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='123' column='1' elf-symbol-id='efi_guid_rsa2048_sha256_cert@@libefivar.so.0'/>
-    <var-decl name='efi_guid_lenovo_diag_splash' type-id='type-id-14' mangled-name='efi_guid_lenovo_diag_splash' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='127' column='1' elf-symbol-id='efi_guid_lenovo_diag_splash@@libefivar.so.0'/>
-    <var-decl name='efi_guid_redhat_2' type-id='type-id-14' mangled-name='efi_guid_redhat_2' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='131' column='1' elf-symbol-id='efi_guid_redhat_2@@libefivar.so.0'/>
-    <var-decl name='efi_guid_lenovo_msg' type-id='type-id-14' mangled-name='efi_guid_lenovo_msg' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='135' column='1' elf-symbol-id='efi_guid_lenovo_msg@@libefivar.so.0'/>
-    <var-decl name='efi_guid_sha256' type-id='type-id-14' mangled-name='efi_guid_sha256' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='139' column='1' elf-symbol-id='efi_guid_sha256@@libefivar.so.0'/>
-    <var-decl name='efi_guid_shell' type-id='type-id-14' mangled-name='efi_guid_shell' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='143' column='1' elf-symbol-id='efi_guid_shell@@libefivar.so.0'/>
-    <var-decl name='efi_guid_security' type-id='type-id-14' mangled-name='efi_guid_security' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='147' column='1' elf-symbol-id='efi_guid_security@@libefivar.so.0'/>
-    <var-decl name='efi_guid_rsa2048_sha256' type-id='type-id-14' mangled-name='efi_guid_rsa2048_sha256' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='151' column='1' elf-symbol-id='efi_guid_rsa2048_sha256@@libefivar.so.0'/>
-    <var-decl name='efi_guid_sha384' type-id='type-id-14' mangled-name='efi_guid_sha384' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='155' column='1' elf-symbol-id='efi_guid_sha384@@libefivar.so.0'/>
-    <var-decl name='efi_guid_lenovo_startup_interrupt' type-id='type-id-14' mangled-name='efi_guid_lenovo_startup_interrupt' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='159' column='1' elf-symbol-id='efi_guid_lenovo_startup_interrupt@@libefivar.so.0'/>
-    <var-decl name='efi_guid_empty' type-id='type-id-14' mangled-name='efi_guid_empty' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='18' column='1' elf-symbol-id='efi_guid_empty@@libefivar.so.0'/>
-    <var-decl name='efi_guid_zero' type-id='type-id-14' mangled-name='efi_guid_zero' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid-symbols.c' line='22' column='1' elf-symbol-id='efi_guid_zero@@libefivar.so.0'/>
-    <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-34'/>
-    </function-decl>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-211'/>
+    <var-decl name='ops' type-id='type-id-211' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='42' column='1'/>
+    <var-decl name='default_ops' type-id='type-id-1' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='37' column='1'/>
+    <class-decl name='guidname' size-in-bits='4224' is-struct='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.h' line='182' column='1' id='type-id-212'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.h' line='183' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='symbol' type-id='type-id-213' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.h' line='184' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='2176'>
+        <var-decl name='name' type-id='type-id-213' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.h' line='185' column='1'/>
+      </data-member>
+    </class-decl>
+
+    <array-type-def dimensions='1' type-id='type-id-12' size-in-bits='2048' id='type-id-213'>
+      <subrange length='256' type-id='type-id-13' id='type-id-214'/>
+
+    </array-type-def>
+    <var-decl name='efi_well_known_names_end' type-id='type-id-212' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='112' column='1'/>
+    <var-decl name='efi_well_known_names' type-id='type-id-212' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='108' column='1'/>
+    <var-decl name='efi_well_known_guids_end' type-id='type-id-212' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='110' column='1'/>
+    <var-decl name='efi_well_known_guids' type-id='type-id-212' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='106' column='1'/>
     <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
-      <return type-id='type-id-34'/>
+      <return type-id='type-id-62'/>
+    </function-decl>
+    <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-62'/>
     </function-decl>
   </abi-instr>
 </abi-corpus>

--- a/src/libefivar.abixml
+++ b/src/libefivar.abixml
@@ -12,11 +12,13 @@
     <elf-symbol name='efi_error_clear' version='LIBEFIVAR_1.30' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_error_get' version='LIBEFIVAR_1.30' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_error_set' version='LIBEFIVAR_1.30' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='efi_get_logfile' version='LIBEFIVAR_1.36' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_get_next_variable_name' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_get_variable' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_get_variable_attributes' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_get_variable_exists' version='LIBEFIVAR_1.35' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_get_variable_size' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='efi_get_verbose' version='LIBEFIVAR_1.36' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_guid_cmp' version='LIBEFIVAR_0.24' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_guid_is_empty' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_guid_to_id_guid' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -26,6 +28,7 @@
     <elf-symbol name='efi_id_guid_to_guid' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_name_to_guid' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' alias='efi_id_guid_to_guid@@libefivar.so.0' is-defined='yes'/>
     <elf-symbol name='efi_set_variable' version='LIBEFIVAR_0.24' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
+    <elf-symbol name='efi_set_verbose' version='LIBEFIVAR_1.36' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_str_to_guid' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_variable_export' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_variable_free' version='libefivar.so.0' is-default-version='yes' type='func-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
@@ -104,37 +107,37 @@
     <elf-symbol name='efi_well_known_guids' size='18480' version='libefivar.so.0' is-default-version='yes' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
     <elf-symbol name='efi_well_known_guids_end' size='1' version='libefivar.so.0' is-default-version='yes' type='object-type' binding='global-binding' visibility='default-visibility' is-defined='yes'/>
   </elf-variable-symbols>
-  <abi-instr version='1.0' address-size='64' path='efivarfs.c' comp-dir-path='/home/pjones/devel/github.com/efivar/master/src' language='LANG_C99'>
-    <class-decl name='efi_var_operations' size-in-bits='2624' is-struct='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='31' column='1' id='type-id-1'>
+  <abi-instr version='1.0' address-size='64' path='efivarfs.c' comp-dir-path='src' language='LANG_C99'>
+    <class-decl name='efi_var_operations' size-in-bits='2624' is-struct='yes' visibility='default' filepath='src/lib.h' line='29' column='1' id='type-id-1'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='name' type-id='type-id-2' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='32' column='1'/>
+        <var-decl name='name' type-id='type-id-2' visibility='default' filepath='src/lib.h' line='30' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2048'>
-        <var-decl name='probe' type-id='type-id-3' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='33' column='1'/>
+        <var-decl name='probe' type-id='type-id-3' visibility='default' filepath='src/lib.h' line='31' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2112'>
-        <var-decl name='set_variable' type-id='type-id-4' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='34' column='1'/>
+        <var-decl name='set_variable' type-id='type-id-4' visibility='default' filepath='src/lib.h' line='32' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='del_variable' type-id='type-id-5' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='36' column='1'/>
+        <var-decl name='del_variable' type-id='type-id-5' visibility='default' filepath='src/lib.h' line='34' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2240'>
-        <var-decl name='get_variable' type-id='type-id-6' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='37' column='1'/>
+        <var-decl name='get_variable' type-id='type-id-6' visibility='default' filepath='src/lib.h' line='35' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2304'>
-        <var-decl name='get_variable_attributes' type-id='type-id-7' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='39' column='1'/>
+        <var-decl name='get_variable_attributes' type-id='type-id-7' visibility='default' filepath='src/lib.h' line='37' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2368'>
-        <var-decl name='get_variable_size' type-id='type-id-8' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='41' column='1'/>
+        <var-decl name='get_variable_size' type-id='type-id-8' visibility='default' filepath='src/lib.h' line='39' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2432'>
-        <var-decl name='get_next_variable_name' type-id='type-id-9' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='43' column='1'/>
+        <var-decl name='get_next_variable_name' type-id='type-id-9' visibility='default' filepath='src/lib.h' line='41' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2496'>
-        <var-decl name='append_variable' type-id='type-id-10' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='44' column='1'/>
+        <var-decl name='append_variable' type-id='type-id-10' visibility='default' filepath='src/lib.h' line='42' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2560'>
-        <var-decl name='chmod_variable' type-id='type-id-11' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='47' column='1'/>
+        <var-decl name='chmod_variable' type-id='type-id-11' visibility='default' filepath='src/lib.h' line='45' column='1'/>
       </data-member>
     </class-decl>
     <type-decl name='char' size-in-bits='8' id='type-id-12'/>
@@ -146,21 +149,21 @@
     </array-type-def>
     <type-decl name='int' size-in-bits='32' id='type-id-15'/>
     <pointer-type-def type-id='type-id-16' size-in-bits='64' id='type-id-3'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='33' column='1' id='type-id-18'>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-17' visibility='default' filepath='src/include/efivar/efivar.h' line='33' column='1' id='type-id-18'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='a' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='34' column='1'/>
+        <var-decl name='a' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar.h' line='34' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='b' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='35' column='1'/>
+        <var-decl name='b' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar.h' line='35' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='c' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='36' column='1'/>
+        <var-decl name='c' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar.h' line='36' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='d' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='37' column='1'/>
+        <var-decl name='d' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar.h' line='37' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='e' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='38' column='1'/>
+        <var-decl name='e' type-id='type-id-21' visibility='default' filepath='src/include/efivar/efivar.h' line='38' column='1'/>
       </data-member>
     </class-decl>
     <type-decl name='unsigned int' size-in-bits='32' id='type-id-22'/>
@@ -177,7 +180,7 @@
       <subrange length='6' type-id='type-id-13' id='type-id-29'/>
 
     </array-type-def>
-    <typedef-decl name='efi_guid_t' type-id='type-id-18' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='39' column='1' id='type-id-17'/>
+    <typedef-decl name='efi_guid_t' type-id='type-id-18' filepath='src/include/efivar/efivar.h' line='39' column='1' id='type-id-17'/>
     <qualified-type-def type-id='type-id-12' const='yes' id='type-id-30'/>
     <pointer-type-def type-id='type-id-30' size-in-bits='64' id='type-id-31'/>
     <pointer-type-def type-id='type-id-28' size-in-bits='64' id='type-id-32'/>
@@ -199,7 +202,7 @@
     <pointer-type-def type-id='type-id-48' size-in-bits='64' id='type-id-9'/>
     <pointer-type-def type-id='type-id-49' size-in-bits='64' id='type-id-10'/>
     <pointer-type-def type-id='type-id-50' size-in-bits='64' id='type-id-11'/>
-    <var-decl name='efivarfs_ops' type-id='type-id-1' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='53' column='1'/>
+    <var-decl name='efivarfs_ops' type-id='type-id-1' visibility='default' filepath='src/lib.h' line='51' column='1'/>
     <function-type size-in-bits='64' id='type-id-16'>
       <return type-id='type-id-15'/>
     </function-type>
@@ -257,1597 +260,1721 @@
       <return type-id='type-id-15'/>
     </function-type>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='guid-symbols.c' comp-dir-path='/home/pjones/devel/github.com/efivar/master/src' language='LANG_C99'>
+  <abi-instr version='1.0' address-size='64' path='guid-symbols.c' comp-dir-path='src' language='LANG_C99'>
     <qualified-type-def type-id='type-id-17' const='yes' id='type-id-51'/>
-    <var-decl name='efi_guid_empty' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='4' column='1'/>
-    <var-decl name='efi_guid_zero' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='5' column='1'/>
-    <var-decl name='efi_guid_sha512' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='6' column='1'/>
-    <var-decl name='efi_guid_redhat' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='7' column='1'/>
-    <var-decl name='efi_guid_fwupdate' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='8' column='1'/>
-    <var-decl name='efi_guid_sha224' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='9' column='1'/>
-    <var-decl name='efi_guid_lenovo_boot_menu' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='10' column='1'/>
-    <var-decl name='efi_guid_ux_capsule' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='11' column='1'/>
-    <var-decl name='efi_guid_x509_sha256' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='12' column='1'/>
-    <var-decl name='efi_guid_rsa2048' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='13' column='1'/>
-    <var-decl name='efi_guid_lenovo' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='14' column='1'/>
-    <var-decl name='efi_guid_lenovo_diag' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='15' column='1'/>
-    <var-decl name='efi_guid_x509_sha512' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='16' column='1'/>
-    <var-decl name='efi_guid_external_management' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='17' column='1'/>
-    <var-decl name='efi_guid_pkcs7_cert' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='18' column='1'/>
-    <var-decl name='efi_guid_shim' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='19' column='1'/>
-    <var-decl name='efi_guid_lenovo_rescue' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='20' column='1'/>
-    <var-decl name='efi_guid_rsa2048_sha1' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='21' column='1'/>
-    <var-decl name='efi_guid_x509_sha384' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='22' column='1'/>
-    <var-decl name='efi_guid_lenovo_setup' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='23' column='1'/>
-    <var-decl name='efi_guid_microsoft' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='24' column='1'/>
-    <var-decl name='efi_guid_lenovo_2' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='25' column='1'/>
-    <var-decl name='efi_guid_sha1' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='26' column='1'/>
-    <var-decl name='efi_guid_lenovo_me_config' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='27' column='1'/>
-    <var-decl name='efi_guid_global' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='28' column='1'/>
-    <var-decl name='efi_guid_x509_cert' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='29' column='1'/>
-    <var-decl name='efi_guid_rsa2048_sha256_cert' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='30' column='1'/>
-    <var-decl name='efi_guid_lenovo_diag_splash' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='31' column='1'/>
-    <var-decl name='efi_guid_redhat_2' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='32' column='1'/>
-    <var-decl name='efi_guid_lenovo_msg' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='33' column='1'/>
-    <var-decl name='efi_guid_sha256' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='34' column='1'/>
-    <var-decl name='efi_guid_shell' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='35' column='1'/>
-    <var-decl name='efi_guid_security' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='36' column='1'/>
-    <var-decl name='efi_guid_rsa2048_sha256' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='37' column='1'/>
-    <var-decl name='efi_guid_sha384' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='38' column='1'/>
-    <var-decl name='efi_guid_lenovo_startup_interrupt' type-id='type-id-51' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-guids.h' line='39' column='1'/>
+    <var-decl name='efi_guid_empty' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='4' column='1'/>
+    <var-decl name='efi_guid_zero' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='5' column='1'/>
+    <var-decl name='efi_guid_sha512' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='6' column='1'/>
+    <var-decl name='efi_guid_redhat' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='7' column='1'/>
+    <var-decl name='efi_guid_fwupdate' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='8' column='1'/>
+    <var-decl name='efi_guid_sha224' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='9' column='1'/>
+    <var-decl name='efi_guid_lenovo_boot_menu' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='10' column='1'/>
+    <var-decl name='efi_guid_ux_capsule' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='11' column='1'/>
+    <var-decl name='efi_guid_x509_sha256' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='12' column='1'/>
+    <var-decl name='efi_guid_rsa2048' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='13' column='1'/>
+    <var-decl name='efi_guid_lenovo' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='14' column='1'/>
+    <var-decl name='efi_guid_lenovo_diag' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='15' column='1'/>
+    <var-decl name='efi_guid_x509_sha512' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='16' column='1'/>
+    <var-decl name='efi_guid_external_management' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='17' column='1'/>
+    <var-decl name='efi_guid_pkcs7_cert' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='18' column='1'/>
+    <var-decl name='efi_guid_shim' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='19' column='1'/>
+    <var-decl name='efi_guid_lenovo_rescue' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='20' column='1'/>
+    <var-decl name='efi_guid_rsa2048_sha1' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='21' column='1'/>
+    <var-decl name='efi_guid_x509_sha384' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='22' column='1'/>
+    <var-decl name='efi_guid_lenovo_setup' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='23' column='1'/>
+    <var-decl name='efi_guid_microsoft' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='24' column='1'/>
+    <var-decl name='efi_guid_lenovo_2' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='25' column='1'/>
+    <var-decl name='efi_guid_sha1' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='26' column='1'/>
+    <var-decl name='efi_guid_lenovo_me_config' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='27' column='1'/>
+    <var-decl name='efi_guid_global' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='28' column='1'/>
+    <var-decl name='efi_guid_x509_cert' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='29' column='1'/>
+    <var-decl name='efi_guid_rsa2048_sha256_cert' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='30' column='1'/>
+    <var-decl name='efi_guid_lenovo_diag_splash' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='31' column='1'/>
+    <var-decl name='efi_guid_redhat_2' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='32' column='1'/>
+    <var-decl name='efi_guid_lenovo_msg' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='33' column='1'/>
+    <var-decl name='efi_guid_sha256' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='34' column='1'/>
+    <var-decl name='efi_guid_shell' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='35' column='1'/>
+    <var-decl name='efi_guid_security' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='36' column='1'/>
+    <var-decl name='efi_guid_rsa2048_sha256' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='37' column='1'/>
+    <var-decl name='efi_guid_sha384' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='38' column='1'/>
+    <var-decl name='efi_guid_lenovo_startup_interrupt' type-id='type-id-51' visibility='default' filepath='src/include/efivar/efivar-guids.h' line='39' column='1'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='vars.c' comp-dir-path='/home/pjones/devel/github.com/efivar/master/src' language='LANG_C99'>
-    <var-decl name='vars_ops' type-id='type-id-1' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.h' line='52' column='1'/>
+  <abi-instr version='1.0' address-size='64' path='vars.c' comp-dir-path='src' language='LANG_C99'>
+    <var-decl name='vars_ops' type-id='type-id-1' visibility='default' filepath='src/lib.h' line='50' column='1'/>
   </abi-instr>
-  <abi-instr version='1.0' address-size='64' path='&lt;artificial&gt;' comp-dir-path='/home/pjones/devel/github.com/efivar/master/src' language='LANG_C99'>
-    <function-decl name='efi_variables_supported' mangled-name='efi_variables_supported' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='246' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variables_supported@@libefivar.so.0'>
+  <abi-instr version='1.0' address-size='64' path='&lt;artificial&gt;' comp-dir-path='src' language='LANG_C99'>
+    <function-decl name='efi_variables_supported' mangled-name='efi_variables_supported' filepath='src/dp-acpi.c' line='222' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variables_supported@@libefivar.so.0'>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_chmod_variable' mangled-name='efi_chmod_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='228' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_chmod_variable@@libefivar.so.0'>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='228' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='228' column='1'/>
-      <parameter type-id='type-id-35' name='mode' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='228' column='1'/>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='228' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='228' column='1'/>
-      <parameter type-id='type-id-35' name='mode' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='228' column='1'/>
+    <function-decl name='efi_chmod_variable' mangled-name='efi_chmod_variable' filepath='src/dp-acpi.c' line='205' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_chmod_variable@@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='205' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='205' column='1'/>
+      <parameter type-id='type-id-35' name='mode' filepath='src/dp-acpi.c' line='205' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='205' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='205' column='1'/>
+      <parameter type-id='type-id-35' name='mode' filepath='src/dp-acpi.c' line='205' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_get_next_variable_name' mangled-name='efi_get_next_variable_name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='209' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_next_variable_name@@libefivar.so.0'>
-      <parameter type-id='type-id-45' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='209' column='1'/>
-      <parameter type-id='type-id-47' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='209' column='1'/>
-      <parameter type-id='type-id-45' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='209' column='1'/>
-      <parameter type-id='type-id-47' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='209' column='1'/>
+    <function-decl name='efi_get_next_variable_name' mangled-name='efi_get_next_variable_name' filepath='src/dp-acpi.c' line='188' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_next_variable_name@@libefivar.so.0'>
+      <parameter type-id='type-id-45' name='guid' filepath='src/dp-acpi.c' line='188' column='1'/>
+      <parameter type-id='type-id-47' name='name' filepath='src/dp-acpi.c' line='188' column='1'/>
+      <parameter type-id='type-id-45' name='guid' filepath='src/dp-acpi.c' line='188' column='1'/>
+      <parameter type-id='type-id-47' name='name' filepath='src/dp-acpi.c' line='188' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_get_variable_size' mangled-name='efi_get_variable_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='190' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable_size@@libefivar.so.0'>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='190' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='190' column='1'/>
-      <parameter type-id='type-id-39' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='190' column='1'/>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='190' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='190' column='1'/>
-      <parameter type-id='type-id-39' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='190' column='1'/>
+    <function-decl name='efi_get_variable_size' mangled-name='efi_get_variable_size' filepath='src/dp-acpi.c' line='171' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable_size@@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='171' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='171' column='1'/>
+      <parameter type-id='type-id-39' name='size' filepath='src/dp-acpi.c' line='171' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='171' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='171' column='1'/>
+      <parameter type-id='type-id-39' name='size' filepath='src/dp-acpi.c' line='171' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_get_variable_exists' mangled-name='efi_get_variable_exists' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable_exists@@LIBEFIVAR_1.35'>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='181' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='181' column='1'/>
+    <function-decl name='efi_get_variable_exists' mangled-name='efi_get_variable_exists' filepath='src/dp-acpi.c' line='164' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable_exists@@LIBEFIVAR_1.35'>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='164' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='164' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_get_variable_attributes' mangled-name='efi_get_variable_attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='161' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable_attributes@@libefivar.so.0'>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='161' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='161' column='1'/>
-      <parameter type-id='type-id-40' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='162' column='1'/>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='161' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='161' column='1'/>
-      <parameter type-id='type-id-40' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='162' column='1'/>
+    <function-decl name='efi_get_variable_attributes' mangled-name='efi_get_variable_attributes' filepath='src/dp-acpi.c' line='146' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable_attributes@@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='146' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='146' column='1'/>
+      <parameter type-id='type-id-40' name='attributes' filepath='src/dp-acpi.c' line='147' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='146' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='146' column='1'/>
+      <parameter type-id='type-id-40' name='attributes' filepath='src/dp-acpi.c' line='147' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_get_variable' mangled-name='efi_get_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='141' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable@@libefivar.so.0'>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='141' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='141' column='1'/>
-      <parameter type-id='type-id-38' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='141' column='1'/>
-      <parameter type-id='type-id-39' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='142' column='1'/>
-      <parameter type-id='type-id-40' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='142' column='1'/>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='141' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='141' column='1'/>
-      <parameter type-id='type-id-38' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='141' column='1'/>
-      <parameter type-id='type-id-39' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='142' column='1'/>
-      <parameter type-id='type-id-40' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='142' column='1'/>
+    <function-decl name='efi_get_variable' mangled-name='efi_get_variable' filepath='src/dp-acpi.c' line='128' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_variable@@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='128' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='128' column='1'/>
+      <parameter type-id='type-id-38' name='data' filepath='src/dp-acpi.c' line='128' column='1'/>
+      <parameter type-id='type-id-39' name='data_size' filepath='src/dp-acpi.c' line='129' column='1'/>
+      <parameter type-id='type-id-40' name='attributes' filepath='src/dp-acpi.c' line='129' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='128' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='128' column='1'/>
+      <parameter type-id='type-id-38' name='data' filepath='src/dp-acpi.c' line='128' column='1'/>
+      <parameter type-id='type-id-39' name='data_size' filepath='src/dp-acpi.c' line='129' column='1'/>
+      <parameter type-id='type-id-40' name='attributes' filepath='src/dp-acpi.c' line='129' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_del_variable' mangled-name='efi_del_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='122' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_del_variable@@libefivar.so.0'>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='122' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='122' column='1'/>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='122' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='122' column='1'/>
+    <function-decl name='efi_del_variable' mangled-name='efi_del_variable' filepath='src/dp-acpi.c' line='111' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_del_variable@@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='111' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='111' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='111' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='111' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_append_variable' mangled-name='efi_append_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='98' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_append_variable@@libefivar.so.0'>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='98' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='98' column='1'/>
-      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='98' column='1'/>
-      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='99' column='1'/>
-      <parameter type-id='type-id-19' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='99' column='1'/>
+    <function-decl name='efi_append_variable' mangled-name='efi_append_variable' filepath='src/dp-acpi.c' line='89' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_append_variable@@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='89' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='89' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='src/dp-acpi.c' line='89' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='src/dp-acpi.c' line='90' column='1'/>
+      <parameter type-id='type-id-19' name='attributes' filepath='src/dp-acpi.c' line='90' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_efi_set_variable_mode' mangled-name='efi_set_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='75' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_set_variable@@LIBEFIVAR_0.24'>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='75' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='75' column='1'/>
-      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='75' column='1'/>
-      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='76' column='1'/>
-      <parameter type-id='type-id-19' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='76' column='1'/>
-      <parameter type-id='type-id-35' name='mode' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='76' column='1'/>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='75' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='75' column='1'/>
-      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='75' column='1'/>
-      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='76' column='1'/>
-      <parameter type-id='type-id-19' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='76' column='1'/>
-      <parameter type-id='type-id-35' name='mode' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='76' column='1'/>
+    <function-decl name='_efi_set_variable_mode' mangled-name='efi_set_variable' filepath='src/dp-acpi.c' line='70' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_set_variable@@LIBEFIVAR_0.24'>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='70' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='70' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='src/dp-acpi.c' line='70' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='src/dp-acpi.c' line='71' column='1'/>
+      <parameter type-id='type-id-19' name='attributes' filepath='src/dp-acpi.c' line='71' column='1'/>
+      <parameter type-id='type-id-35' name='mode' filepath='src/dp-acpi.c' line='71' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='70' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='70' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='src/dp-acpi.c' line='70' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='src/dp-acpi.c' line='71' column='1'/>
+      <parameter type-id='type-id-19' name='attributes' filepath='src/dp-acpi.c' line='71' column='1'/>
+      <parameter type-id='type-id-35' name='mode' filepath='src/dp-acpi.c' line='71' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_efi_set_variable_variadic' mangled-name='_efi_set_variable_variadic' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_efi_set_variable_variadic@@libefivar.so.0'>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
-      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
-      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
-      <parameter type-id='type-id-19' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
-      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
-      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
-      <parameter type-id='type-id-19' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
+    <function-decl name='_efi_set_variable_variadic' mangled-name='_efi_set_variable_variadic' filepath='src/dp-acpi.c' line='58' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_efi_set_variable_variadic@@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='58' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='58' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='src/dp-acpi.c' line='58' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='src/dp-acpi.c' line='59' column='1'/>
+      <parameter type-id='type-id-19' name='attributes' filepath='src/dp-acpi.c' line='59' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='58' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='58' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='src/dp-acpi.c' line='58' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='src/dp-acpi.c' line='59' column='1'/>
+      <parameter type-id='type-id-19' name='attributes' filepath='src/dp-acpi.c' line='59' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='_efi_set_variable' mangled-name='_efi_set_variable' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='47' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_efi_set_variable@libefivar.so.0'>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
-      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
-      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
-      <parameter type-id='type-id-19' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
-      <parameter type-id='type-id-17' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
-      <parameter type-id='type-id-31' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
-      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='61' column='1'/>
-      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
-      <parameter type-id='type-id-19' name='attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='62' column='1'/>
+    <function-decl name='_efi_set_variable' mangled-name='_efi_set_variable' filepath='src/dp-acpi.c' line='46' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_efi_set_variable@libefivar.so.0'>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='58' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='58' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='src/dp-acpi.c' line='58' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='src/dp-acpi.c' line='59' column='1'/>
+      <parameter type-id='type-id-19' name='attributes' filepath='src/dp-acpi.c' line='59' column='1'/>
+      <parameter type-id='type-id-17' name='guid' filepath='src/dp-acpi.c' line='58' column='1'/>
+      <parameter type-id='type-id-31' name='name' filepath='src/dp-acpi.c' line='58' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='src/dp-acpi.c' line='58' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='src/dp-acpi.c' line='59' column='1'/>
+      <parameter type-id='type-id-19' name='attributes' filepath='src/dp-acpi.c' line='59' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_name_to_guid' mangled-name='efi_name_to_guid' filepath='/usr/include/sys/stat.h' line='269' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_name_to_guid@@libefivar.so.0'>
-      <parameter type-id='type-id-31' name='name' filepath='/usr/include/sys/stat.h' line='269' column='1'/>
-      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='269' column='1'/>
+    <function-decl name='efi_name_to_guid' mangled-name='efi_name_to_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_name_to_guid@@libefivar.so.0'>
+      <parameter type-id='type-id-31' name='name'/>
+      <parameter type-id='type-id-44' name='guid'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <pointer-type-def type-id='type-id-51' size-in-bits='64' id='type-id-52'/>
-    <function-decl name='efi_guid_to_id_guid' mangled-name='efi_guid_to_id_guid' filepath='/usr/include/sys/stat.h' line='197' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_id_guid@@libefivar.so.0'>
-      <parameter type-id='type-id-52' name='guid' filepath='/usr/include/sys/stat.h' line='197' column='1'/>
-      <parameter type-id='type-id-47' name='sp' filepath='/usr/include/sys/stat.h' line='197' column='1'/>
+    <function-decl name='efi_guid_to_id_guid' mangled-name='efi_guid_to_id_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_id_guid@@libefivar.so.0'>
+      <parameter type-id='type-id-52' name='guid'/>
+      <parameter type-id='type-id-47' name='sp'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_guid_to_symbol' mangled-name='efi_guid_to_symbol' filepath='/usr/include/sys/stat.h' line='181' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_symbol@@libefivar.so.0'>
-      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
-      <parameter type-id='type-id-47' name='symbol' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
-      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
-      <parameter type-id='type-id-47' name='symbol' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
+    <function-decl name='efi_guid_to_symbol' mangled-name='efi_guid_to_symbol' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_symbol@@libefivar.so.0'>
+      <parameter type-id='type-id-44' name='guid'/>
+      <parameter type-id='type-id-47' name='symbol'/>
+      <parameter type-id='type-id-44' name='guid'/>
+      <parameter type-id='type-id-47' name='symbol'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_guid_to_name' mangled-name='efi_guid_to_name' filepath='/usr/include/sys/stat.h' line='164' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_name@@libefivar.so.0'>
-      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
-      <parameter type-id='type-id-47' name='symbol' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
-      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
-      <parameter type-id='type-id-47' name='symbol' filepath='/usr/include/sys/stat.h' line='181' column='1'/>
+    <function-decl name='efi_guid_to_name' mangled-name='efi_guid_to_name' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_name@@libefivar.so.0'>
+      <parameter type-id='type-id-44' name='guid'/>
+      <parameter type-id='type-id-47' name='symbol'/>
+      <parameter type-id='type-id-44' name='guid'/>
+      <parameter type-id='type-id-47' name='symbol'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_guid_to_str' mangled-name='efi_guid_to_str' filepath='/usr/include/sys/stat.h' line='69' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_str@@libefivar.so.0'>
-      <parameter type-id='type-id-52' name='guid' filepath='/usr/include/sys/stat.h' line='69' column='1'/>
-      <parameter type-id='type-id-47' name='sp' filepath='/usr/include/sys/stat.h' line='69' column='1'/>
+    <function-decl name='efi_guid_to_str' mangled-name='efi_guid_to_str' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_to_str@@libefivar.so.0'>
+      <parameter type-id='type-id-52' name='guid'/>
+      <parameter type-id='type-id-47' name='sp'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_str_to_guid' mangled-name='efi_str_to_guid' filepath='/usr/include/sys/stat.h' line='57' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_str_to_guid@@libefivar.so.0'>
-      <parameter type-id='type-id-31' name='s' filepath='/usr/include/sys/stat.h' line='57' column='1'/>
-      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='57' column='1'/>
-      <parameter type-id='type-id-31' name='s' filepath='/usr/include/sys/stat.h' line='57' column='1'/>
-      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='57' column='1'/>
+    <function-decl name='efi_str_to_guid' mangled-name='efi_str_to_guid' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_str_to_guid@@libefivar.so.0'>
+      <parameter type-id='type-id-31' name='s'/>
+      <parameter type-id='type-id-44' name='guid'/>
+      <parameter type-id='type-id-31' name='s'/>
+      <parameter type-id='type-id-44' name='guid'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_guid_is_zero' mangled-name='efi_guid_is_empty' filepath='/usr/include/sys/stat.h' line='43' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_is_empty@@libefivar.so.0'>
-      <parameter type-id='type-id-52' name='guid' filepath='/usr/include/sys/stat.h' line='43' column='1'/>
+    <function-decl name='efi_guid_is_zero' mangled-name='efi_guid_is_empty' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_is_empty@@libefivar.so.0'>
+      <parameter type-id='type-id-52' name='guid'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_guid_cmp' mangled-name='efi_guid_cmp' filepath='/usr/include/sys/stat.h' line='35' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_cmp@@LIBEFIVAR_0.24'>
-      <parameter type-id='type-id-52' name='a' filepath='/usr/include/sys/stat.h' line='35' column='1'/>
-      <parameter type-id='type-id-52' name='b' filepath='/usr/include/sys/stat.h' line='35' column='1'/>
+    <function-decl name='efi_guid_cmp' mangled-name='efi_guid_cmp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_guid_cmp@@LIBEFIVAR_0.24'>
+      <parameter type-id='type-id-52' name='a'/>
+      <parameter type-id='type-id-52' name='b'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <class-decl name='efi_variable' size-in-bits='320' is-struct='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='34' column='1' id='type-id-53'>
+    <class-decl name='efi_variable' size-in-bits='320' is-struct='yes' visibility='default' filepath='src/export.c' line='35' column='1' id='type-id-53'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='attrs' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='35' column='1'/>
+        <var-decl name='attrs' type-id='type-id-54' visibility='default' filepath='src/export.c' line='36' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='guid' type-id='type-id-44' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='36' column='1'/>
+        <var-decl name='guid' type-id='type-id-44' visibility='default' filepath='src/export.c' line='37' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='name' type-id='type-id-46' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='37' column='1'/>
+        <var-decl name='name' type-id='type-id-46' visibility='default' filepath='src/export.c' line='38' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='data' type-id='type-id-32' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='38' column='1'/>
+        <var-decl name='data' type-id='type-id-32' visibility='default' filepath='src/export.c' line='39' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='data_size' type-id='type-id-33' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/export.c' line='39' column='1'/>
+        <var-decl name='data_size' type-id='type-id-33' visibility='default' filepath='src/export.c' line='40' column='1'/>
       </data-member>
     </class-decl>
     <typedef-decl name='__uint64_t' type-id='type-id-13' filepath='/usr/include/bits/types.h' line='44' column='1' id='type-id-55'/>
     <typedef-decl name='uint64_t' type-id='type-id-55' filepath='/usr/include/bits/stdint-uintn.h' line='27' column='1' id='type-id-54'/>
-    <typedef-decl name='efi_variable_t' type-id='type-id-53' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='133' column='1' id='type-id-56'/>
+    <typedef-decl name='efi_variable_t' type-id='type-id-53' filepath='src/include/efivar/efivar.h' line='133' column='1' id='type-id-56'/>
     <pointer-type-def type-id='type-id-56' size-in-bits='64' id='type-id-57'/>
-    <function-decl name='efi_variable_realize' mangled-name='efi_variable_realize' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='351' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_realize@@libefivar.so.0'>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='351' column='1'/>
+    <function-decl name='efi_variable_realize' mangled-name='efi_variable_realize' filepath='/usr/include/sys/stat.h' line='318' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_realize@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='318' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <pointer-type-def type-id='type-id-54' size-in-bits='64' id='type-id-58'/>
-    <function-decl name='efi_variable_get_attributes' mangled-name='efi_variable_get_attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='337' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_attributes@@libefivar.so.0'>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='337' column='1'/>
-      <parameter type-id='type-id-58' name='attrs' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='337' column='1'/>
+    <function-decl name='efi_variable_get_attributes' mangled-name='efi_variable_get_attributes' filepath='/usr/include/sys/stat.h' line='306' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_attributes@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='306' column='1'/>
+      <parameter type-id='type-id-58' name='attrs' filepath='/usr/include/sys/stat.h' line='306' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_variable_get_guid' mangled-name='efi_variable_get_guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='284' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_guid@@libefivar.so.0'>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='284' column='1'/>
-      <parameter type-id='type-id-45' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='284' column='1'/>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='284' column='1'/>
-      <parameter type-id='type-id-45' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='284' column='1'/>
+    <function-decl name='efi_variable_get_guid' mangled-name='efi_variable_get_guid' filepath='/usr/include/sys/stat.h' line='261' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_guid@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='261' column='1'/>
+      <parameter type-id='type-id-45' name='guid' filepath='/usr/include/sys/stat.h' line='261' column='1'/>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='261' column='1'/>
+      <parameter type-id='type-id-45' name='guid' filepath='/usr/include/sys/stat.h' line='261' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_variable_set_attributes' mangled-name='efi_variable_set_attributes' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='328' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_attributes@@libefivar.so.0'>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='328' column='1'/>
-      <parameter type-id='type-id-54' name='attrs' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='328' column='1'/>
+    <function-decl name='efi_variable_set_attributes' mangled-name='efi_variable_set_attributes' filepath='/usr/include/sys/stat.h' line='299' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_attributes@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='299' column='1'/>
+      <parameter type-id='type-id-54' name='attrs' filepath='/usr/include/sys/stat.h' line='299' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <type-decl name='long int' size-in-bits='64' id='type-id-59'/>
     <typedef-decl name='__ssize_t' type-id='type-id-59' filepath='/usr/include/bits/types.h' line='181' column='1' id='type-id-60'/>
     <typedef-decl name='ssize_t' type-id='type-id-60' filepath='/usr/include/sys/types.h' line='109' column='1' id='type-id-61'/>
-    <function-decl name='efi_variable_get_data' mangled-name='efi_variable_get_data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='313' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_data@@libefivar.so.0'>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='313' column='1'/>
-      <parameter type-id='type-id-38' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='313' column='1'/>
-      <parameter type-id='type-id-39' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='313' column='1'/>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='313' column='1'/>
-      <parameter type-id='type-id-38' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='313' column='1'/>
-      <parameter type-id='type-id-39' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='313' column='1'/>
+    <function-decl name='efi_variable_get_data' mangled-name='efi_variable_get_data' filepath='/usr/include/sys/stat.h' line='286' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_data@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='286' column='1'/>
+      <parameter type-id='type-id-38' name='data' filepath='/usr/include/sys/stat.h' line='286' column='1'/>
+      <parameter type-id='type-id-39' name='size' filepath='/usr/include/sys/stat.h' line='286' column='1'/>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='286' column='1'/>
+      <parameter type-id='type-id-38' name='data' filepath='/usr/include/sys/stat.h' line='286' column='1'/>
+      <parameter type-id='type-id-39' name='size' filepath='/usr/include/sys/stat.h' line='286' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_variable_set_data' mangled-name='efi_variable_set_data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='298' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_data@@libefivar.so.0'>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='298' column='1'/>
-      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='298' column='1'/>
-      <parameter type-id='type-id-33' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='298' column='1'/>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='298' column='1'/>
-      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='298' column='1'/>
-      <parameter type-id='type-id-33' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='298' column='1'/>
+    <function-decl name='efi_variable_set_data' mangled-name='efi_variable_set_data' filepath='/usr/include/sys/stat.h' line='273' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_data@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='273' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='/usr/include/sys/stat.h' line='273' column='1'/>
+      <parameter type-id='type-id-33' name='size' filepath='/usr/include/sys/stat.h' line='273' column='1'/>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='273' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='/usr/include/sys/stat.h' line='273' column='1'/>
+      <parameter type-id='type-id-33' name='size' filepath='/usr/include/sys/stat.h' line='273' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_variable_set_guid' mangled-name='efi_variable_set_guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='275' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_guid@@libefivar.so.0'>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='275' column='1'/>
-      <parameter type-id='type-id-44' name='guid' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='275' column='1'/>
+    <function-decl name='efi_variable_set_guid' mangled-name='efi_variable_set_guid' filepath='/usr/include/sys/stat.h' line='254' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_guid@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='254' column='1'/>
+      <parameter type-id='type-id-44' name='guid' filepath='/usr/include/sys/stat.h' line='254' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efi_variable_get_name' mangled-name='efi_variable_get_name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='262' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_name@@libefivar.so.0'>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='262' column='1'/>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='262' column='1'/>
+    <function-decl name='efi_variable_get_name' mangled-name='efi_variable_get_name' filepath='/usr/include/sys/stat.h' line='243' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_get_name@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='243' column='1'/>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='243' column='1'/>
       <return type-id='type-id-46'/>
     </function-decl>
-    <function-decl name='efi_variable_set_name' mangled-name='efi_variable_set_name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='248' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_name@@libefivar.so.0'>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='248' column='1'/>
-      <parameter type-id='type-id-46' name='name' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='248' column='1'/>
+    <function-decl name='efi_variable_set_name' mangled-name='efi_variable_set_name' filepath='/usr/include/sys/stat.h' line='236' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_set_name@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='236' column='1'/>
+      <parameter type-id='type-id-46' name='name' filepath='/usr/include/sys/stat.h' line='236' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
     <type-decl name='void' id='type-id-62'/>
-    <function-decl name='efi_variable_free' mangled-name='efi_variable_free' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='225' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_free@@libefivar.so.0'>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='225' column='1'/>
-      <parameter type-id='type-id-15' name='free_data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='225' column='1'/>
+    <function-decl name='efi_variable_free' mangled-name='efi_variable_free' filepath='/usr/include/sys/stat.h' line='215' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_free@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='215' column='1'/>
+      <parameter type-id='type-id-15' name='free_data' filepath='/usr/include/sys/stat.h' line='215' column='1'/>
       <return type-id='type-id-62'/>
     </function-decl>
-    <function-decl name='efi_variable_export' mangled-name='efi_variable_export' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='153' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_export@@libefivar.so.0'>
-      <parameter type-id='type-id-57' name='var' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='153' column='1'/>
-      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='153' column='1'/>
-      <parameter type-id='type-id-33' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='153' column='1'/>
+    <function-decl name='efi_variable_export' mangled-name='efi_variable_export' filepath='/usr/include/sys/stat.h' line='150' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_export@@libefivar.so.0'>
+      <parameter type-id='type-id-57' name='var' filepath='/usr/include/sys/stat.h' line='150' column='1'/>
+      <parameter type-id='type-id-32' name='data' filepath='/usr/include/sys/stat.h' line='150' column='1'/>
+      <parameter type-id='type-id-33' name='size' filepath='/usr/include/sys/stat.h' line='150' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
     <pointer-type-def type-id='type-id-57' size-in-bits='64' id='type-id-63'/>
-    <function-decl name='efi_variable_import' mangled-name='efi_variable_import' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='59' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_import@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='59' column='1'/>
-      <parameter type-id='type-id-33' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='59' column='1'/>
-      <parameter type-id='type-id-63' name='var_out' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='59' column='1'/>
+    <function-decl name='efi_variable_import' mangled-name='efi_variable_import' filepath='/usr/include/sys/stat.h' line='58' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_variable_import@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='data' filepath='/usr/include/sys/stat.h' line='58' column='1'/>
+      <parameter type-id='type-id-33' name='size' filepath='/usr/include/sys/stat.h' line='58' column='1'/>
+      <parameter type-id='type-id-63' name='var_out' filepath='/usr/include/sys/stat.h' line='58' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efi_error_clear' mangled-name='efi_error_clear' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='142' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_error_clear@@LIBEFIVAR_1.30'>
+    <function-decl name='efi_get_verbose' mangled-name='efi_get_verbose' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_verbose@@LIBEFIVAR_1.36'>
+      <return type-id='type-id-15'/>
+    </function-decl>
+    <class-decl name='_IO_FILE' size-in-bits='1728' is-struct='yes' visibility='default' filepath='/usr/include/bits/libio.h' line='245' column='1' id='type-id-64'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_flags' type-id='type-id-15' visibility='default' filepath='/usr/include/bits/libio.h' line='246' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_IO_read_ptr' type-id='type-id-46' visibility='default' filepath='/usr/include/bits/libio.h' line='251' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_IO_read_end' type-id='type-id-46' visibility='default' filepath='/usr/include/bits/libio.h' line='252' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='192'>
+        <var-decl name='_IO_read_base' type-id='type-id-46' visibility='default' filepath='/usr/include/bits/libio.h' line='253' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='256'>
+        <var-decl name='_IO_write_base' type-id='type-id-46' visibility='default' filepath='/usr/include/bits/libio.h' line='254' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='320'>
+        <var-decl name='_IO_write_ptr' type-id='type-id-46' visibility='default' filepath='/usr/include/bits/libio.h' line='255' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='384'>
+        <var-decl name='_IO_write_end' type-id='type-id-46' visibility='default' filepath='/usr/include/bits/libio.h' line='256' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='448'>
+        <var-decl name='_IO_buf_base' type-id='type-id-46' visibility='default' filepath='/usr/include/bits/libio.h' line='257' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='512'>
+        <var-decl name='_IO_buf_end' type-id='type-id-46' visibility='default' filepath='/usr/include/bits/libio.h' line='258' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='576'>
+        <var-decl name='_IO_save_base' type-id='type-id-46' visibility='default' filepath='/usr/include/bits/libio.h' line='260' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='640'>
+        <var-decl name='_IO_backup_base' type-id='type-id-46' visibility='default' filepath='/usr/include/bits/libio.h' line='261' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='704'>
+        <var-decl name='_IO_save_end' type-id='type-id-46' visibility='default' filepath='/usr/include/bits/libio.h' line='262' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='768'>
+        <var-decl name='_markers' type-id='type-id-65' visibility='default' filepath='/usr/include/bits/libio.h' line='264' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='832'>
+        <var-decl name='_chain' type-id='type-id-66' visibility='default' filepath='/usr/include/bits/libio.h' line='266' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='896'>
+        <var-decl name='_fileno' type-id='type-id-15' visibility='default' filepath='/usr/include/bits/libio.h' line='268' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='928'>
+        <var-decl name='_flags2' type-id='type-id-15' visibility='default' filepath='/usr/include/bits/libio.h' line='272' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='960'>
+        <var-decl name='_old_offset' type-id='type-id-67' visibility='default' filepath='/usr/include/bits/libio.h' line='274' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1024'>
+        <var-decl name='_cur_column' type-id='type-id-24' visibility='default' filepath='/usr/include/bits/libio.h' line='278' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1040'>
+        <var-decl name='_vtable_offset' type-id='type-id-68' visibility='default' filepath='/usr/include/bits/libio.h' line='279' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1048'>
+        <var-decl name='_shortbuf' type-id='type-id-69' visibility='default' filepath='/usr/include/bits/libio.h' line='280' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1152'>
+        <var-decl name='_offset' type-id='type-id-70' visibility='default' filepath='/usr/include/bits/libio.h' line='293' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1216'>
+        <var-decl name='__pad1' type-id='type-id-71' visibility='default' filepath='/usr/include/bits/libio.h' line='301' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1280'>
+        <var-decl name='__pad2' type-id='type-id-71' visibility='default' filepath='/usr/include/bits/libio.h' line='302' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1344'>
+        <var-decl name='__pad3' type-id='type-id-71' visibility='default' filepath='/usr/include/bits/libio.h' line='303' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1408'>
+        <var-decl name='__pad4' type-id='type-id-71' visibility='default' filepath='/usr/include/bits/libio.h' line='304' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1472'>
+        <var-decl name='__pad5' type-id='type-id-33' visibility='default' filepath='/usr/include/bits/libio.h' line='306' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1536'>
+        <var-decl name='_mode' type-id='type-id-15' visibility='default' filepath='/usr/include/bits/libio.h' line='307' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='1568'>
+        <var-decl name='_unused2' type-id='type-id-72' visibility='default' filepath='/usr/include/bits/libio.h' line='309' column='1'/>
+      </data-member>
+    </class-decl>
+    <class-decl name='_IO_marker' size-in-bits='192' is-struct='yes' visibility='default' filepath='/usr/include/bits/libio.h' line='160' column='1' id='type-id-73'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='_next' type-id='type-id-65' visibility='default' filepath='/usr/include/bits/libio.h' line='161' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='64'>
+        <var-decl name='_sbuf' type-id='type-id-66' visibility='default' filepath='/usr/include/bits/libio.h' line='162' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='128'>
+        <var-decl name='_pos' type-id='type-id-15' visibility='default' filepath='/usr/include/bits/libio.h' line='166' column='1'/>
+      </data-member>
+    </class-decl>
+    <pointer-type-def type-id='type-id-73' size-in-bits='64' id='type-id-65'/>
+    <pointer-type-def type-id='type-id-64' size-in-bits='64' id='type-id-66'/>
+    <typedef-decl name='__off_t' type-id='type-id-59' filepath='/usr/include/bits/types.h' line='140' column='1' id='type-id-67'/>
+    <type-decl name='signed char' size-in-bits='8' id='type-id-68'/>
+
+    <array-type-def dimensions='1' type-id='type-id-12' size-in-bits='8' id='type-id-69'>
+      <subrange length='1' type-id='type-id-13' id='type-id-74'/>
+
+    </array-type-def>
+    <typedef-decl name='__off64_t' type-id='type-id-59' filepath='/usr/include/bits/types.h' line='141' column='1' id='type-id-70'/>
+    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-71'/>
+
+    <array-type-def dimensions='1' type-id='type-id-12' size-in-bits='160' id='type-id-72'>
+      <subrange length='20' type-id='type-id-13' id='type-id-75'/>
+
+    </array-type-def>
+    <typedef-decl name='FILE' type-id='type-id-64' filepath='/usr/include/bits/types/FILE.h' line='7' column='1' id='type-id-76'/>
+    <pointer-type-def type-id='type-id-76' size-in-bits='64' id='type-id-77'/>
+    <function-decl name='efi_set_verbose' mangled-name='efi_set_verbose' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_set_verbose@@LIBEFIVAR_1.36'>
+      <parameter type-id='type-id-15' name='verbosity'/>
+      <parameter type-id='type-id-77' name='errlog'/>
       <return type-id='type-id-62'/>
     </function-decl>
-    <function-decl name='efi_error_set' mangled-name='efi_error_set' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='82' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_error_set@@LIBEFIVAR_1.30'>
-      <parameter type-id='type-id-31' name='filename' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='82' column='1'/>
-      <parameter type-id='type-id-31' name='function' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='83' column='1'/>
-      <parameter type-id='type-id-15' name='line' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='84' column='1'/>
-      <parameter type-id='type-id-15' name='error' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='85' column='1'/>
-      <parameter type-id='type-id-31' name='fmt' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='86' column='1'/>
+    <function-decl name='efi_get_logfile' mangled-name='efi_get_logfile' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_get_logfile@@LIBEFIVAR_1.36'>
+      <return type-id='type-id-77'/>
+    </function-decl>
+    <function-decl name='efi_error_clear' mangled-name='efi_error_clear' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_error_clear@@LIBEFIVAR_1.30'>
+      <return type-id='type-id-62'/>
+    </function-decl>
+    <function-decl name='efi_error_set' mangled-name='efi_error_set' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_error_set@@LIBEFIVAR_1.30'>
+      <parameter type-id='type-id-31' name='filename'/>
+      <parameter type-id='type-id-31' name='function'/>
+      <parameter type-id='type-id-15' name='line'/>
+      <parameter type-id='type-id-15' name='error'/>
+      <parameter type-id='type-id-31' name='fmt'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-47' const='yes' id='type-id-64'/>
-    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-65'/>
-    <function-decl name='efi_error_get' mangled-name='efi_error_get' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='53' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_error_get@@LIBEFIVAR_1.30'>
-      <parameter type-id='type-id-22' name='n' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='53' column='1'/>
-      <parameter type-id='type-id-64' name='filename' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='54' column='1'/>
-      <parameter type-id='type-id-64' name='function' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='55' column='1'/>
-      <parameter type-id='type-id-65' name='line' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='56' column='1'/>
-      <parameter type-id='type-id-64' name='message' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='57' column='1'/>
-      <parameter type-id='type-id-65' name='error' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='58' column='1'/>
-      <parameter type-id='type-id-22' name='n' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='53' column='1'/>
-      <parameter type-id='type-id-64' name='filename' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='54' column='1'/>
-      <parameter type-id='type-id-64' name='function' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='55' column='1'/>
-      <parameter type-id='type-id-65' name='line' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='56' column='1'/>
-      <parameter type-id='type-id-64' name='message' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='57' column='1'/>
-      <parameter type-id='type-id-65' name='error' filepath='/home/pjones/devel/github.com/efivar/master/src/util.h' line='58' column='1'/>
+    <qualified-type-def type-id='type-id-47' const='yes' id='type-id-78'/>
+    <pointer-type-def type-id='type-id-15' size-in-bits='64' id='type-id-79'/>
+    <function-decl name='efi_error_get' mangled-name='efi_error_get' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_error_get@@LIBEFIVAR_1.30'>
+      <parameter type-id='type-id-22' name='n'/>
+      <parameter type-id='type-id-78' name='filename'/>
+      <parameter type-id='type-id-78' name='function'/>
+      <parameter type-id='type-id-79' name='line'/>
+      <parameter type-id='type-id-78' name='message'/>
+      <parameter type-id='type-id-79' name='error'/>
+      <parameter type-id='type-id-22' name='n'/>
+      <parameter type-id='type-id-78' name='filename'/>
+      <parameter type-id='type-id-78' name='function'/>
+      <parameter type-id='type-id-79' name='line'/>
+      <parameter type-id='type-id-78' name='message'/>
+      <parameter type-id='type-id-79' name='error'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efidp_make_nvdimm' mangled-name='efidp_make_nvdimm' filepath='/usr/include/bits/byteswap.h' line='813' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_nvdimm@@LIBEFIVAR_1.33'>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='813' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='813' column='1'/>
-      <parameter type-id='type-id-44' name='uuid' filepath='/usr/include/bits/byteswap.h' line='813' column='1'/>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='813' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='813' column='1'/>
-      <parameter type-id='type-id-44' name='uuid' filepath='/usr/include/bits/byteswap.h' line='813' column='1'/>
+    <function-decl name='efidp_make_nvdimm' mangled-name='efidp_make_nvdimm' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_nvdimm@@LIBEFIVAR_1.33'>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-44' name='uuid'/>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-44' name='uuid'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_make_sas' mangled-name='efidp_make_sas' filepath='/usr/include/bits/byteswap.h' line='787' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_sas@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='787' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='787' column='1'/>
-      <parameter type-id='type-id-54' name='sas_address' filepath='/usr/include/bits/byteswap.h' line='787' column='1'/>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='787' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='787' column='1'/>
-      <parameter type-id='type-id-54' name='sas_address' filepath='/usr/include/bits/byteswap.h' line='787' column='1'/>
+    <function-decl name='efidp_make_sas' mangled-name='efidp_make_sas' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_sas@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-54' name='sas_address'/>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-54' name='sas_address'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_make_atapi' mangled-name='efidp_make_atapi' filepath='/usr/include/bits/byteswap.h' line='763' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_atapi@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='763' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='763' column='1'/>
-      <parameter type-id='type-id-20' name='primary' filepath='/usr/include/bits/byteswap.h' line='763' column='1'/>
-      <parameter type-id='type-id-20' name='slave' filepath='/usr/include/bits/byteswap.h' line='764' column='1'/>
-      <parameter type-id='type-id-20' name='lun' filepath='/usr/include/bits/byteswap.h' line='764' column='1'/>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='763' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='763' column='1'/>
-      <parameter type-id='type-id-20' name='primary' filepath='/usr/include/bits/byteswap.h' line='763' column='1'/>
-      <parameter type-id='type-id-20' name='slave' filepath='/usr/include/bits/byteswap.h' line='764' column='1'/>
-      <parameter type-id='type-id-20' name='lun' filepath='/usr/include/bits/byteswap.h' line='764' column='1'/>
+    <function-decl name='efidp_make_atapi' mangled-name='efidp_make_atapi' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_atapi@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-20' name='primary'/>
+      <parameter type-id='type-id-20' name='slave'/>
+      <parameter type-id='type-id-20' name='lun'/>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-20' name='primary'/>
+      <parameter type-id='type-id-20' name='slave'/>
+      <parameter type-id='type-id-20' name='lun'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <type-decl name='short int' size-in-bits='16' id='type-id-66'/>
-    <typedef-decl name='__int16_t' type-id='type-id-66' filepath='/usr/include/bits/types.h' line='38' column='1' id='type-id-67'/>
-    <typedef-decl name='int16_t' type-id='type-id-67' filepath='/usr/include/bits/stdint-intn.h' line='25' column='1' id='type-id-68'/>
-    <function-decl name='efidp_make_sata' mangled-name='efidp_make_sata' filepath='/usr/include/bits/byteswap.h' line='740' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_sata@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='740' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='740' column='1'/>
-      <parameter type-id='type-id-20' name='hba_port' filepath='/usr/include/bits/byteswap.h' line='740' column='1'/>
-      <parameter type-id='type-id-68' name='port_multiplier_port' filepath='/usr/include/bits/byteswap.h' line='741' column='1'/>
-      <parameter type-id='type-id-20' name='lun' filepath='/usr/include/bits/byteswap.h' line='741' column='1'/>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='740' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='740' column='1'/>
-      <parameter type-id='type-id-20' name='hba_port' filepath='/usr/include/bits/byteswap.h' line='740' column='1'/>
-      <parameter type-id='type-id-68' name='port_multiplier_port' filepath='/usr/include/bits/byteswap.h' line='741' column='1'/>
-      <parameter type-id='type-id-20' name='lun' filepath='/usr/include/bits/byteswap.h' line='741' column='1'/>
+    <type-decl name='short int' size-in-bits='16' id='type-id-80'/>
+    <typedef-decl name='__int16_t' type-id='type-id-80' filepath='/usr/include/bits/types.h' line='38' column='1' id='type-id-81'/>
+    <typedef-decl name='int16_t' type-id='type-id-81' filepath='/usr/include/bits/stdint-intn.h' line='25' column='1' id='type-id-82'/>
+    <function-decl name='efidp_make_sata' mangled-name='efidp_make_sata' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_sata@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-20' name='hba_port'/>
+      <parameter type-id='type-id-82' name='port_multiplier_port'/>
+      <parameter type-id='type-id-20' name='lun'/>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-20' name='hba_port'/>
+      <parameter type-id='type-id-82' name='port_multiplier_port'/>
+      <parameter type-id='type-id-20' name='lun'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_make_nvme' mangled-name='efidp_make_nvme' filepath='/usr/include/bits/byteswap.h' line='713' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_nvme@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='713' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='713' column='1'/>
-      <parameter type-id='type-id-19' name='namespace_id' filepath='/usr/include/bits/byteswap.h' line='713' column='1'/>
-      <parameter type-id='type-id-32' name='ieee_eui_64' filepath='/usr/include/bits/byteswap.h' line='714' column='1'/>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='713' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='713' column='1'/>
-      <parameter type-id='type-id-19' name='namespace_id' filepath='/usr/include/bits/byteswap.h' line='713' column='1'/>
-      <parameter type-id='type-id-32' name='ieee_eui_64' filepath='/usr/include/bits/byteswap.h' line='714' column='1'/>
+    <function-decl name='efidp_make_nvme' mangled-name='efidp_make_nvme' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_nvme@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-19' name='namespace_id'/>
+      <parameter type-id='type-id-32' name='ieee_eui_64'/>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-19' name='namespace_id'/>
+      <parameter type-id='type-id-32' name='ieee_eui_64'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_make_scsi' mangled-name='efidp_make_scsi' filepath='/usr/include/bits/byteswap.h' line='694' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_scsi@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
-      <parameter type-id='type-id-20' name='target' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
-      <parameter type-id='type-id-20' name='lun' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
-      <parameter type-id='type-id-20' name='target' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
-      <parameter type-id='type-id-20' name='lun' filepath='/usr/include/bits/byteswap.h' line='694' column='1'/>
+    <function-decl name='efidp_make_scsi' mangled-name='efidp_make_scsi' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_scsi@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-20' name='target'/>
+      <parameter type-id='type-id-20' name='lun'/>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-20' name='target'/>
+      <parameter type-id='type-id-20' name='lun'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_make_ipv4' mangled-name='efidp_make_ipv4' filepath='/usr/include/bits/byteswap.h' line='664' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_ipv4@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='664' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='664' column='1'/>
-      <parameter type-id='type-id-19' name='local' filepath='/usr/include/bits/byteswap.h' line='664' column='1'/>
-      <parameter type-id='type-id-19' name='remote' filepath='/usr/include/bits/byteswap.h' line='664' column='1'/>
-      <parameter type-id='type-id-19' name='gateway' filepath='/usr/include/bits/byteswap.h' line='665' column='1'/>
-      <parameter type-id='type-id-19' name='netmask' filepath='/usr/include/bits/byteswap.h' line='665' column='1'/>
-      <parameter type-id='type-id-20' name='local_port' filepath='/usr/include/bits/byteswap.h' line='666' column='1'/>
-      <parameter type-id='type-id-20' name='remote_port' filepath='/usr/include/bits/byteswap.h' line='666' column='1'/>
-      <parameter type-id='type-id-20' name='protocol' filepath='/usr/include/bits/byteswap.h' line='667' column='1'/>
-      <parameter type-id='type-id-15' name='is_static' filepath='/usr/include/bits/byteswap.h' line='667' column='1'/>
+    <function-decl name='efidp_make_ipv4' mangled-name='efidp_make_ipv4' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_ipv4@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-19' name='local'/>
+      <parameter type-id='type-id-19' name='remote'/>
+      <parameter type-id='type-id-19' name='gateway'/>
+      <parameter type-id='type-id-19' name='netmask'/>
+      <parameter type-id='type-id-20' name='local_port'/>
+      <parameter type-id='type-id-20' name='remote_port'/>
+      <parameter type-id='type-id-20' name='protocol'/>
+      <parameter type-id='type-id-15' name='is_static'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-69'/>
-    <pointer-type-def type-id='type-id-69' size-in-bits='64' id='type-id-70'/>
-    <qualified-type-def type-id='type-id-70' const='yes' id='type-id-71'/>
-    <function-decl name='efidp_make_mac_addr' mangled-name='efidp_make_mac_addr' filepath='/usr/include/bits/byteswap.h' line='642' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_mac_addr@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='642' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='642' column='1'/>
-      <parameter type-id='type-id-28' name='if_type' filepath='/usr/include/bits/byteswap.h' line='642' column='1'/>
-      <parameter type-id='type-id-71' name='mac_addr' filepath='/usr/include/bits/byteswap.h' line='643' column='1'/>
-      <parameter type-id='type-id-61' name='mac_addr_size' filepath='/usr/include/bits/byteswap.h' line='643' column='1'/>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/bits/byteswap.h' line='642' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/bits/byteswap.h' line='642' column='1'/>
-      <parameter type-id='type-id-28' name='if_type' filepath='/usr/include/bits/byteswap.h' line='642' column='1'/>
-      <parameter type-id='type-id-71' name='mac_addr' filepath='/usr/include/bits/byteswap.h' line='643' column='1'/>
-      <parameter type-id='type-id-61' name='mac_addr_size' filepath='/usr/include/bits/byteswap.h' line='643' column='1'/>
+    <qualified-type-def type-id='type-id-28' const='yes' id='type-id-83'/>
+    <pointer-type-def type-id='type-id-83' size-in-bits='64' id='type-id-84'/>
+    <qualified-type-def type-id='type-id-84' const='yes' id='type-id-85'/>
+    <function-decl name='efidp_make_mac_addr' mangled-name='efidp_make_mac_addr' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_mac_addr@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-28' name='if_type'/>
+      <parameter type-id='type-id-85' name='mac_addr'/>
+      <parameter type-id='type-id-61' name='mac_addr_size'/>
+      <parameter type-id='type-id-32' name='buf'/>
+      <parameter type-id='type-id-61' name='size'/>
+      <parameter type-id='type-id-28' name='if_type'/>
+      <parameter type-id='type-id-85' name='mac_addr'/>
+      <parameter type-id='type-id-61' name='mac_addr_size'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_make_hd' mangled-name='efidp_make_hd' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_hd@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
-      <parameter type-id='type-id-19' name='num' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
-      <parameter type-id='type-id-54' name='part_start' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
-      <parameter type-id='type-id-54' name='part_size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='180' column='1'/>
-      <parameter type-id='type-id-32' name='signature' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='180' column='1'/>
-      <parameter type-id='type-id-28' name='format' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='180' column='1'/>
-      <parameter type-id='type-id-28' name='signature_type' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='181' column='1'/>
-      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
-      <parameter type-id='type-id-19' name='num' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
-      <parameter type-id='type-id-54' name='part_start' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='179' column='1'/>
-      <parameter type-id='type-id-54' name='part_size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='180' column='1'/>
-      <parameter type-id='type-id-32' name='signature' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='180' column='1'/>
-      <parameter type-id='type-id-28' name='format' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='180' column='1'/>
-      <parameter type-id='type-id-28' name='signature_type' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='181' column='1'/>
+    <function-decl name='efidp_make_hd' mangled-name='efidp_make_hd' filepath='src/&lt;built-in&gt;' line='178' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_hd@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='src/&lt;built-in&gt;' line='178' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='src/&lt;built-in&gt;' line='178' column='1'/>
+      <parameter type-id='type-id-19' name='num' filepath='src/&lt;built-in&gt;' line='178' column='1'/>
+      <parameter type-id='type-id-54' name='part_start' filepath='src/&lt;built-in&gt;' line='178' column='1'/>
+      <parameter type-id='type-id-54' name='part_size' filepath='src/&lt;built-in&gt;' line='179' column='1'/>
+      <parameter type-id='type-id-32' name='signature' filepath='src/&lt;built-in&gt;' line='179' column='1'/>
+      <parameter type-id='type-id-28' name='format' filepath='src/&lt;built-in&gt;' line='179' column='1'/>
+      <parameter type-id='type-id-28' name='signature_type' filepath='src/&lt;built-in&gt;' line='180' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='src/&lt;built-in&gt;' line='178' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='src/&lt;built-in&gt;' line='178' column='1'/>
+      <parameter type-id='type-id-19' name='num' filepath='src/&lt;built-in&gt;' line='178' column='1'/>
+      <parameter type-id='type-id-54' name='part_start' filepath='src/&lt;built-in&gt;' line='178' column='1'/>
+      <parameter type-id='type-id-54' name='part_size' filepath='src/&lt;built-in&gt;' line='179' column='1'/>
+      <parameter type-id='type-id-32' name='signature' filepath='src/&lt;built-in&gt;' line='179' column='1'/>
+      <parameter type-id='type-id-28' name='format' filepath='src/&lt;built-in&gt;' line='179' column='1'/>
+      <parameter type-id='type-id-28' name='signature_type' filepath='src/&lt;built-in&gt;' line='180' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_make_file' mangled-name='efidp_make_file' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_file@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='157' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='157' column='1'/>
-      <parameter type-id='type-id-46' name='filepath' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='157' column='1'/>
-      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='157' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='157' column='1'/>
-      <parameter type-id='type-id-46' name='filepath' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='157' column='1'/>
+    <function-decl name='efidp_make_file' mangled-name='efidp_make_file' filepath='src/&lt;built-in&gt;' line='157' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_file@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='src/&lt;built-in&gt;' line='157' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='src/&lt;built-in&gt;' line='157' column='1'/>
+      <parameter type-id='type-id-46' name='filepath' filepath='src/&lt;built-in&gt;' line='157' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='src/&lt;built-in&gt;' line='157' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='src/&lt;built-in&gt;' line='157' column='1'/>
+      <parameter type-id='type-id-46' name='filepath' filepath='src/&lt;built-in&gt;' line='157' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_make_edd10' mangled-name='efidp_make_edd10' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_edd10@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
-      <parameter type-id='type-id-19' name='hardware_device' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
-      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
-      <parameter type-id='type-id-19' name='hardware_device' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
+    <function-decl name='efidp_make_edd10' mangled-name='efidp_make_edd10' filepath='src/&lt;built-in&gt;' line='105' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_edd10@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='src/&lt;built-in&gt;' line='105' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='src/&lt;built-in&gt;' line='105' column='1'/>
+      <parameter type-id='type-id-19' name='hardware_device' filepath='src/&lt;built-in&gt;' line='105' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='src/&lt;built-in&gt;' line='105' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='src/&lt;built-in&gt;' line='105' column='1'/>
+      <parameter type-id='type-id-19' name='hardware_device' filepath='src/&lt;built-in&gt;' line='105' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_make_pci' mangled-name='efidp_make_pci' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_pci@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
-      <parameter type-id='type-id-28' name='device' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
-      <parameter type-id='type-id-28' name='function' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
-      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
-      <parameter type-id='type-id-28' name='device' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
-      <parameter type-id='type-id-28' name='function' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='86' column='1'/>
+    <function-decl name='efidp_make_pci' mangled-name='efidp_make_pci' filepath='src/&lt;built-in&gt;' line='86' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_pci@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='src/&lt;built-in&gt;' line='86' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='src/&lt;built-in&gt;' line='86' column='1'/>
+      <parameter type-id='type-id-28' name='device' filepath='src/&lt;built-in&gt;' line='86' column='1'/>
+      <parameter type-id='type-id-28' name='function' filepath='src/&lt;built-in&gt;' line='86' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='src/&lt;built-in&gt;' line='86' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='src/&lt;built-in&gt;' line='86' column='1'/>
+      <parameter type-id='type-id-28' name='device' filepath='src/&lt;built-in&gt;' line='86' column='1'/>
+      <parameter type-id='type-id-28' name='function' filepath='src/&lt;built-in&gt;' line='86' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_make_acpi_hid_ex' mangled-name='efidp_make_acpi_hid_ex' filepath='/usr/include/sys/stat.h' line='239' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_acpi_hid_ex@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/sys/stat.h' line='239' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/sys/stat.h' line='239' column='1'/>
-      <parameter type-id='type-id-19' name='hid' filepath='/usr/include/sys/stat.h' line='240' column='1'/>
-      <parameter type-id='type-id-19' name='uid' filepath='/usr/include/sys/stat.h' line='240' column='1'/>
-      <parameter type-id='type-id-19' name='cid' filepath='/usr/include/sys/stat.h' line='240' column='1'/>
-      <parameter type-id='type-id-46' name='hidstr' filepath='/usr/include/sys/stat.h' line='241' column='1'/>
-      <parameter type-id='type-id-46' name='uidstr' filepath='/usr/include/sys/stat.h' line='241' column='1'/>
-      <parameter type-id='type-id-46' name='cidstr' filepath='/usr/include/sys/stat.h' line='241' column='1'/>
+    <function-decl name='efidp_make_acpi_hid_ex' mangled-name='efidp_make_acpi_hid_ex' filepath='src/&lt;built-in&gt;' line='263' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_acpi_hid_ex@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='src/&lt;built-in&gt;' line='263' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='src/&lt;built-in&gt;' line='263' column='1'/>
+      <parameter type-id='type-id-19' name='hid' filepath='src/&lt;built-in&gt;' line='264' column='1'/>
+      <parameter type-id='type-id-19' name='uid' filepath='src/&lt;built-in&gt;' line='264' column='1'/>
+      <parameter type-id='type-id-19' name='cid' filepath='src/&lt;built-in&gt;' line='264' column='1'/>
+      <parameter type-id='type-id-31' name='hidstr' filepath='src/&lt;built-in&gt;' line='265' column='1'/>
+      <parameter type-id='type-id-31' name='uidstr' filepath='src/&lt;built-in&gt;' line='265' column='1'/>
+      <parameter type-id='type-id-31' name='cidstr' filepath='src/&lt;built-in&gt;' line='266' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_make_acpi_hid' mangled-name='efidp_make_acpi_hid' filepath='/usr/include/sys/stat.h' line='217' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_acpi_hid@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
-      <parameter type-id='type-id-19' name='hid' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
-      <parameter type-id='type-id-19' name='uid' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
-      <parameter type-id='type-id-32' name='buf' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
-      <parameter type-id='type-id-19' name='hid' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
-      <parameter type-id='type-id-19' name='uid' filepath='/usr/include/sys/stat.h' line='217' column='1'/>
+    <function-decl name='efidp_make_acpi_hid' mangled-name='efidp_make_acpi_hid' filepath='src/&lt;built-in&gt;' line='243' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_acpi_hid@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='src/&lt;built-in&gt;' line='243' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='src/&lt;built-in&gt;' line='243' column='1'/>
+      <parameter type-id='type-id-19' name='hid' filepath='src/&lt;built-in&gt;' line='243' column='1'/>
+      <parameter type-id='type-id-19' name='uid' filepath='src/&lt;built-in&gt;' line='243' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='src/&lt;built-in&gt;' line='243' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='src/&lt;built-in&gt;' line='243' column='1'/>
+      <parameter type-id='type-id-19' name='hid' filepath='src/&lt;built-in&gt;' line='243' column='1'/>
+      <parameter type-id='type-id-19' name='uid' filepath='src/&lt;built-in&gt;' line='243' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_make_generic' mangled-name='efidp_make_generic' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_generic@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
-      <parameter type-id='type-id-28' name='type' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
-      <parameter type-id='type-id-28' name='subtype' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
-      <parameter type-id='type-id-61' name='total_size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='452' column='1'/>
-      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
-      <parameter type-id='type-id-28' name='type' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
-      <parameter type-id='type-id-28' name='subtype' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='451' column='1'/>
-      <parameter type-id='type-id-61' name='total_size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='452' column='1'/>
+    <function-decl name='efidp_make_generic' mangled-name='efidp_make_generic' filepath='src/dp-acpi.c' line='439' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_generic@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='src/dp-acpi.c' line='439' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='src/dp-acpi.c' line='439' column='1'/>
+      <parameter type-id='type-id-28' name='type' filepath='src/dp-acpi.c' line='439' column='1'/>
+      <parameter type-id='type-id-28' name='subtype' filepath='src/dp-acpi.c' line='439' column='1'/>
+      <parameter type-id='type-id-61' name='total_size' filepath='src/dp-acpi.c' line='440' column='1'/>
+      <parameter type-id='type-id-32' name='buf' filepath='src/dp-acpi.c' line='439' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='src/dp-acpi.c' line='439' column='1'/>
+      <parameter type-id='type-id-28' name='type' filepath='src/dp-acpi.c' line='439' column='1'/>
+      <parameter type-id='type-id-28' name='subtype' filepath='src/dp-acpi.c' line='439' column='1'/>
+      <parameter type-id='type-id-61' name='total_size' filepath='src/dp-acpi.c' line='440' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-62' size-in-bits='64' id='type-id-72'/>
-    <function-decl name='efidp_make_vendor' mangled-name='efidp_make_vendor' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='434' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_vendor@@libefivar.so.0'>
-      <parameter type-id='type-id-32' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='434' column='1'/>
-      <parameter type-id='type-id-61' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='434' column='1'/>
-      <parameter type-id='type-id-28' name='type' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='434' column='1'/>
-      <parameter type-id='type-id-28' name='subtype' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='434' column='1'/>
-      <parameter type-id='type-id-17' name='vendor_guid' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='435' column='1'/>
-      <parameter type-id='type-id-72' name='data' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='435' column='1'/>
-      <parameter type-id='type-id-33' name='data_size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='435' column='1'/>
+    <function-decl name='efidp_make_vendor' mangled-name='efidp_make_vendor' filepath='src/dp-acpi.c' line='423' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_make_vendor@@libefivar.so.0'>
+      <parameter type-id='type-id-32' name='buf' filepath='src/dp-acpi.c' line='423' column='1'/>
+      <parameter type-id='type-id-61' name='size' filepath='src/dp-acpi.c' line='423' column='1'/>
+      <parameter type-id='type-id-28' name='type' filepath='src/dp-acpi.c' line='423' column='1'/>
+      <parameter type-id='type-id-28' name='subtype' filepath='src/dp-acpi.c' line='423' column='1'/>
+      <parameter type-id='type-id-17' name='vendor_guid' filepath='src/dp-acpi.c' line='424' column='1'/>
+      <parameter type-id='type-id-71' name='data' filepath='src/dp-acpi.c' line='424' column='1'/>
+      <parameter type-id='type-id-33' name='data_size' filepath='src/dp-acpi.c' line='424' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='832' column='1' id='type-id-73'>
+    <union-decl name='__anonymous_union__' size-in-bits='384' is-anonymous='yes' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='833' column='1' id='type-id-86'>
       <data-member access='private'>
-        <var-decl name='' type-id='type-id-74' visibility='default'/>
+        <var-decl name='' type-id='type-id-87' visibility='default'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='838' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='839' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='pci' type-id='type-id-76' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='839' column='1'/>
+        <var-decl name='pci' type-id='type-id-89' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='840' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='pccard' type-id='type-id-77' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='840' column='1'/>
+        <var-decl name='pccard' type-id='type-id-90' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='841' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='mmio' type-id='type-id-78' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='841' column='1'/>
+        <var-decl name='mmio' type-id='type-id-91' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='842' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='hw_vendor' type-id='type-id-79' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='842' column='1'/>
+        <var-decl name='hw_vendor' type-id='type-id-92' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='843' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='controller' type-id='type-id-80' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='843' column='1'/>
+        <var-decl name='controller' type-id='type-id-93' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='844' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='bmc' type-id='type-id-81' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='844' column='1'/>
+        <var-decl name='bmc' type-id='type-id-94' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='845' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='acpi_hid' type-id='type-id-82' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='845' column='1'/>
+        <var-decl name='acpi_hid' type-id='type-id-95' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='846' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='acpi_hid_ex' type-id='type-id-83' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='846' column='1'/>
+        <var-decl name='acpi_hid_ex' type-id='type-id-96' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='847' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='acpi_adr' type-id='type-id-84' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='847' column='1'/>
+        <var-decl name='acpi_adr' type-id='type-id-97' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='848' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='atapi' type-id='type-id-85' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='848' column='1'/>
+        <var-decl name='atapi' type-id='type-id-98' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='849' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='scsi' type-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='849' column='1'/>
+        <var-decl name='scsi' type-id='type-id-99' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='850' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='fc' type-id='type-id-87' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='850' column='1'/>
+        <var-decl name='fc' type-id='type-id-100' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='851' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='fcex' type-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='851' column='1'/>
+        <var-decl name='fcex' type-id='type-id-101' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='852' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='firewire' type-id='type-id-89' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='852' column='1'/>
+        <var-decl name='firewire' type-id='type-id-102' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='853' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='usb' type-id='type-id-90' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='853' column='1'/>
+        <var-decl name='usb' type-id='type-id-103' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='854' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='usb_class' type-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='854' column='1'/>
+        <var-decl name='usb_class' type-id='type-id-104' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='855' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='usb_wwid' type-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='855' column='1'/>
+        <var-decl name='usb_wwid' type-id='type-id-105' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='856' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='lun' type-id='type-id-93' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='856' column='1'/>
+        <var-decl name='lun' type-id='type-id-106' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='857' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sata' type-id='type-id-94' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='857' column='1'/>
+        <var-decl name='sata' type-id='type-id-107' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='858' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='i2o' type-id='type-id-95' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='858' column='1'/>
+        <var-decl name='i2o' type-id='type-id-108' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='859' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='mac_addr' type-id='type-id-96' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='859' column='1'/>
+        <var-decl name='mac_addr' type-id='type-id-109' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='860' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='ipv4_addr' type-id='type-id-97' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='860' column='1'/>
+        <var-decl name='ipv4_addr' type-id='type-id-110' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='861' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='ipv6_addr' type-id='type-id-98' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='861' column='1'/>
+        <var-decl name='ipv6_addr' type-id='type-id-111' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='862' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='vlan' type-id='type-id-99' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='862' column='1'/>
+        <var-decl name='vlan' type-id='type-id-112' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='863' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='infiniband' type-id='type-id-100' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='863' column='1'/>
+        <var-decl name='infiniband' type-id='type-id-113' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='864' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='uart' type-id='type-id-101' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='864' column='1'/>
+        <var-decl name='uart' type-id='type-id-114' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='865' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='msg_vendor' type-id='type-id-102' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='865' column='1'/>
+        <var-decl name='msg_vendor' type-id='type-id-115' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='866' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='uart_flow_control' type-id='type-id-103' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='866' column='1'/>
+        <var-decl name='uart_flow_control' type-id='type-id-116' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='867' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sas' type-id='type-id-104' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='867' column='1'/>
+        <var-decl name='sas' type-id='type-id-117' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='868' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sas_ex' type-id='type-id-105' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='868' column='1'/>
+        <var-decl name='sas_ex' type-id='type-id-118' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='869' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='iscsi' type-id='type-id-106' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='869' column='1'/>
+        <var-decl name='iscsi' type-id='type-id-119' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='870' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='nvme' type-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='870' column='1'/>
+        <var-decl name='nvme' type-id='type-id-120' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='871' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='uri' type-id='type-id-108' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='871' column='1'/>
+        <var-decl name='uri' type-id='type-id-121' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='872' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='ufs' type-id='type-id-109' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='872' column='1'/>
+        <var-decl name='ufs' type-id='type-id-122' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='873' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='sd' type-id='type-id-110' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='873' column='1'/>
+        <var-decl name='sd' type-id='type-id-123' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='874' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='bt' type-id='type-id-111' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='874' column='1'/>
+        <var-decl name='bt' type-id='type-id-124' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='875' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='wifi' type-id='type-id-112' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='875' column='1'/>
+        <var-decl name='wifi' type-id='type-id-125' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='876' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='emmc' type-id='type-id-113' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='876' column='1'/>
+        <var-decl name='emmc' type-id='type-id-126' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='877' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='btle' type-id='type-id-114' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='877' column='1'/>
+        <var-decl name='btle' type-id='type-id-127' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='878' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='dns' type-id='type-id-115' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='878' column='1'/>
+        <var-decl name='dns' type-id='type-id-128' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='879' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='nvdimm' type-id='type-id-116' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='879' column='1'/>
+        <var-decl name='nvdimm' type-id='type-id-129' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='880' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='hd' type-id='type-id-117' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='880' column='1'/>
+        <var-decl name='hd' type-id='type-id-130' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='881' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='cdrom' type-id='type-id-118' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='881' column='1'/>
+        <var-decl name='cdrom' type-id='type-id-131' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='882' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='media_vendor' type-id='type-id-119' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='882' column='1'/>
+        <var-decl name='media_vendor' type-id='type-id-132' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='883' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='file' type-id='type-id-120' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='883' column='1'/>
+        <var-decl name='file' type-id='type-id-133' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='884' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='protocol' type-id='type-id-121' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='884' column='1'/>
+        <var-decl name='protocol' type-id='type-id-134' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='885' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='firmware_file' type-id='type-id-122' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='885' column='1'/>
+        <var-decl name='firmware_file' type-id='type-id-135' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='886' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='firmware_volume' type-id='type-id-123' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='886' column='1'/>
+        <var-decl name='firmware_volume' type-id='type-id-136' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='887' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='relative_offset' type-id='type-id-124' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='887' column='1'/>
+        <var-decl name='relative_offset' type-id='type-id-137' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='888' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='ramdisk' type-id='type-id-125' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='888' column='1'/>
+        <var-decl name='ramdisk' type-id='type-id-138' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='889' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='bios_boot' type-id='type-id-126' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='889' column='1'/>
+        <var-decl name='bios_boot' type-id='type-id-139' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='890' column='1'/>
       </data-member>
     </union-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='833' column='1' id='type-id-74'>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='834' column='1' id='type-id-87'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='type' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='834' column='1'/>
+        <var-decl name='type' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='835' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8'>
-        <var-decl name='subtype' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='835' column='1'/>
+        <var-decl name='subtype' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='836' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='length' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='836' column='1'/>
+        <var-decl name='length' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='837' column='1'/>
       </data-member>
     </class-decl>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='36' column='1' id='type-id-127'>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='36' column='1' id='type-id-140'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='type' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='37' column='1'/>
+        <var-decl name='type' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='37' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='8'>
-        <var-decl name='subtype' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='38' column='1'/>
+        <var-decl name='subtype' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='38' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='16'>
-        <var-decl name='length' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='39' column='1'/>
+        <var-decl name='length' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='39' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_header' type-id='type-id-127' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='40' column='1' id='type-id-75'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-76' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='55' column='1' id='type-id-128'>
+    <typedef-decl name='efidp_header' type-id='type-id-140' filepath='src/include/efivar/efivar-dp.h' line='40' column='1' id='type-id-88'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-89' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='55' column='1' id='type-id-141'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='56' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='56' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='function' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='57' column='1'/>
+        <var-decl name='function' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='57' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='device' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='58' column='1'/>
+        <var-decl name='device' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='58' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_pci' type-id='type-id-128' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='59' column='1' id='type-id-76'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-77' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='64' column='1' id='type-id-129'>
+    <typedef-decl name='efidp_pci' type-id='type-id-141' filepath='src/include/efivar/efivar-dp.h' line='59' column='1' id='type-id-89'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-90' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='64' column='1' id='type-id-142'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='65' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='65' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='function' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='66' column='1'/>
+        <var-decl name='function' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='66' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_pccard' type-id='type-id-129' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='67' column='1' id='type-id-77'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-78' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='70' column='1' id='type-id-130'>
+    <typedef-decl name='efidp_pccard' type-id='type-id-142' filepath='src/include/efivar/efivar-dp.h' line='67' column='1' id='type-id-90'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-91' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='70' column='1' id='type-id-143'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='71' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='71' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='memory_type' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='72' column='1'/>
+        <var-decl name='memory_type' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='72' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='starting_address' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='73' column='1'/>
+        <var-decl name='starting_address' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='73' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='ending_address' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='74' column='1'/>
+        <var-decl name='ending_address' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='74' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_mmio' type-id='type-id-130' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='75' column='1' id='type-id-78'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-79' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='78' column='1' id='type-id-131'>
+    <typedef-decl name='efidp_mmio' type-id='type-id-143' filepath='src/include/efivar/efivar-dp.h' line='75' column='1' id='type-id-91'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-92' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='78' column='1' id='type-id-144'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='79' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='79' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='80' column='1'/>
+        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='80' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='vendor_data' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='81' column='1'/>
+        <var-decl name='vendor_data' type-id='type-id-145' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='81' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='8' id='type-id-132'>
-      <subrange length='1' type-id='type-id-13' id='type-id-133'/>
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='8' id='type-id-145'>
+      <subrange length='1' type-id='type-id-13' id='type-id-74'/>
 
     </array-type-def>
-    <typedef-decl name='efidp_hw_vendor' type-id='type-id-131' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='82' column='1' id='type-id-79'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-80' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='99' column='1' id='type-id-134'>
+    <typedef-decl name='efidp_hw_vendor' type-id='type-id-144' filepath='src/include/efivar/efivar-dp.h' line='82' column='1' id='type-id-92'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-93' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='99' column='1' id='type-id-146'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='100' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='100' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='controller' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='101' column='1'/>
+        <var-decl name='controller' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='101' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_controller' type-id='type-id-134' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='102' column='1' id='type-id-80'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='104' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-81' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='105' column='1' id='type-id-135'>
+    <typedef-decl name='efidp_controller' type-id='type-id-146' filepath='src/include/efivar/efivar-dp.h' line='102' column='1' id='type-id-93'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='104' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-94' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='105' column='1' id='type-id-147'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='106' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='106' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='interface_type' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='107' column='1'/>
+        <var-decl name='interface_type' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='107' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='base_addr' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='108' column='1'/>
+        <var-decl name='base_addr' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='108' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_bmc' type-id='type-id-135' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='109' column='1' id='type-id-81'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='96' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-82' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='119' column='1' id='type-id-136'>
+    <typedef-decl name='efidp_bmc' type-id='type-id-147' filepath='src/include/efivar/efivar-dp.h' line='109' column='1' id='type-id-94'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='96' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-95' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='119' column='1' id='type-id-148'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='120' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='120' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='hid' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='121' column='1'/>
+        <var-decl name='hid' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='121' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='uid' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='122' column='1'/>
+        <var-decl name='uid' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='122' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_acpi_hid' type-id='type-id-136' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='123' column='1' id='type-id-82'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-83' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='128' column='1' id='type-id-137'>
+    <typedef-decl name='efidp_acpi_hid' type-id='type-id-148' filepath='src/include/efivar/efivar-dp.h' line='123' column='1' id='type-id-95'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-96' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='128' column='1' id='type-id-149'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='129' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='129' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='hid' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='130' column='1'/>
+        <var-decl name='hid' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='130' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='uid' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='131' column='1'/>
+        <var-decl name='uid' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='131' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='cid' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='132' column='1'/>
+        <var-decl name='cid' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='132' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='hidstr' type-id='type-id-138' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='134' column='1'/>
+        <var-decl name='hidstr' type-id='type-id-69' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='134' column='1'/>
+      </data-member>
+    </class-decl>
+    <typedef-decl name='efidp_acpi_hid_ex' type-id='type-id-149' filepath='src/include/efivar/efivar-dp.h' line='135' column='1' id='type-id-96'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-97' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='166' column='1' id='type-id-150'>
+      <data-member access='public' layout-offset-in-bits='0'>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='167' column='1'/>
+      </data-member>
+      <data-member access='public' layout-offset-in-bits='32'>
+        <var-decl name='adr' type-id='type-id-151' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='168' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-12' size-in-bits='8' id='type-id-138'>
-      <subrange length='1' type-id='type-id-13' id='type-id-133'/>
+    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='32' id='type-id-151'>
+      <subrange length='1' type-id='type-id-13' id='type-id-74'/>
 
     </array-type-def>
-    <typedef-decl name='efidp_acpi_hid_ex' type-id='type-id-137' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='135' column='1' id='type-id-83'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-84' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='165' column='1' id='type-id-139'>
+    <typedef-decl name='efidp_acpi_adr' type-id='type-id-150' filepath='src/include/efivar/efivar-dp.h' line='169' column='1' id='type-id-97'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-98' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='327' column='1' id='type-id-152'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='166' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='328' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='adr' type-id='type-id-140' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='167' column='1'/>
-      </data-member>
-    </class-decl>
-
-    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='32' id='type-id-140'>
-      <subrange length='1' type-id='type-id-13' id='type-id-133'/>
-
-    </array-type-def>
-    <typedef-decl name='efidp_acpi_adr' type-id='type-id-139' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='168' column='1' id='type-id-84'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-85' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='326' column='1' id='type-id-141'>
-      <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='327' column='1'/>
-      </data-member>
-      <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='primary' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='328' column='1'/>
+        <var-decl name='primary' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='329' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='slave' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='329' column='1'/>
+        <var-decl name='slave' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='330' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='lun' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='330' column='1'/>
+        <var-decl name='lun' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='331' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_atapi' type-id='type-id-141' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='331' column='1' id='type-id-85'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-86' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='336' column='1' id='type-id-142'>
+    <typedef-decl name='efidp_atapi' type-id='type-id-152' filepath='src/include/efivar/efivar-dp.h' line='332' column='1' id='type-id-98'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-99' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='337' column='1' id='type-id-153'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='337' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='338' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='target' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='338' column='1'/>
+        <var-decl name='target' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='339' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='lun' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='339' column='1'/>
+        <var-decl name='lun' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='340' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_scsi' type-id='type-id-142' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='340' column='1' id='type-id-86'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-87' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='345' column='1' id='type-id-143'>
+    <typedef-decl name='efidp_scsi' type-id='type-id-153' filepath='src/include/efivar/efivar-dp.h' line='341' column='1' id='type-id-99'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-100' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='346' column='1' id='type-id-154'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='346' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='347' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='347' column='1'/>
+        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='348' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='wwn' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='348' column='1'/>
+        <var-decl name='wwn' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='349' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='lun' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='349' column='1'/>
+        <var-decl name='lun' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='350' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_fc' type-id='type-id-143' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='350' column='1' id='type-id-87'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-88' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='353' column='1' id='type-id-144'>
+    <typedef-decl name='efidp_fc' type-id='type-id-154' filepath='src/include/efivar/efivar-dp.h' line='351' column='1' id='type-id-100'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-101' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='354' column='1' id='type-id-155'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='354' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='355' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='355' column='1'/>
+        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='356' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='wwn' type-id='type-id-145' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='356' column='1'/>
+        <var-decl name='wwn' type-id='type-id-156' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='357' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='lun' type-id='type-id-145' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='357' column='1'/>
+        <var-decl name='lun' type-id='type-id-156' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='358' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='64' id='type-id-145'>
-      <subrange length='8' type-id='type-id-13' id='type-id-146'/>
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='64' id='type-id-156'>
+      <subrange length='8' type-id='type-id-13' id='type-id-157'/>
 
     </array-type-def>
-    <typedef-decl name='efidp_fcex' type-id='type-id-144' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='358' column='1' id='type-id-88'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-89' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='361' column='1' id='type-id-147'>
+    <typedef-decl name='efidp_fcex' type-id='type-id-155' filepath='src/include/efivar/efivar-dp.h' line='359' column='1' id='type-id-101'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-102' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='362' column='1' id='type-id-158'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='362' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='363' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='363' column='1'/>
+        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='364' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='guid' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='364' column='1'/>
+        <var-decl name='guid' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='365' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_1394' type-id='type-id-147' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='365' column='1' id='type-id-89'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-90' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='368' column='1' id='type-id-148'>
+    <typedef-decl name='efidp_1394' type-id='type-id-158' filepath='src/include/efivar/efivar-dp.h' line='366' column='1' id='type-id-102'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-103' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='369' column='1' id='type-id-159'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='369' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='370' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='parent_port' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='370' column='1'/>
+        <var-decl name='parent_port' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='371' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='interface' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='371' column='1'/>
+        <var-decl name='interface' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='372' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_usb' type-id='type-id-148' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='372' column='1' id='type-id-90'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-91' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='375' column='1' id='type-id-149'>
+    <typedef-decl name='efidp_usb' type-id='type-id-159' filepath='src/include/efivar/efivar-dp.h' line='373' column='1' id='type-id-103'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-104' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='376' column='1' id='type-id-160'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='376' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='377' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_id' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='377' column='1'/>
+        <var-decl name='vendor_id' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='378' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='product_id' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='378' column='1'/>
+        <var-decl name='product_id' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='379' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='device_class' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='379' column='1'/>
+        <var-decl name='device_class' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='380' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='72'>
-        <var-decl name='device_subclass' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='380' column='1'/>
+        <var-decl name='device_subclass' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='381' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='device_protocol' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='381' column='1'/>
+        <var-decl name='device_protocol' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='382' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_usb_class' type-id='type-id-149' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='382' column='1' id='type-id-91'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-92' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='402' column='1' id='type-id-150'>
+    <typedef-decl name='efidp_usb_class' type-id='type-id-160' filepath='src/include/efivar/efivar-dp.h' line='383' column='1' id='type-id-104'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-105' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='403' column='1' id='type-id-161'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='403' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='404' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='interface' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='404' column='1'/>
+        <var-decl name='interface' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='405' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='vendor_id' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='405' column='1'/>
+        <var-decl name='vendor_id' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='406' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='product_id' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='406' column='1'/>
+        <var-decl name='product_id' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='407' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='serial_number' type-id='type-id-151' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='407' column='1'/>
+        <var-decl name='serial_number' type-id='type-id-162' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='408' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='16' id='type-id-151'>
-      <subrange length='1' type-id='type-id-13' id='type-id-133'/>
+    <array-type-def dimensions='1' type-id='type-id-20' size-in-bits='16' id='type-id-162'>
+      <subrange length='1' type-id='type-id-13' id='type-id-74'/>
 
     </array-type-def>
-    <typedef-decl name='efidp_usb_wwid' type-id='type-id-150' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='408' column='1' id='type-id-92'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-93' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='411' column='1' id='type-id-152'>
+    <typedef-decl name='efidp_usb_wwid' type-id='type-id-161' filepath='src/include/efivar/efivar-dp.h' line='409' column='1' id='type-id-105'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-106' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='412' column='1' id='type-id-163'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='412' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='413' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='lun' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='413' column='1'/>
+        <var-decl name='lun' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='414' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_lun' type-id='type-id-152' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='414' column='1' id='type-id-93'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-94' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='417' column='1' id='type-id-153'>
+    <typedef-decl name='efidp_lun' type-id='type-id-163' filepath='src/include/efivar/efivar-dp.h' line='415' column='1' id='type-id-106'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-107' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='418' column='1' id='type-id-164'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='418' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='419' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='hba_port' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='419' column='1'/>
+        <var-decl name='hba_port' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='420' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='port_multiplier_port' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='420' column='1'/>
+        <var-decl name='port_multiplier_port' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='421' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='lun' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='421' column='1'/>
+        <var-decl name='lun' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='422' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_sata' type-id='type-id-153' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='422' column='1' id='type-id-94'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-95' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='428' column='1' id='type-id-154'>
+    <typedef-decl name='efidp_sata' type-id='type-id-164' filepath='src/include/efivar/efivar-dp.h' line='423' column='1' id='type-id-107'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-108' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='429' column='1' id='type-id-165'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='429' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='430' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='target' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='430' column='1'/>
+        <var-decl name='target' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='431' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_i2o' type-id='type-id-154' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='431' column='1' id='type-id-95'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='296' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-96' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='434' column='1' id='type-id-155'>
+    <typedef-decl name='efidp_i2o' type-id='type-id-165' filepath='src/include/efivar/efivar-dp.h' line='432' column='1' id='type-id-108'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='296' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-109' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='435' column='1' id='type-id-166'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='435' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='436' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='mac_addr' type-id='type-id-156' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='436' column='1'/>
+        <var-decl name='mac_addr' type-id='type-id-167' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='437' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='if_type' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='437' column='1'/>
+        <var-decl name='if_type' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='438' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='256' id='type-id-156'>
-      <subrange length='32' type-id='type-id-13' id='type-id-157'/>
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='256' id='type-id-167'>
+      <subrange length='32' type-id='type-id-13' id='type-id-168'/>
 
     </array-type-def>
-    <typedef-decl name='efidp_mac_addr' type-id='type-id-155' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='438' column='1' id='type-id-96'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='216' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-97' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='446' column='1' id='type-id-158'>
+    <typedef-decl name='efidp_mac_addr' type-id='type-id-166' filepath='src/include/efivar/efivar-dp.h' line='439' column='1' id='type-id-109'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='216' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-110' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='447' column='1' id='type-id-169'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='447' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='448' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='local_ipv4_addr' type-id='type-id-159' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='448' column='1'/>
+        <var-decl name='local_ipv4_addr' type-id='type-id-170' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='449' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='remote_ipv4_addr' type-id='type-id-159' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='449' column='1'/>
+        <var-decl name='remote_ipv4_addr' type-id='type-id-170' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='450' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='local_port' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='450' column='1'/>
+        <var-decl name='local_port' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='451' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='112'>
-        <var-decl name='remote_port' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='451' column='1'/>
+        <var-decl name='remote_port' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='452' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='protocol' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='452' column='1'/>
+        <var-decl name='protocol' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='453' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='static_ip_addr' type-id='type-id-160' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='453' column='1'/>
+        <var-decl name='static_ip_addr' type-id='type-id-171' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='454' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='152'>
-        <var-decl name='gateway' type-id='type-id-159' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='454' column='1'/>
+        <var-decl name='gateway' type-id='type-id-170' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='455' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='184'>
-        <var-decl name='netmask' type-id='type-id-159' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='455' column='1'/>
+        <var-decl name='netmask' type-id='type-id-170' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='456' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='32' id='type-id-159'>
-      <subrange length='4' type-id='type-id-13' id='type-id-161'/>
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='32' id='type-id-170'>
+      <subrange length='4' type-id='type-id-13' id='type-id-172'/>
 
     </array-type-def>
-    <typedef-decl name='efidp_boolean' type-id='type-id-28' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='43' column='1' id='type-id-160'/>
-    <typedef-decl name='efidp_ipv4_addr' type-id='type-id-158' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='456' column='1' id='type-id-97'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='360' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-98' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='468' column='1' id='type-id-162'>
+    <typedef-decl name='efidp_boolean' type-id='type-id-28' filepath='src/include/efivar/efivar-dp.h' line='43' column='1' id='type-id-171'/>
+    <typedef-decl name='efidp_ipv4_addr' type-id='type-id-169' filepath='src/include/efivar/efivar-dp.h' line='457' column='1' id='type-id-110'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='360' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-111' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='469' column='1' id='type-id-173'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='469' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='470' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='local_ipv6_addr' type-id='type-id-163' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='470' column='1'/>
+        <var-decl name='local_ipv6_addr' type-id='type-id-174' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='471' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='remote_ipv6_addr' type-id='type-id-163' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='471' column='1'/>
+        <var-decl name='remote_ipv6_addr' type-id='type-id-174' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='472' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='local_port' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='472' column='1'/>
+        <var-decl name='local_port' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='473' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='304'>
-        <var-decl name='remote_port' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='473' column='1'/>
+        <var-decl name='remote_port' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='474' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='protocol' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='474' column='1'/>
+        <var-decl name='protocol' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='475' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='336'>
-        <var-decl name='ip_addr_origin' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='475' column='1'/>
+        <var-decl name='ip_addr_origin' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='476' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='344'>
-        <var-decl name='prefix_length' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='476' column='1'/>
+        <var-decl name='prefix_length' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='477' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='352'>
-        <var-decl name='gateway_ipv6_addr' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='477' column='1'/>
+        <var-decl name='gateway_ipv6_addr' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='478' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='128' id='type-id-163'>
-      <subrange length='16' type-id='type-id-13' id='type-id-164'/>
+    <array-type-def dimensions='1' type-id='type-id-28' size-in-bits='128' id='type-id-174'>
+      <subrange length='16' type-id='type-id-13' id='type-id-175'/>
 
     </array-type-def>
-    <typedef-decl name='efidp_ipv6_addr' type-id='type-id-162' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='478' column='1' id='type-id-98'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-99' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='485' column='1' id='type-id-165'>
+    <typedef-decl name='efidp_ipv6_addr' type-id='type-id-173' filepath='src/include/efivar/efivar-dp.h' line='479' column='1' id='type-id-111'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-112' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='486' column='1' id='type-id-176'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='486' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='487' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vlan_id' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='487' column='1'/>
+        <var-decl name='vlan_id' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='488' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_vlan' type-id='type-id-165' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='488' column='1' id='type-id-99'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='384' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-100' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='491' column='1' id='type-id-166'>
+    <typedef-decl name='efidp_vlan' type-id='type-id-176' filepath='src/include/efivar/efivar-dp.h' line='489' column='1' id='type-id-112'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='384' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-113' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='492' column='1' id='type-id-177'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='492' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='493' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='resource_flags' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='493' column='1'/>
+        <var-decl name='resource_flags' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='494' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='port_gid' type-id='type-id-167' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='494' column='1'/>
+        <var-decl name='port_gid' type-id='type-id-178' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='495' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='' type-id='type-id-168' visibility='default'/>
+        <var-decl name='' type-id='type-id-179' visibility='default'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='target_port_id' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='499' column='1'/>
+        <var-decl name='target_port_id' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='500' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='device_id' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='500' column='1'/>
+        <var-decl name='device_id' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='501' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-54' size-in-bits='128' id='type-id-167'>
-      <subrange length='2' type-id='type-id-13' id='type-id-169'/>
+    <array-type-def dimensions='1' type-id='type-id-54' size-in-bits='128' id='type-id-178'>
+      <subrange length='2' type-id='type-id-13' id='type-id-180'/>
 
     </array-type-def>
-    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='495' column='1' id='type-id-168'>
+    <union-decl name='__anonymous_union__' size-in-bits='64' is-anonymous='yes' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='496' column='1' id='type-id-179'>
       <data-member access='private'>
-        <var-decl name='ioc_guid' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='496' column='1'/>
+        <var-decl name='ioc_guid' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='497' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='service_id' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='497' column='1'/>
+        <var-decl name='service_id' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='498' column='1'/>
       </data-member>
     </union-decl>
-    <typedef-decl name='efidp_infiniband' type-id='type-id-166' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='501' column='1' id='type-id-100'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='152' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-101' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='510' column='1' id='type-id-170'>
+    <typedef-decl name='efidp_infiniband' type-id='type-id-177' filepath='src/include/efivar/efivar-dp.h' line='502' column='1' id='type-id-113'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='152' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-114' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='511' column='1' id='type-id-181'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='511' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='512' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='512' column='1'/>
+        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='513' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='baud_rate' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='513' column='1'/>
+        <var-decl name='baud_rate' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='514' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='data_bits' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='514' column='1'/>
+        <var-decl name='data_bits' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='515' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='136'>
-        <var-decl name='parity' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='515' column='1'/>
+        <var-decl name='parity' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='516' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='stop_bits' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='516' column='1'/>
+        <var-decl name='stop_bits' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='517' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_uart' type-id='type-id-170' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='517' column='1' id='type-id-101'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-102' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='541' column='1' id='type-id-171'>
+    <typedef-decl name='efidp_uart' type-id='type-id-181' filepath='src/include/efivar/efivar-dp.h' line='518' column='1' id='type-id-114'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-115' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='542' column='1' id='type-id-182'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='542' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='543' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='543' column='1'/>
+        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='544' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='vendor_data' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='544' column='1'/>
+        <var-decl name='vendor_data' type-id='type-id-145' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='545' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_msg_vendor' type-id='type-id-171' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='545' column='1' id='type-id-102'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-103' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='554' column='1' id='type-id-172'>
+    <typedef-decl name='efidp_msg_vendor' type-id='type-id-182' filepath='src/include/efivar/efivar-dp.h' line='546' column='1' id='type-id-115'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-116' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='555' column='1' id='type-id-183'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='555' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='556' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='556' column='1'/>
+        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='557' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='flow_control_map' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='557' column='1'/>
+        <var-decl name='flow_control_map' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='558' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_uart_flow_control' type-id='type-id-172' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='558' column='1' id='type-id-103'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='352' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-104' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='565' column='1' id='type-id-173'>
+    <typedef-decl name='efidp_uart_flow_control' type-id='type-id-183' filepath='src/include/efivar/efivar-dp.h' line='559' column='1' id='type-id-116'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='352' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-117' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='566' column='1' id='type-id-184'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='566' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='567' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='567' column='1'/>
+        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='568' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='568' column='1'/>
+        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='569' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='sas_address' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='569' column='1'/>
+        <var-decl name='sas_address' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='570' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='256'>
-        <var-decl name='lun' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='570' column='1'/>
+        <var-decl name='lun' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='571' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='device_topology_info' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='571' column='1'/>
+        <var-decl name='device_topology_info' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='572' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='drive_bay_id' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='572' column='1'/>
+        <var-decl name='drive_bay_id' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='573' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='336'>
-        <var-decl name='rtp' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='573' column='1'/>
+        <var-decl name='rtp' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='574' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_sas' type-id='type-id-173' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='574' column='1' id='type-id-104'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-105' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='598' column='1' id='type-id-174'>
+    <typedef-decl name='efidp_sas' type-id='type-id-184' filepath='src/include/efivar/efivar-dp.h' line='575' column='1' id='type-id-117'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-118' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='599' column='1' id='type-id-185'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='599' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='600' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='sas_address' type-id='type-id-145' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='600' column='1'/>
+        <var-decl name='sas_address' type-id='type-id-156' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='601' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='lun' type-id='type-id-145' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='601' column='1'/>
+        <var-decl name='lun' type-id='type-id-156' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='602' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='device_topology_info' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='602' column='1'/>
+        <var-decl name='device_topology_info' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='603' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='168'>
-        <var-decl name='drive_bay_id' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='603' column='1'/>
+        <var-decl name='drive_bay_id' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='604' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='176'>
-        <var-decl name='rtp' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='604' column='1'/>
+        <var-decl name='rtp' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='605' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_sas_ex' type-id='type-id-174' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='605' column='1' id='type-id-105'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='144' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-106' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='611' column='1' id='type-id-175'>
+    <typedef-decl name='efidp_sas_ex' type-id='type-id-185' filepath='src/include/efivar/efivar-dp.h' line='606' column='1' id='type-id-118'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='144' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-119' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='612' column='1' id='type-id-186'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='612' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='613' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='protocol' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='613' column='1'/>
+        <var-decl name='protocol' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='614' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='options' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='614' column='1'/>
+        <var-decl name='options' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='615' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='lun' type-id='type-id-145' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='615' column='1'/>
+        <var-decl name='lun' type-id='type-id-156' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='616' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='tpgt' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='616' column='1'/>
+        <var-decl name='tpgt' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='617' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='144'>
-        <var-decl name='target_name' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='617' column='1'/>
+        <var-decl name='target_name' type-id='type-id-145' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='618' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_iscsi' type-id='type-id-175' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='618' column='1' id='type-id-106'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-107' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='646' column='1' id='type-id-176'>
+    <typedef-decl name='efidp_iscsi' type-id='type-id-186' filepath='src/include/efivar/efivar-dp.h' line='619' column='1' id='type-id-119'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-120' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='647' column='1' id='type-id-187'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='647' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='648' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='namespace_id' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='648' column='1'/>
+        <var-decl name='namespace_id' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='649' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='ieee_eui_64' type-id='type-id-145' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='649' column='1'/>
+        <var-decl name='ieee_eui_64' type-id='type-id-156' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='650' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_nvme' type-id='type-id-176' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='650' column='1' id='type-id-107'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-108' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='655' column='1' id='type-id-177'>
+    <typedef-decl name='efidp_nvme' type-id='type-id-187' filepath='src/include/efivar/efivar-dp.h' line='651' column='1' id='type-id-120'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-121' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='656' column='1' id='type-id-188'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='656' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='657' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='uri' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='657' column='1'/>
+        <var-decl name='uri' type-id='type-id-145' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='658' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_uri' type-id='type-id-177' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='658' column='1' id='type-id-108'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-109' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='661' column='1' id='type-id-178'>
+    <typedef-decl name='efidp_uri' type-id='type-id-188' filepath='src/include/efivar/efivar-dp.h' line='659' column='1' id='type-id-121'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='48' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-122' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='662' column='1' id='type-id-189'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='662' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='663' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='target_id' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='663' column='1'/>
+        <var-decl name='target_id' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='664' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='lun' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='664' column='1'/>
+        <var-decl name='lun' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='665' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_ufs' type-id='type-id-178' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='665' column='1' id='type-id-109'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-110' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='668' column='1' id='type-id-179'>
+    <typedef-decl name='efidp_ufs' type-id='type-id-189' filepath='src/include/efivar/efivar-dp.h' line='666' column='1' id='type-id-122'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-123' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='669' column='1' id='type-id-190'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='669' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='670' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='slot_number' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='670' column='1'/>
+        <var-decl name='slot_number' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='671' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_sd' type-id='type-id-179' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='671' column='1' id='type-id-110'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-111' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='674' column='1' id='type-id-180'>
+    <typedef-decl name='efidp_sd' type-id='type-id-190' filepath='src/include/efivar/efivar-dp.h' line='672' column='1' id='type-id-123'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='80' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-124' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='675' column='1' id='type-id-191'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='675' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='676' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='addr' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='676' column='1'/>
+        <var-decl name='addr' type-id='type-id-21' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='677' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_bt' type-id='type-id-180' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='677' column='1' id='type-id-111'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='288' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-112' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='680' column='1' id='type-id-181'>
+    <typedef-decl name='efidp_bt' type-id='type-id-191' filepath='src/include/efivar/efivar-dp.h' line='678' column='1' id='type-id-124'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='288' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-125' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='681' column='1' id='type-id-192'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='681' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='682' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='ssid' type-id='type-id-156' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='682' column='1'/>
+        <var-decl name='ssid' type-id='type-id-167' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='683' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_wifi' type-id='type-id-181' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='683' column='1' id='type-id-112'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-113' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='686' column='1' id='type-id-182'>
+    <typedef-decl name='efidp_wifi' type-id='type-id-192' filepath='src/include/efivar/efivar-dp.h' line='684' column='1' id='type-id-125'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-126' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='687' column='1' id='type-id-193'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='687' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='688' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='slot' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='688' column='1'/>
+        <var-decl name='slot' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='689' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_emmc' type-id='type-id-182' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='689' column='1' id='type-id-113'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-114' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='692' column='1' id='type-id-183'>
+    <typedef-decl name='efidp_emmc' type-id='type-id-193' filepath='src/include/efivar/efivar-dp.h' line='690' column='1' id='type-id-126'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='88' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-127' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='693' column='1' id='type-id-194'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='693' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='694' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='addr' type-id='type-id-21' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='694' column='1'/>
+        <var-decl name='addr' type-id='type-id-21' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='695' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='80'>
-        <var-decl name='addr_type' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='695' column='1'/>
+        <var-decl name='addr_type' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='696' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_btle' type-id='type-id-183' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='696' column='1' id='type-id-114'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-115' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='702' column='1' id='type-id-184'>
+    <typedef-decl name='efidp_btle' type-id='type-id-194' filepath='src/include/efivar/efivar-dp.h' line='697' column='1' id='type-id-127'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='40' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-128' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='703' column='1' id='type-id-195'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='703' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='704' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='is_ipv6' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='704' column='1'/>
+        <var-decl name='is_ipv6' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='705' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='40'>
-        <var-decl name='addrs' type-id='type-id-185' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='705' column='1'/>
+        <var-decl name='addrs' type-id='type-id-196' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='706' column='1'/>
       </data-member>
     </class-decl>
-    <union-decl name='__anonymous_union__' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='49' column='1' id='type-id-186'>
+    <union-decl name='__anonymous_union__' size-in-bits='128' is-anonymous='yes' visibility='default' filepath='src/include/efivar/efivar.h' line='49' column='1' id='type-id-197'>
       <data-member access='private'>
-        <var-decl name='addr' type-id='type-id-187' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='50' column='1'/>
+        <var-decl name='addr' type-id='type-id-198' visibility='default' filepath='src/include/efivar/efivar.h' line='50' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='v4' type-id='type-id-188' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='51' column='1'/>
+        <var-decl name='v4' type-id='type-id-199' visibility='default' filepath='src/include/efivar/efivar.h' line='51' column='1'/>
       </data-member>
       <data-member access='private'>
-        <var-decl name='v6' type-id='type-id-189' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='52' column='1'/>
+        <var-decl name='v6' type-id='type-id-200' visibility='default' filepath='src/include/efivar/efivar.h' line='52' column='1'/>
       </data-member>
     </union-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='128' id='type-id-187'>
-      <subrange length='4' type-id='type-id-13' id='type-id-161'/>
+    <array-type-def dimensions='1' type-id='type-id-19' size-in-bits='128' id='type-id-198'>
+      <subrange length='4' type-id='type-id-13' id='type-id-172'/>
 
     </array-type-def>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-188' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='41' column='1' id='type-id-190'>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-199' visibility='default' filepath='src/include/efivar/efivar.h' line='41' column='1' id='type-id-201'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='addr' type-id='type-id-159' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='42' column='1'/>
+        <var-decl name='addr' type-id='type-id-170' visibility='default' filepath='src/include/efivar/efivar.h' line='42' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efi_ipv4_addr_t' type-id='type-id-190' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='43' column='1' id='type-id-188'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-189' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='45' column='1' id='type-id-191'>
+    <typedef-decl name='efi_ipv4_addr_t' type-id='type-id-201' filepath='src/include/efivar/efivar.h' line='43' column='1' id='type-id-199'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='128' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-200' visibility='default' filepath='src/include/efivar/efivar.h' line='45' column='1' id='type-id-202'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='addr' type-id='type-id-163' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='46' column='1'/>
+        <var-decl name='addr' type-id='type-id-174' visibility='default' filepath='src/include/efivar/efivar.h' line='46' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efi_ipv6_addr_t' type-id='type-id-191' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='47' column='1' id='type-id-189'/>
-    <typedef-decl name='efi_ip_addr_t' type-id='type-id-186' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar.h' line='53' column='1' id='type-id-192'/>
+    <typedef-decl name='efi_ipv6_addr_t' type-id='type-id-202' filepath='src/include/efivar/efivar.h' line='47' column='1' id='type-id-200'/>
+    <typedef-decl name='efi_ip_addr_t' type-id='type-id-197' filepath='src/include/efivar/efivar.h' line='53' column='1' id='type-id-203'/>
 
-    <array-type-def dimensions='1' type-id='type-id-192' size-in-bits='128' id='type-id-185'>
-      <subrange length='1' type-id='type-id-13' id='type-id-133'/>
+    <array-type-def dimensions='1' type-id='type-id-203' size-in-bits='128' id='type-id-196'>
+      <subrange length='1' type-id='type-id-13' id='type-id-74'/>
 
     </array-type-def>
-    <typedef-decl name='efidp_dns' type-id='type-id-184' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='706' column='1' id='type-id-115'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-116' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='709' column='1' id='type-id-193'>
+    <typedef-decl name='efidp_dns' type-id='type-id-195' filepath='src/include/efivar/efivar-dp.h' line='707' column='1' id='type-id-128'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-129' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='710' column='1' id='type-id-204'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='710' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='711' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='uuid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='711' column='1'/>
+        <var-decl name='uuid' type-id='type-id-17' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='712' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_nvdimm' type-id='type-id-193' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='712' column='1' id='type-id-116'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='336' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-117' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='717' column='1' id='type-id-194'>
+    <typedef-decl name='efidp_nvdimm' type-id='type-id-204' filepath='src/include/efivar/efivar-dp.h' line='713' column='1' id='type-id-129'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='336' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-130' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='718' column='1' id='type-id-205'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='718' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='719' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='partition_number' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='719' column='1'/>
+        <var-decl name='partition_number' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='720' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='start' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='720' column='1'/>
+        <var-decl name='start' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='721' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='size' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='721' column='1'/>
+        <var-decl name='size' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='722' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='192'>
-        <var-decl name='signature' type-id='type-id-163' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='722' column='1'/>
+        <var-decl name='signature' type-id='type-id-174' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='723' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='320'>
-        <var-decl name='format' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='723' column='1'/>
+        <var-decl name='format' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='724' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='328'>
-        <var-decl name='signature_type' type-id='type-id-28' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='724' column='1'/>
+        <var-decl name='signature_type' type-id='type-id-28' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='725' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_hd' type-id='type-id-194' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='728' column='1' id='type-id-117'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-118' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='742' column='1' id='type-id-195'>
+    <typedef-decl name='efidp_hd' type-id='type-id-205' filepath='src/include/efivar/efivar-dp.h' line='729' column='1' id='type-id-130'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-131' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='743' column='1' id='type-id-206'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='743' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='744' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='boot_catalog_entry' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='744' column='1'/>
+        <var-decl name='boot_catalog_entry' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='745' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='partition_rba' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='745' column='1'/>
+        <var-decl name='partition_rba' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='746' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='sectors' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='746' column='1'/>
+        <var-decl name='sectors' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='747' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_cdrom' type-id='type-id-195' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='747' column='1' id='type-id-118'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-119' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='750' column='1' id='type-id-196'>
+    <typedef-decl name='efidp_cdrom' type-id='type-id-206' filepath='src/include/efivar/efivar-dp.h' line='748' column='1' id='type-id-131'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-132' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='751' column='1' id='type-id-207'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='751' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='752' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='752' column='1'/>
+        <var-decl name='vendor_guid' type-id='type-id-17' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='753' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='vendor_data' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='753' column='1'/>
+        <var-decl name='vendor_data' type-id='type-id-145' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='754' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_media_vendor' type-id='type-id-196' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='754' column='1' id='type-id-119'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-120' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='761' column='1' id='type-id-197'>
+    <typedef-decl name='efidp_media_vendor' type-id='type-id-207' filepath='src/include/efivar/efivar-dp.h' line='755' column='1' id='type-id-132'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-133' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='762' column='1' id='type-id-208'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='762' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='763' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='name' type-id='type-id-151' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='763' column='1'/>
+        <var-decl name='name' type-id='type-id-162' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='764' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_file' type-id='type-id-197' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='764' column='1' id='type-id-120'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-121' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='768' column='1' id='type-id-198'>
+    <typedef-decl name='efidp_file' type-id='type-id-208' filepath='src/include/efivar/efivar-dp.h' line='765' column='1' id='type-id-133'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='160' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-134' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='769' column='1' id='type-id-209'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='769' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='770' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='protocol_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='770' column='1'/>
+        <var-decl name='protocol_guid' type-id='type-id-17' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='771' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_protocol' type-id='type-id-198' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='771' column='1' id='type-id-121'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-122' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='774' column='1' id='type-id-199'>
+    <typedef-decl name='efidp_protocol' type-id='type-id-209' filepath='src/include/efivar/efivar-dp.h' line='772' column='1' id='type-id-134'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-135' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='775' column='1' id='type-id-210'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='775' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='776' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='pi_info' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='776' column='1'/>
+        <var-decl name='pi_info' type-id='type-id-145' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='777' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_firmware_file' type-id='type-id-199' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='777' column='1' id='type-id-122'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-123' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='780' column='1' id='type-id-200'>
+    <typedef-decl name='efidp_firmware_file' type-id='type-id-210' filepath='src/include/efivar/efivar-dp.h' line='778' column='1' id='type-id-135'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='32' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-136' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='781' column='1' id='type-id-211'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='781' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='782' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='pi_info' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='782' column='1'/>
+        <var-decl name='pi_info' type-id='type-id-145' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='783' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_firmware_volume' type-id='type-id-200' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='783' column='1' id='type-id-123'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-124' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='786' column='1' id='type-id-201'>
+    <typedef-decl name='efidp_firmware_volume' type-id='type-id-211' filepath='src/include/efivar/efivar-dp.h' line='784' column='1' id='type-id-136'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='192' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-137' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='787' column='1' id='type-id-212'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='787' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='788' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='788' column='1'/>
+        <var-decl name='reserved' type-id='type-id-19' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='789' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='first_byte' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='789' column='1'/>
+        <var-decl name='first_byte' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='790' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='last_byte' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='790' column='1'/>
+        <var-decl name='last_byte' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='791' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_relative_offset' type-id='type-id-201' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='791' column='1' id='type-id-124'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='304' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-125' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='794' column='1' id='type-id-202'>
+    <typedef-decl name='efidp_relative_offset' type-id='type-id-212' filepath='src/include/efivar/efivar-dp.h' line='792' column='1' id='type-id-137'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='304' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-138' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='795' column='1' id='type-id-213'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='795' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='796' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='start_addr' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='796' column='1'/>
+        <var-decl name='start_addr' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='797' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='96'>
-        <var-decl name='end_addr' type-id='type-id-54' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='797' column='1'/>
+        <var-decl name='end_addr' type-id='type-id-54' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='798' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='160'>
-        <var-decl name='disk_type_guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='798' column='1'/>
+        <var-decl name='disk_type_guid' type-id='type-id-17' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='799' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='288'>
-        <var-decl name='instance_number' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='799' column='1'/>
+        <var-decl name='instance_number' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='800' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_ramdisk' type-id='type-id-202' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='800' column='1' id='type-id-125'/>
-    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-126' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='813' column='1' id='type-id-203'>
+    <typedef-decl name='efidp_ramdisk' type-id='type-id-213' filepath='src/include/efivar/efivar-dp.h' line='801' column='1' id='type-id-138'/>
+    <class-decl name='__anonymous_struct__' size-in-bits='64' is-struct='yes' is-anonymous='yes' naming-typedef-id='type-id-139' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='814' column='1' id='type-id-214'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='header' type-id='type-id-75' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='814' column='1'/>
+        <var-decl name='header' type-id='type-id-88' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='815' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='32'>
-        <var-decl name='device_type' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='815' column='1'/>
+        <var-decl name='device_type' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='816' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='48'>
-        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='816' column='1'/>
+        <var-decl name='status' type-id='type-id-20' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='817' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='64'>
-        <var-decl name='description' type-id='type-id-132' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='817' column='1'/>
+        <var-decl name='description' type-id='type-id-145' visibility='default' filepath='src/include/efivar/efivar-dp.h' line='818' column='1'/>
       </data-member>
     </class-decl>
-    <typedef-decl name='efidp_bios_boot' type-id='type-id-203' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='818' column='1' id='type-id-126'/>
-    <typedef-decl name='efidp_data' type-id='type-id-73' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='890' column='1' id='type-id-204'/>
-    <pointer-type-def type-id='type-id-204' size-in-bits='64' id='type-id-205'/>
-    <typedef-decl name='efidp' type-id='type-id-205' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='891' column='1' id='type-id-206'/>
-    <function-decl name='efidp_parse_device_path' mangled-name='efidp_parse_device_path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='423' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_parse_device_path@@libefivar.so.0'>
-      <parameter type-id='type-id-46' name='path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='423' column='1'/>
-      <parameter type-id='type-id-206' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='424' column='1'/>
-      <parameter type-id='type-id-33' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='425' column='1'/>
+    <typedef-decl name='efidp_bios_boot' type-id='type-id-214' filepath='src/include/efivar/efivar-dp.h' line='819' column='1' id='type-id-139'/>
+    <typedef-decl name='efidp_data' type-id='type-id-86' filepath='src/include/efivar/efivar-dp.h' line='891' column='1' id='type-id-215'/>
+    <pointer-type-def type-id='type-id-215' size-in-bits='64' id='type-id-216'/>
+    <typedef-decl name='efidp' type-id='type-id-216' filepath='src/include/efivar/efivar-dp.h' line='892' column='1' id='type-id-217'/>
+    <function-decl name='efidp_parse_device_path' mangled-name='efidp_parse_device_path' filepath='src/dp-acpi.c' line='414' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_parse_device_path@@libefivar.so.0'>
+      <parameter type-id='type-id-46' name='path' filepath='src/dp-acpi.c' line='414' column='1'/>
+      <parameter type-id='type-id-217' name='out' filepath='src/dp-acpi.c' line='414' column='1'/>
+      <parameter type-id='type-id-33' name='size' filepath='src/dp-acpi.c' line='415' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <function-decl name='efidp_parse_device_node' mangled-name='efidp_parse_device_node' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='412' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_parse_device_node@@libefivar.so.0'>
-      <parameter type-id='type-id-46' name='path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='423' column='1'/>
-      <parameter type-id='type-id-206' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='424' column='1'/>
-      <parameter type-id='type-id-33' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='425' column='1'/>
+    <function-decl name='efidp_parse_device_node' mangled-name='efidp_parse_device_node' filepath='src/dp-acpi.c' line='405' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_parse_device_node@@libefivar.so.0'>
+      <parameter type-id='type-id-46' name='path' filepath='src/dp-acpi.c' line='414' column='1'/>
+      <parameter type-id='type-id-217' name='out' filepath='src/dp-acpi.c' line='414' column='1'/>
+      <parameter type-id='type-id-33' name='size' filepath='src/dp-acpi.c' line='415' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <qualified-type-def type-id='type-id-204' const='yes' id='type-id-207'/>
-    <pointer-type-def type-id='type-id-207' size-in-bits='64' id='type-id-208'/>
-    <typedef-decl name='const_efidp' type-id='type-id-208' filepath='/home/pjones/devel/github.com/efivar/master/src/include/efivar/efivar-dp.h' line='892' column='1' id='type-id-209'/>
-    <function-decl name='efidp_format_device_path' mangled-name='efidp_format_device_path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='307' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_format_device_path@@libefivar.so.0'>
-      <parameter type-id='type-id-46' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='307' column='1'/>
-      <parameter type-id='type-id-33' name='size' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='307' column='1'/>
-      <parameter type-id='type-id-209' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='307' column='1'/>
-      <parameter type-id='type-id-61' name='limit' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='307' column='1'/>
+    <qualified-type-def type-id='type-id-215' const='yes' id='type-id-218'/>
+    <pointer-type-def type-id='type-id-218' size-in-bits='64' id='type-id-219'/>
+    <typedef-decl name='const_efidp' type-id='type-id-219' filepath='src/include/efivar/efivar-dp.h' line='893' column='1' id='type-id-220'/>
+    <function-decl name='efidp_format_device_path' mangled-name='efidp_format_device_path' filepath='src/dp-acpi.c' line='301' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_format_device_path@@libefivar.so.0'>
+      <parameter type-id='type-id-46' name='buf' filepath='src/dp-acpi.c' line='301' column='1'/>
+      <parameter type-id='type-id-33' name='size' filepath='src/dp-acpi.c' line='301' column='1'/>
+      <parameter type-id='type-id-220' name='dp' filepath='src/dp-acpi.c' line='301' column='1'/>
+      <parameter type-id='type-id-61' name='limit' filepath='src/dp-acpi.c' line='301' column='1'/>
       <return type-id='type-id-61'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-206' size-in-bits='64' id='type-id-210'/>
-    <function-decl name='efidp_append_instance' mangled-name='efidp_append_instance' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='259' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_append_instance@@libefivar.so.0'>
-      <parameter type-id='type-id-209' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='259' column='1'/>
-      <parameter type-id='type-id-209' name='dpi' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='259' column='1'/>
-      <parameter type-id='type-id-210' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='259' column='1'/>
-      <parameter type-id='type-id-209' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='259' column='1'/>
-      <parameter type-id='type-id-209' name='dpi' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='259' column='1'/>
-      <parameter type-id='type-id-210' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='259' column='1'/>
+    <pointer-type-def type-id='type-id-217' size-in-bits='64' id='type-id-221'/>
+    <function-decl name='efidp_append_instance' mangled-name='efidp_append_instance' filepath='src/dp-acpi.c' line='254' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_append_instance@@libefivar.so.0'>
+      <parameter type-id='type-id-220' name='dp' filepath='src/dp-acpi.c' line='254' column='1'/>
+      <parameter type-id='type-id-220' name='dpi' filepath='src/dp-acpi.c' line='254' column='1'/>
+      <parameter type-id='type-id-221' name='out' filepath='src/dp-acpi.c' line='254' column='1'/>
+      <parameter type-id='type-id-220' name='dp' filepath='src/dp-acpi.c' line='254' column='1'/>
+      <parameter type-id='type-id-220' name='dpi' filepath='src/dp-acpi.c' line='254' column='1'/>
+      <parameter type-id='type-id-221' name='out' filepath='src/dp-acpi.c' line='254' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efidp_append_node' mangled-name='efidp_append_node' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='197' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_append_node@@libefivar.so.0'>
-      <parameter type-id='type-id-209' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='197' column='1'/>
-      <parameter type-id='type-id-209' name='dn' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='197' column='1'/>
-      <parameter type-id='type-id-210' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='197' column='1'/>
+    <function-decl name='efidp_append_node' mangled-name='efidp_append_node' filepath='src/dp-acpi.c' line='193' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_append_node@@libefivar.so.0'>
+      <parameter type-id='type-id-220' name='dp' filepath='src/dp-acpi.c' line='193' column='1'/>
+      <parameter type-id='type-id-220' name='dn' filepath='src/dp-acpi.c' line='193' column='1'/>
+      <parameter type-id='type-id-221' name='out' filepath='src/dp-acpi.c' line='193' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efidp_append_path' mangled-name='efidp_append_path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='114' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_append_path@@libefivar.so.0'>
-      <parameter type-id='type-id-209' name='dp0' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='114' column='1'/>
-      <parameter type-id='type-id-209' name='dp1' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='114' column='1'/>
-      <parameter type-id='type-id-210' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='114' column='1'/>
+    <function-decl name='efidp_append_path' mangled-name='efidp_append_path' filepath='src/dp-acpi.c' line='111' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_append_path@@libefivar.so.0'>
+      <parameter type-id='type-id-220' name='dp0' filepath='src/dp-acpi.c' line='111' column='1'/>
+      <parameter type-id='type-id-220' name='dp1' filepath='src/dp-acpi.c' line='111' column='1'/>
+      <parameter type-id='type-id-221' name='out' filepath='src/dp-acpi.c' line='111' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efidp_duplicate_path' mangled-name='efidp_duplicate_path' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='103' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_duplicate_path@@libefivar.so.0'>
-      <parameter type-id='type-id-209' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='103' column='1'/>
-      <parameter type-id='type-id-210' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='103' column='1'/>
-      <parameter type-id='type-id-209' name='dp' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='103' column='1'/>
-      <parameter type-id='type-id-210' name='out' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='103' column='1'/>
+    <function-decl name='efidp_duplicate_path' mangled-name='efidp_duplicate_path' filepath='src/dp-acpi.c' line='101' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_duplicate_path@@libefivar.so.0'>
+      <parameter type-id='type-id-220' name='dp' filepath='src/dp-acpi.c' line='101' column='1'/>
+      <parameter type-id='type-id-221' name='out' filepath='src/dp-acpi.c' line='101' column='1'/>
+      <parameter type-id='type-id-220' name='dp' filepath='src/dp-acpi.c' line='101' column='1'/>
+      <parameter type-id='type-id-221' name='out' filepath='src/dp-acpi.c' line='101' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <function-decl name='efidp_set_node_data' mangled-name='efidp_set_node_data' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='48' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_set_node_data@@libefivar.so.0'>
-      <parameter type-id='type-id-209' name='dn' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='48' column='1'/>
-      <parameter type-id='type-id-72' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='48' column='1'/>
-      <parameter type-id='type-id-33' name='bufsize' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='48' column='1'/>
-      <parameter type-id='type-id-209' name='dn' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='48' column='1'/>
-      <parameter type-id='type-id-72' name='buf' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='48' column='1'/>
-      <parameter type-id='type-id-33' name='bufsize' filepath='/home/pjones/devel/github.com/efivar/master/src/dp-media.c' line='48' column='1'/>
+    <function-decl name='efidp_set_node_data' mangled-name='efidp_set_node_data' filepath='src/dp-acpi.c' line='47' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efidp_set_node_data@@libefivar.so.0'>
+      <parameter type-id='type-id-220' name='dn' filepath='src/dp-acpi.c' line='47' column='1'/>
+      <parameter type-id='type-id-71' name='buf' filepath='src/dp-acpi.c' line='47' column='1'/>
+      <parameter type-id='type-id-33' name='bufsize' filepath='src/dp-acpi.c' line='47' column='1'/>
+      <parameter type-id='type-id-220' name='dn' filepath='src/dp-acpi.c' line='47' column='1'/>
+      <parameter type-id='type-id-71' name='buf' filepath='src/dp-acpi.c' line='47' column='1'/>
+      <parameter type-id='type-id-33' name='bufsize' filepath='src/dp-acpi.c' line='47' column='1'/>
       <return type-id='type-id-15'/>
     </function-decl>
-    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-211'/>
-    <var-decl name='ops' type-id='type-id-211' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='42' column='1'/>
-    <var-decl name='default_ops' type-id='type-id-1' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/lib.c' line='37' column='1'/>
-    <class-decl name='guidname' size-in-bits='4224' is-struct='yes' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.h' line='182' column='1' id='type-id-212'>
+    <pointer-type-def type-id='type-id-1' size-in-bits='64' id='type-id-222'/>
+    <var-decl name='ops' type-id='type-id-222' visibility='default' filepath='src/lib.c' line='43' column='1'/>
+    <var-decl name='default_ops' type-id='type-id-1' visibility='default' filepath='src/lib.c' line='38' column='1'/>
+    <class-decl name='guidname' size-in-bits='4224' is-struct='yes' visibility='default' filepath='src/guid.h' line='181' column='1' id='type-id-223'>
       <data-member access='public' layout-offset-in-bits='0'>
-        <var-decl name='guid' type-id='type-id-17' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.h' line='183' column='1'/>
+        <var-decl name='guid' type-id='type-id-17' visibility='default' filepath='src/guid.h' line='182' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='128'>
-        <var-decl name='symbol' type-id='type-id-213' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.h' line='184' column='1'/>
+        <var-decl name='symbol' type-id='type-id-224' visibility='default' filepath='src/guid.h' line='183' column='1'/>
       </data-member>
       <data-member access='public' layout-offset-in-bits='2176'>
-        <var-decl name='name' type-id='type-id-213' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.h' line='185' column='1'/>
+        <var-decl name='name' type-id='type-id-224' visibility='default' filepath='src/guid.h' line='184' column='1'/>
       </data-member>
     </class-decl>
 
-    <array-type-def dimensions='1' type-id='type-id-12' size-in-bits='2048' id='type-id-213'>
-      <subrange length='256' type-id='type-id-13' id='type-id-214'/>
+    <array-type-def dimensions='1' type-id='type-id-12' size-in-bits='2048' id='type-id-224'>
+      <subrange length='256' type-id='type-id-13' id='type-id-225'/>
 
     </array-type-def>
-    <var-decl name='efi_well_known_names_end' type-id='type-id-212' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='112' column='1'/>
-    <var-decl name='efi_well_known_names' type-id='type-id-212' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='108' column='1'/>
-    <var-decl name='efi_well_known_guids_end' type-id='type-id-212' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='110' column='1'/>
-    <var-decl name='efi_well_known_guids' type-id='type-id-212' visibility='default' filepath='/home/pjones/devel/github.com/efivar/master/src/guid.c' line='106' column='1'/>
+    <var-decl name='efi_well_known_names_end' type-id='type-id-223' visibility='default' filepath='src/guid.c' line='100' column='1'/>
+    <var-decl name='efi_well_known_names' type-id='type-id-223' visibility='default' filepath='src/guid.c' line='98' column='1'/>
+    <var-decl name='efi_well_known_guids_end' type-id='type-id-223' visibility='default' filepath='src/guid.c' line='99' column='1'/>
+    <var-decl name='efi_well_known_guids' type-id='type-id-223' visibility='default' filepath='src/guid.c' line='97' column='1'/>
+    <var-decl name='stderr' type-id='type-id-66' visibility='default' filepath='/usr/include/stdio.h' line='137' column='1'/>
     <function-decl name='__builtin_memcpy' mangled-name='memcpy' visibility='default' binding='global' size-in-bits='64'>
+      <return type-id='type-id-62'/>
+    </function-decl>
+    <function-decl name='__builtin_calloc' mangled-name='calloc' visibility='default' binding='global' size-in-bits='64'>
       <return type-id='type-id-62'/>
     </function-decl>
     <function-decl name='__builtin_memset' mangled-name='memset' visibility='default' binding='global' size-in-bits='64'>

--- a/src/linux-ata.c
+++ b/src/linux-ata.c
@@ -1,0 +1,104 @@
+/*
+ * libefiboot - library for the manipulation of EFI boot variables
+ * Copyright 2012-2018 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fix_coverity.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "efiboot.h"
+
+/*
+ * support for old-school ATA devices
+ *
+ * /sys/dev/block/$major:$minor looks like:
+ * 8:0 -> ../../devices/pci0000:00/0000:00:17.0/ata2/host1/target1:0:0/1:0:0:0/block/sda
+ * 8:1 -> ../../devices/pci0000:00/0000:00:17.0/ata2/host1/target1:0:0/1:0:0:0/block/sda/sda1
+ * 11:0 -> ../../devices/pci0000:00/0000:00:11.5/ata3/host2/target2:0:0/2:0:0:0/block/sr0
+ */
+static ssize_t
+parse_ata(struct device *dev, const char *current UNUSED)
+{
+        debug(DEBUG, "entry");
+        /* IDE disks can have up to 64 partitions, or 6 bits worth,
+         * and have one bit for the disk number.
+         * This leaves an extra bit at the top.
+         */
+        if (dev->major == 3) {
+                dev->disknum = (dev->minor >> 6) & 1;
+                dev->controllernum = (dev->major - 3 + 0) + dev->disknum;
+                dev->interface_type = ata;
+                set_part(dev, dev->minor & 0x3F);
+        } else if (dev->major == 22) {
+                dev->disknum = (dev->minor >> 6) & 1;
+                dev->controllernum = (dev->major - 22 + 2) + dev->disknum;
+                dev->interface_type = ata;
+                set_part(dev, dev->minor & 0x3F);
+        } else if (dev->major >= 33 && dev->major <= 34) {
+                dev->disknum = (dev->minor >> 6) & 1;
+                dev->controllernum = (dev->major - 33 + 4) + dev->disknum;
+                dev->interface_type = ata;
+                set_part(dev, dev->minor & 0x3F);
+        } else if (dev->major >= 56 && dev->major <= 57) {
+                dev->disknum = (dev->minor >> 6) & 1;
+                dev->controllernum = (dev->major - 56 + 8) + dev->disknum;
+                dev->interface_type = ata;
+                set_part(dev, dev->minor & 0x3F);
+        } else if (dev->major >= 88 && dev->major <= 91) {
+                dev->disknum = (dev->minor >> 6) & 1;
+                dev->controllernum = (dev->major - 88 + 12) + dev->disknum;
+                dev->interface_type = ata;
+                set_part(dev, dev->minor & 0x3F);
+        } else {
+                /*
+                 * If it isn't one of those majors, it isn't a PATA device.
+                 */
+                return 0;
+        }
+
+        if (!strncmp(dev->driver, "pata_", 5) ||
+                   !(strcmp(dev->driver, "ata_piix"))) {
+                dev->interface_type = ata;
+        } else {
+                /*
+                 * If it isn't one of the pata drivers or ata_piix, it isn't a
+                 * PATA device.
+                 */
+                return 0;
+        }
+
+        char *block = strstr(current, "/block/");
+        if (!block)
+                return -1;
+        return block + 1 - current;
+}
+
+enum interface_type ata_iftypes[] = { ata, atapi, unknown };
+
+struct dev_probe ata_parser = {
+        .name = "ata",
+        .iftypes = ata_iftypes,
+        .flags = DEV_PROVIDES_HD,
+        .parse = parse_ata,
+        .create = NULL,
+};

--- a/src/linux-i2o.c
+++ b/src/linux-i2o.c
@@ -1,0 +1,63 @@
+/*
+ * libefiboot - library for the manipulation of EFI boot variables
+ * Copyright 2012-2018 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fix_coverity.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "efiboot.h"
+
+/*
+ * support for I2O devices
+ * ... probably doesn't work.
+ */
+static ssize_t
+parse_i2o(struct device *dev, const char *current UNUSED)
+{
+        debug(DEBUG, "entry");
+        /* I2O disks can have up to 16 partitions, or 4 bits worth. */
+        if (dev->major >= 80 && dev->major <= 87) {
+                dev->interface_type = i2o;
+                dev->disknum = 16*(dev->major-80) + (dev->minor >> 4);
+                set_part(dev, dev->minor & 0xF);
+        } else {
+                /* If it isn't those majors, it's not an i2o dev */
+                return 0;
+        }
+
+        char *block = strstr(current, "/block/");
+        if (!block)
+                return -1;
+        return block + 1 - current;
+}
+
+enum interface_type i2o_iftypes[] = { i2o, unknown };
+
+struct dev_probe HIDDEN i2o_parser = {
+        .name = "i2o",
+        .iftypes = i2o_iftypes,
+        .flags = DEV_PROVIDES_HD,
+        .parse = parse_i2o,
+        .create = NULL,
+};

--- a/src/linux-nvme.c
+++ b/src/linux-nvme.c
@@ -1,0 +1,170 @@
+/*
+ * libefiboot - library for the manipulation of EFI boot variables
+ * Copyright 2012-2018 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fix_coverity.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "efiboot.h"
+
+/*
+ * support for NVMe devices
+ *
+ * /sys/dev/block/$major:$minor looks like:
+ * 259:0 -> ../../devices/pci0000:00/0000:00:1d.0/0000:05:00.0/nvme/nvme0/nvme0n1
+ * 259:1 -> ../../devices/pci0000:00/0000:00:1d.0/0000:05:00.0/nvme/nvme0/nvme0n1/nvme0n1p1
+ *
+ * /sys/dev/block/259:0/device looks like:
+ * device -> ../../nvme0
+ *
+ * /sys/dev/block/259:1/partition looks like:
+ * $ cat partition
+ * 1
+ *
+ * /sys/class/block/nvme0n1/eui looks like:
+ * $ cat /sys/class/block/nvme0n1/eui
+ * 00 25 38 53 5a 16 1d a9
+ */
+
+static ssize_t
+parse_nvme(struct device *dev, const char *current)
+{
+        int rc;
+        int32_t tosser0, tosser1, tosser2, ctrl_id, ns_id, partition;
+        uint8_t *filebuf = NULL;
+        int pos0 = 0, pos1 = 0;
+        char *spaces;
+
+        pos0 = strlen(current);
+        spaces = alloca(pos0+1);
+        memset(spaces, ' ', pos0+1);
+        spaces[pos0] = '\0';
+        pos0 = 0;
+
+        debug(DEBUG, "entry");
+
+        debug(DEBUG, "searching for nvme/nvme0/nvme0n1 or nvme/nvme0/nvme0n1/nvme0n1p1");
+        rc = sscanf(current, "nvme/nvme%d/nvme%dn%d%n/nvme%dn%dp%d%n",
+                    &tosser0, &ctrl_id, &ns_id, &pos0,
+                    &tosser1, &tosser2, &partition, &pos1);
+        debug(DEBUG, "current:\"%s\" rc:%d pos0:%d pos1:%d\n", current, rc, pos0, pos1);
+        arrow(DEBUG, spaces, 9, pos0, rc, 3);
+        arrow(DEBUG, spaces, 9, pos1, rc, 6);
+        /*
+         * If it isn't of that form, it's not one of our nvme devices.
+         */
+        if (rc != 3 && rc != 6)
+                return 0;
+
+        dev->nvme_info.ctrl_id = ctrl_id;
+        dev->nvme_info.ns_id = ns_id;
+        dev->nvme_info.has_eui = 0;
+        dev->interface_type = nvme;
+
+        if (rc == 6) {
+                if (dev->part == -1)
+                        dev->part = partition;
+
+                pos0 = pos1;
+        }
+
+        /*
+         * now fish the eui out of sysfs is there is one...
+         */
+        rc = read_sysfs_file(&filebuf,
+                             "class/block/nvme%dn%d/eui",
+                             ctrl_id, ns_id);
+        if ((rc < 0 && errno == ENOENT) || filebuf == NULL) {
+                rc = read_sysfs_file(&filebuf,
+                             "class/block/nvme%dn%d/device/eui",
+                             ctrl_id, ns_id);
+        }
+        if (rc >= 0 && filebuf != NULL) {
+                uint8_t eui[8];
+                if (rc < 23) {
+                        errno = EINVAL;
+                        return -1;
+                }
+                rc = sscanf((char *)filebuf,
+                            "%02hhx %02hhx %02hhx %02hhx "
+                            "%02hhx %02hhx %02hhx %02hhx",
+                            &eui[0], &eui[1], &eui[2], &eui[3],
+                            &eui[4], &eui[5], &eui[6], &eui[7]);
+                if (rc < 8) {
+                        errno = EINVAL;
+                        return -1;
+                }
+                dev->nvme_info.has_eui = 1;
+                memcpy(dev->nvme_info.eui, eui, sizeof(eui));
+        } else {
+                return -1;
+        }
+
+        return pos0;
+}
+
+static ssize_t
+dp_create_nvme(struct device *dev,
+               uint8_t *buf,  ssize_t size, ssize_t off)
+{
+        ssize_t sz;
+
+        debug(DEBUG, "entry");
+
+        sz = efidp_make_nvme(buf + off, size ? size - off : 0,
+                             dev->nvme_info.ns_id,
+                             dev->nvme_info.has_eui ? dev->nvme_info.eui
+                                                        : NULL);
+        return sz;
+}
+
+static char *
+make_part_name(struct device *dev)
+{
+        char *ret = NULL;
+        ssize_t rc;
+
+        if (dev->part < 1)
+                return NULL;
+
+        rc = asprintf(&ret, "%sp%d", dev->disk_name, dev->part);
+        if (rc < 0) {
+                efi_error("could not allocate memory");
+                return NULL;
+        }
+
+        return ret;
+}
+
+static enum interface_type nvme_iftypes[] = { nvme, unknown };
+
+struct dev_probe HIDDEN nvme_parser = {
+        .name = "nvme",
+        .iftypes = nvme_iftypes,
+        .flags = DEV_PROVIDES_HD,
+        .parse = parse_nvme,
+        .create = dp_create_nvme,
+        .make_part_name = make_part_name,
+};
+

--- a/src/linux-pci.c
+++ b/src/linux-pci.c
@@ -1,0 +1,220 @@
+/*
+ * libefiboot - library for the manipulation of EFI boot variables
+ * Copyright 2012-2018 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fix_coverity.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "efiboot.h"
+
+/*
+ * support for PCI root hub and devices
+ *
+ * various devices /sys/dev/block/$major:$minor start with:
+ * maj:min -> ../../devices/pci$PCIROOT/$PCI_DEVICES/$BLOCKDEV_STUFF/block/$DISK/$PART
+ * i.e.:                    pci0000:00/0000:00:1d.0/0000:05:00.0/
+ *                          ^ root hub ^device      ^device
+ *
+ * for network devices, we also get:
+ * /sys/class/net/$IFACE -> ../../devices/$PCI_STUFF/net/$IFACE
+ *
+ */
+static ssize_t
+parse_pci(struct device *dev, const char *current)
+{
+        int rc;
+        int pos;
+        uint16_t root_domain;
+        uint8_t root_bus;
+        uint32_t acpi_hid = 0;
+        uint64_t acpi_uid_int = 0;
+        const char *devpart = current;
+        char *fbuf = NULL;
+        uint16_t tmp16 = 0;
+        char *spaces;
+
+        pos = strlen(current);
+        spaces = alloca(pos+1);
+        memset(spaces, ' ', pos+1);
+        spaces[pos] = '\0';
+        pos = 0;
+
+        debug(DEBUG, "entry");
+
+        /*
+         * find the pci root domain and port; they basically look like:
+         * pci0000:00/
+         *    ^d   ^p
+         */
+        rc = sscanf(devpart, "../../devices/pci%hx:%hhx/%n", &root_domain, &root_bus, &pos);
+        /*
+         * If we can't find that, it's not a PCI device.
+         */
+        if (rc != 2)
+                return 0;
+        devpart += pos;
+
+        dev->pci_root.pci_root_domain = root_domain;
+        dev->pci_root.pci_root_bus = root_bus;
+
+        rc = read_sysfs_file(&fbuf,
+                             "devices/pci%04hx:%02hhx/firmware_node/hid",
+                             root_domain, root_bus);
+        if (rc < 0 || fbuf == NULL)
+                return -1;
+
+        rc = sscanf((char *)fbuf, "PNP%hx", &tmp16);
+        if (rc != 1)
+                return -1;
+        acpi_hid = EFIDP_EFI_PNP_ID(tmp16);
+
+        /*
+         * Apparently basically nothing can look up a PcieRoot() node,
+         * because they just check _CID.  So since _CID for the root pretty
+         * much always has to be PNP0A03 anyway, just use that no matter
+         * what.
+         */
+        if (acpi_hid == EFIDP_ACPI_PCIE_ROOT_HID)
+                acpi_hid = EFIDP_ACPI_PCI_ROOT_HID;
+        dev->pci_root.pci_root_acpi_hid = acpi_hid;
+
+        errno = 0;
+        fbuf = NULL;
+        rc = read_sysfs_file(&fbuf,
+                             "devices/pci%04hx:%02hhx/firmware_node/uid",
+                             root_domain, root_bus);
+        if ((rc <= 0 && errno != ENOENT) || fbuf == NULL)
+                return -1;
+        if (rc > 0) {
+                rc = sscanf((char *)fbuf, "%"PRIu64"\n", &acpi_uid_int);
+                if (rc == 1) {
+                        dev->pci_root.pci_root_acpi_uid = acpi_uid_int;
+                } else {
+                        /* kernel uses "%s\n" to print it, so there
+                         * should always be some value and a newline... */
+                        int l = strlen((char *)fbuf);
+                        if (l >= 1) {
+                                fbuf[l-1] = '\0';
+                                dev->pci_root.pci_root_acpi_uid_str = fbuf;
+                        }
+                }
+        }
+        errno = 0;
+
+        /* find the pci domain/bus/device/function:
+         * 0000:00:01.0/0000:01:00.0/
+         *              ^d   ^b ^d ^f (of the last one in the series)
+         */
+        while (*devpart) {
+                uint16_t domain;
+                uint8_t bus, device, function;
+                struct pci_dev_info *pci_dev;
+                unsigned int i = dev->n_pci_devs;
+
+                pos = 0;
+                debug(DEBUG, "searching for 0000:00:00.0/");
+                rc = sscanf(devpart, "%hx:%hhx:%hhx.%hhx/%n",
+                            &domain, &bus, &device, &function, &pos);
+                debug(DEBUG, "current:\"%s\" rc:%d pos:%d\n", devpart, rc, pos);
+                arrow(DEBUG, spaces, 9, pos, rc, 3);
+                if (rc != 4)
+                        break;
+                devpart += pos;
+
+                debug(DEBUG, "found pci domain %04hx:%02hhx:%02hhx.%02hhx",
+                      domain, bus, device, function);
+                pci_dev = realloc(dev->pci_dev,
+                                  sizeof(*pci_dev) * (i + 1));
+                if (!pci_dev) {
+                        efi_error("realloc(%p, %zd * (%d + 1)) failed",
+                                  dev->pci_dev, sizeof(*pci_dev), i);
+                        return -1;
+                }
+                dev->pci_dev = pci_dev;
+
+                dev->pci_dev[i].pci_domain = domain;
+                dev->pci_dev[i].pci_bus = bus;
+                dev->pci_dev[i].pci_device = device;
+                dev->pci_dev[i].pci_function = function;
+                dev->n_pci_devs += 1;
+        }
+
+        return devpart - current;
+}
+
+static ssize_t
+dp_create_pci(struct device *dev,
+              uint8_t *buf, ssize_t size, ssize_t off)
+{
+        ssize_t sz = 0, new = 0;
+
+        debug(DEBUG, "entry buf:%p size:%zd off:%zd", buf, size, off);
+
+        if (dev->pci_root.pci_root_acpi_uid_str) {
+                new = efidp_make_acpi_hid_ex(buf + off, size ? size - off : 0,
+                                            dev->pci_root.pci_root_acpi_hid,
+                                            0, 0, "",
+                                            dev->pci_root.pci_root_acpi_uid_str,
+                                            "");
+                if (new < 0) {
+                        efi_error("efidp_make_acpi_hid_ex() failed");
+                        return new;
+                }
+        } else {
+                new = efidp_make_acpi_hid(buf + off, size ? size - off : 0,
+                                         dev->pci_root.pci_root_acpi_hid,
+                                         dev->pci_root.pci_root_acpi_uid);
+                if (new < 0) {
+                        efi_error("efidp_make_acpi_hid() failed");
+                        return new;
+                }
+        }
+        off += new;
+        sz += new;
+
+        for (unsigned int i = 0; i < dev->n_pci_devs; i++) {
+                new = efidp_make_pci(buf + off, size ? size - off : 0,
+                                    dev->pci_dev[i].pci_device,
+                                    dev->pci_dev[i].pci_function);
+                if (new < 0) {
+                        efi_error("efidp_make_pci() failed");
+                        return new;
+                }
+                sz += new;
+                off += new;
+        }
+
+        debug(DEBUG, "returning %zd", sz);
+        return sz;
+}
+
+enum interface_type pci_iftypes[] = { pci, unknown };
+
+struct dev_probe HIDDEN pci_parser = {
+        .name = "pci",
+        .iftypes = pci_iftypes,
+        .flags = DEV_PROVIDES_ROOT,
+        .parse = parse_pci,
+        .create = dp_create_pci,
+};

--- a/src/linux-pmem.c
+++ b/src/linux-pmem.c
@@ -1,0 +1,154 @@
+/*
+ * libefiboot - library for the manipulation of EFI boot variables
+ * Copyright 2012-2018 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fix_coverity.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "efiboot.h"
+
+/*
+ * support NVDIMM-P (pmem / btt) devices
+ * (does not include NVDIMM-${ANYTHING_ELSE})
+ *
+ * /sys/dev/block/$major:$minor looks like:
+ * 259:0 -> ../../devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region9/btt9.0/block/pmem9s
+ * 259:1 -> ../../devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region11/btt11.0/block/pmem11s
+ * 259:3 -> ../../devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region11/btt11.0/block/pmem11s/pmem11s1
+ *
+ * /sys/dev/block/259:0/device looks like:
+ * device -> ../../../btt9.0
+ * /sys/dev/block/259:1/device looks like:
+ * device -> ../../../btt11.0
+ *
+ * /sys/dev/block/259:1/partition looks like:
+ * $ cat partition
+ * 1
+ *
+ * /sys/dev/block/259:0/uuid looks like:
+ * $ cat uuid
+ * 6e54091e-7476-47ac-824b-b6dd69878661
+ *
+ * pmem12s -> ../devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region12/btt12.1/block/pmem12s
+ * dev: 259:0
+ * device -> ../../../btt12.1
+ * device/uuid: 0cee166e-dd56-4bc2-99d2-2544b69025b8
+ * 259:0 -> ../../devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region12/btt12.1/block/pmem12s
+ *
+ * pmem12.1s -> ../devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region12/btt12.2/block/pmem12.1s
+ * dev: 259:1
+ * device -> ../../../btt12.2
+ * device/uuid: 78d94521-91f7-47db-b3a7-51b764281940
+ * 259:1 -> ../../devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region12/btt12.2/block/pmem12.1s
+ *
+ * pmem12.2 -> ../devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region12/pfn12.1/block/pmem12.2
+ * dev: 259:2
+ * device -> ../../../pfn12.1
+ * device/uuid: 829c5205-89a5-4581-9819-df7d7754c622
+ * 259:2 -> ../../devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region12/pfn12.1/block/pmem12.2
+ */
+
+static ssize_t
+parse_pmem(struct device *dev, const char *current)
+{
+        uint8_t *filebuf = NULL;
+        uint8_t system, sysbus, acpi_id;
+        uint16_t pnp_id;
+        int ndbus, region, btt_region_id, btt_id, rc, pos;
+
+        debug(DEBUG, "entry");
+
+        if (!strcmp(dev->driver, "nd_pmem")) {
+                ;
+#if 0 /* dunno */
+        } else if (!strcmp(dev->driver, "nd_blk")) {
+                /* dunno */
+                dev->inteface_type = scsi;
+#endif
+        } else {
+                /*
+                 * not a pmem device
+                 */
+                return 0;
+        }
+
+        /*
+         * We're not actually using any of the values here except pos (our
+         * return value), but rather just being paranoid that this is the sort
+         * of device we care about.
+         *
+         * 259:0 -> ../../devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region12/btt12.1/block/pmem12s
+         */
+        rc = sscanf(current,
+                    "../../devices/LNXSYSTM:%hhx/LNXSYBUS:%hhx/ACPI%hx:%hhx/ndbus%d/region%d/btt%d.%d/%n",
+                    &system, &sysbus, &pnp_id, &acpi_id, &ndbus, &region,
+                    &btt_region_id, &btt_id, &pos);
+        if (rc < 8)
+                return 0;
+
+        /*
+         * but the UUID we really do need to have.
+         */
+        rc = read_sysfs_file(&filebuf,
+                             "class/block/%s/device/uuid", dev->disk_name);
+        if ((rc < 0 && errno == ENOENT) || filebuf == NULL)
+                return -1;
+
+        rc = efi_str_to_guid((char *)filebuf, &dev->nvdimm_label);
+        if (rc < 0)
+                return -1;
+
+        /* UUIDs are stored opposite Endian from GUIDs, so our normal GUID
+         * parser is giving us the wrong thing; swizzle those bytes around.
+         */
+        swizzle_guid_to_uuid(&dev->nvdimm_label);
+
+        dev->interface_type = nd_pmem;
+
+        return pos;
+}
+
+static ssize_t
+dp_create_pmem(struct device *dev,
+               uint8_t *buf, ssize_t size, ssize_t off)
+{
+        ssize_t sz;
+
+        debug(DEBUG, "entry");
+
+        sz = efidp_make_nvdimm(buf + off, size ? size - off : 0,
+                               &dev->nvdimm_label);
+
+        return sz;
+}
+
+enum interface_type pmem_iftypes[] = { nd_pmem, unknown };
+
+struct dev_probe HIDDEN pmem_parser = {
+        .name = "pmem",
+        .iftypes = pmem_iftypes,
+        .flags = DEV_PROVIDES_ROOT|DEV_PROVIDES_HD,
+        .parse = parse_pmem,
+        .create = dp_create_pmem,
+};

--- a/src/linux-sas.c
+++ b/src/linux-sas.c
@@ -1,0 +1,130 @@
+/*
+ * libefiboot - library for the manipulation of EFI boot variables
+ * Copyright 2012-2018 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fix_coverity.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "efiboot.h"
+
+/*
+ * support for SAS devices
+ *
+ * /sys/dev/block/$major:$minor looks like:
+ * 8:32 -> ../../devices/pci0000:00/0000:00:01.0/0000:01:00.0/host4/port-4:0/end_device-4:0/target4:0:0/4:0:0:0/block/sdc
+ * 8:33 -> ../../devices/pci0000:00/0000:00:01.0/0000:01:00.0/host4/port-4:0/end_device-4:0/target4:0:0/4:0:0:0/block/sdc/sdc1
+ *
+ * /sys/dev/block/8:32/device looks like:
+ * DUNNO.  But I suspect it's: ../../../4:0:0:0
+ *
+ * These things are also things in this case:
+ * /sys/class/scsi_host/host4/host_sas_address
+ * /sys/class/block/sdc/device/sas_address
+ *
+ * I'm not sure at the moment if they're the same or not.
+ */
+static ssize_t
+parse_sas(struct device *dev, const char *current)
+{
+        struct stat statbuf = { 0, };
+        int rc;
+        uint32_t scsi_host, scsi_bus, scsi_device, scsi_target;
+        uint64_t scsi_lun;
+        ssize_t pos;
+        uint8_t *filebuf = NULL;
+        uint64_t sas_address;
+
+        debug(DEBUG, "entry");
+
+        pos = parse_scsi_link(current, &scsi_host,
+                              &scsi_bus, &scsi_device,
+                              &scsi_target, &scsi_lun);
+        /*
+         * If we can't parse the scsi data, it isn't a sas device, so return 0
+         * not error.
+         */
+        if (pos < 0)
+                return 0;
+
+        /*
+         * Make sure it has the actual /SAS/ bits before we continue
+         * validating all this junk.
+         */
+        rc = sysfs_stat(&statbuf,
+                        "class/scsi_host/host%d/host_sas_address",
+                        scsi_host);
+        /*
+         * If we can't parse the scsi data, it isn't a /SAS/ device, so return
+         * 0 not error. Later errors mean it is an ata device, but we can't
+         * parse it right, so they return -1.
+         */
+        if (rc < 0)
+                return 0;
+
+        /*
+         * we also need to get the actual sas_address from someplace...
+         */
+        rc = read_sysfs_file(&filebuf,
+                             "class/block/%s/device/sas_address",
+                             dev->disk_name);
+        if (rc < 0 || filebuf == NULL)
+                return -1;
+
+        rc = sscanf((char *)filebuf, "%"PRIx64, &sas_address);
+        if (rc != 1)
+                return -1;
+
+        dev->sas_info.sas_address = sas_address;
+
+        dev->scsi_info.scsi_bus = scsi_bus;
+        dev->scsi_info.scsi_device = scsi_device;
+        dev->scsi_info.scsi_target = scsi_target;
+        dev->scsi_info.scsi_lun = scsi_lun;
+        dev->interface_type = sas;
+        return pos;
+}
+
+static ssize_t
+dp_create_sas(struct device *dev,
+              uint8_t *buf,  ssize_t size, ssize_t off)
+{
+        ssize_t sz;
+
+        debug(DEBUG, "entry");
+
+        sz = efidp_make_sas(buf + off, size ? size - off : 0,
+                            dev->sas_info.sas_address);
+
+        return sz;
+}
+
+enum interface_type sas_iftypes[] = { sas, unknown };
+
+struct dev_probe HIDDEN sas_parser = {
+        .name = "sas",
+        .iftypes = sas_iftypes,
+        .flags = DEV_PROVIDES_HD,
+        .parse = parse_sas,
+        .create = dp_create_sas,
+};

--- a/src/linux-sata.c
+++ b/src/linux-sata.c
@@ -157,6 +157,10 @@ parse_sata(struct device *dev, const char *devlink)
         pos = 0;
 
         debug(DEBUG, "entry");
+        if (is_pata(dev)) {
+                debug(DEBUG, "This is a PATA device; skipping.");
+                return 0;
+        }
 
         /* find the ata info:
          * ata1/host0/target0:0:0/0:0:0:0

--- a/src/linux-sata.c
+++ b/src/linux-sata.c
@@ -1,0 +1,259 @@
+/*
+ * libefiboot - library for the manipulation of EFI boot variables
+ * Copyright 2012-2018 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fix_coverity.h"
+
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "efiboot.h"
+
+/*
+ * Support for SATA (and in some cases other ATA) devices
+ *
+ * /dev/sda as SATA looks like:
+ * /sys/dev/block/8:0 -> ../../devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda
+ *                                                                ^     ^       ^ ^ ^ ^ ^ ^ ^
+ *                                                                |     |       | | | | | | lun again
+ *                                                                |     |       | | | | | target again
+ *                                                                |     |       | | | | device again
+ *                                                                |     |       | | | bus again
+ *                                                                |     |       | | 64-bit lun
+ *                                                                |     |       | 32-bit target
+ *                                                                |     |       32-bit device
+ *                                                                |     32-bit scsi "bus"
+ *                                                                ata print id
+ *
+ * This is not only highly repetitive, but most of it is always 0 anyway.
+ *
+ * /dev/sda1 looks like:
+ * /sys/dev/block/8:1 -> ../../devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0/block/sda/sda1
+ *
+ * sda/device looks like:
+ * device -> ../../../0:0:0:0
+ *
+ * For all of these we're searching for a match for $PRINT_ID and then getting
+ * the other info - if there's a port multiplier and if so what's the PMPN,
+ * and what's the port number:
+ * /sys/class/ata_device/dev$PRINT_ID.$PMPN.$DEVICE  - values "print id", pmp id, and device number
+ * /sys/class/ata_device/dev$PRINT_ID.$DEVICE - values are "print id" and device number
+ * /sys/class/ata_port/ata$PRINT_ID/port_no - contains off-by-one port number)
+ *
+ */
+
+static ssize_t
+sysfs_sata_get_port_info(uint32_t print_id, struct device *dev)
+{
+        DIR *d;
+        struct dirent *de;
+        uint8_t *buf = NULL;
+        int rc;
+
+        d = sysfs_opendir("class/ata_device/");
+        if (!d) {
+                efi_error("could not open /sys/class/ata_device/");
+                return -1;
+        }
+
+        while ((de = readdir(d)) != NULL) {
+                uint32_t found_print_id;
+                uint32_t found_pmp;
+                uint32_t found_devno = 0;
+
+                if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, ".."))
+                        continue;
+
+                rc = sscanf(de->d_name, "dev%d.%d.%d", &found_print_id,
+                            &found_pmp, &found_devno);
+                if (rc < 2 || rc > 3) {
+                        closedir(d);
+                        errno = EINVAL;
+                        return -1;
+                } else if (found_print_id != print_id) {
+                        continue;
+                } else if (rc == 3) {
+                        /*
+                         * the kernel doesn't ever tell us the SATA PMPN
+                         * sentinal value, it'll give us devM.N instead of
+                         * devM.N.O in that case instead.
+                         */
+                        if (found_pmp > 0x7fff) {
+                                closedir(d);
+                                errno = EINVAL;
+                                return -1;
+                        }
+                        dev->sata_info.ata_devno = 0;
+                        dev->sata_info.ata_pmp = found_pmp;
+                        break;
+                } else if (rc == 2) {
+                        dev->sata_info.ata_devno = 0;
+                        dev->sata_info.ata_pmp = 0xffff;
+                        break;
+                }
+        }
+        closedir(d);
+
+        rc = read_sysfs_file(&buf, "class/ata_port/ata%d/port_no",
+                             print_id);
+        if (rc <= 0 || buf == NULL)
+                return -1;
+
+        rc = sscanf((char *)buf, "%d", &dev->sata_info.ata_port);
+        if (rc != 1)
+                return -1;
+
+        /*
+         * ata_port numbers are 1-indexed from libata in the kernel, but
+         * they're 0-indexed in the spec.  For maximal confusion.
+         */
+        if (dev->sata_info.ata_port == 0) {
+                errno = EINVAL;
+                return -1;
+        } else {
+                dev->sata_info.ata_port -= 1;
+        }
+
+        return 0;
+}
+
+static ssize_t
+parse_sata(struct device *dev, const char *devlink)
+{
+        const char *current = devlink;
+        uint32_t print_id;
+        uint32_t scsi_bus, tosser0;
+        uint32_t scsi_device, tosser1;
+        uint32_t scsi_target, tosser2;
+        uint64_t scsi_lun, tosser3;
+        int pos = 0;
+        int rc;
+        char *spaces;
+
+        pos = strlen(current);
+        spaces = alloca(pos+1);
+        memset(spaces, ' ', pos+1);
+        spaces[pos] = '\0';
+        pos = 0;
+
+        debug(DEBUG, "entry");
+
+        /* find the ata info:
+         * ata1/host0/target0:0:0/0:0:0:0
+         *    ^dev  ^host   x y z
+         */
+        debug(DEBUG, "searching for ata1/");
+        rc = sscanf(current, "ata%"PRIu32"/%n", &print_id, &pos);
+        debug(DEBUG, "current:\"%s\" rc:%d pos:%d\n", current, rc, pos);
+        arrow(DEBUG, spaces, 9, pos, rc, 1);
+        /*
+         * If we don't find this one, it isn't an ata device, so return 0 not
+         * error.  Later errors mean it is an ata device, but we can't parse
+         * it right, so they return -1.
+         */
+        if (rc != 1)
+                return 0;
+        current += pos;
+        pos = 0;
+
+        debug(DEBUG, "searching for host0/");
+        rc = sscanf(current, "host%"PRIu32"/%n", &scsi_bus, &pos);
+        debug(DEBUG, "current:\"%s\" rc:%d pos:%d\n", current, rc, pos);
+        arrow(DEBUG, spaces, 9, pos, rc, 1);
+        if (rc != 1)
+                return -1;
+        current += pos;
+        pos = 0;
+
+        debug(DEBUG, "searching for target0:0:0:0/");
+        rc = sscanf(current, "target%"PRIu32":%"PRIu32":%"PRIu64"/%n",
+                    &scsi_device, &scsi_target, &scsi_lun, &pos);
+        debug(DEBUG, "current:\"%s\" rc:%d pos:%d\n", current, rc, pos);
+        arrow(DEBUG, spaces, 9, pos, rc, 3);
+        if (rc != 3)
+                return -1;
+        current += pos;
+        pos = 0;
+
+        debug(DEBUG, "searching for 0:0:0:0/");
+        rc = sscanf(current, "%"PRIu32":%"PRIu32":%"PRIu32":%"PRIu64"/%n",
+                    &tosser0, &tosser1, &tosser2, &tosser3, &pos);
+        debug(DEBUG, "current:\"%s\" rc:%d pos:%d\n", current, rc, pos);
+        arrow(DEBUG, spaces, 9, pos, rc, 4);
+        if (rc != 4)
+                return -1;
+        current += pos;
+
+        rc = sysfs_sata_get_port_info(print_id, dev);
+        if (rc < 0)
+                return -1;
+
+        dev->sata_info.scsi_bus = scsi_bus;
+        dev->sata_info.scsi_device = scsi_device;
+        dev->sata_info.scsi_target = scsi_target;
+        dev->sata_info.scsi_lun = scsi_lun;
+
+        if (dev->interface_type == unknown)
+                dev->interface_type = sata;
+
+        return current - devlink;
+}
+
+static ssize_t
+dp_create_sata(struct device *dev,
+               uint8_t *buf, ssize_t size, ssize_t off)
+{
+        ssize_t sz = -1;
+
+        debug(DEBUG, "entry buf:%p size:%zd off:%zd", buf, size, off);
+
+        if (dev->interface_type == ata || dev->interface_type == atapi) {
+                sz = efidp_make_atapi(buf + off, size ? size - off : 0,
+                                      dev->sata_info.ata_port,
+                                      dev->sata_info.ata_pmp,
+                                      dev->sata_info.ata_devno);
+                if (sz < 0)
+                        efi_error("efidp_make_atapi() failed");
+        } else if (dev->interface_type == sata) {
+                sz = efidp_make_sata(buf + off, size ? size - off : 0,
+                                     dev->sata_info.ata_port,
+                                     dev->sata_info.ata_pmp,
+                                     dev->sata_info.ata_devno);
+                if (sz < 0)
+                        efi_error("efidp_make_sata() failed");
+        } else {
+                return -EINVAL;
+        }
+
+        return sz;
+}
+
+enum interface_type sata_iftypes[] = { sata, unknown };
+
+struct dev_probe HIDDEN sata_parser = {
+        .name = "sata",
+        .iftypes = sata_iftypes,
+        .flags = DEV_PROVIDES_HD,
+        .parse = parse_sata,
+        .create = dp_create_sata,
+};

--- a/src/linux-scsi.c
+++ b/src/linux-scsi.c
@@ -1,0 +1,240 @@
+/*
+ * libefiboot - library for the manipulation of EFI boot variables
+ * Copyright 2012-2018 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fix_coverity.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "efiboot.h"
+
+/*
+ * support for Old-school SCSI devices
+ */
+
+/*
+ * helper for scsi formats...
+ */
+ssize_t HIDDEN
+parse_scsi_link(const char *current, uint32_t *scsi_host,
+                uint32_t *scsi_bus, uint32_t *scsi_device,
+                uint32_t *scsi_target, uint64_t *scsi_lun)
+{
+        int rc;
+        int sz = 0;
+        int pos = 0;
+        char *spaces;
+
+        sz = strlen(current);
+        spaces = alloca(sz+1);
+        memset(spaces, ' ', sz+1);
+        spaces[sz] = '\0';
+        sz = 0;
+
+        debug(DEBUG, "entry");
+        /*
+         * This structure is completely ridiculous.
+         *
+         * /dev/sdc as SAS looks like:
+         * /sys/dev/block/8:32 -> ../../devices/pci0000:00/0000:00:01.0/0000:01:00.0/host4/port-4:0/end_device-4:0/target4:0:0/4:0:0:0/block/sdc
+         * /dev/sdc1 looks like:
+         * /sys/dev/block/8:33 -> ../../devices/pci0000:00/0000:00:01.0/0000:01:00.0/host4/port-4:0/end_device-4:0/target4:0:0/4:0:0:0/block/sdc/sdc1
+         *
+         * OR
+         *
+         * /dev/sdc as SAS looks like:
+         * /sys/dev/block/8:32 -> ../../devices/pci0000:00/0000:00:01.0/0000:01:00.0/host4/port-4:2:0/end_device-4:2:0/target4:2:0/4:2:0:0/block/sdc
+         * /dev/sdc1 looks like:
+         * /sys/dev/block/8:33 -> ../../devices/pci0000:00/0000:00:01.0/0000:01:00.0/host4/port-4:2:0/end_device-4:2:0/target4:2:0/4:2:0:0/block/sdc/sdc1
+         *
+         * /sys/block/sdc/device looks like:
+         * device-> ../../../4:2:0:0
+         *
+         */
+
+        /*
+         * So we start when current is:
+         * host4/port-4:0/end_device-4:0/target4:0:0/4:0:0:0/block/sdc/sdc1
+         */
+        uint32_t tosser0, tosser1;
+
+        /* ignore a bunch of stuff
+         *    host4/port-4:0
+         * or host4/port-4:0:0
+         */
+        debug(DEBUG, "searching for host4/port-4:0 or host4/port-4:0:0");
+        rc = sscanf(current, "host%d/port-%d:%d%n", scsi_host, &tosser0,
+                    &tosser1, &pos);
+        debug(DEBUG, "current:\"%s\" rc:%d pos:%d\n", current+sz, rc, pos);
+        arrow(DEBUG, spaces, 9, pos, rc, 3);
+        if (rc != 3)
+                return -1;
+        sz += pos;
+        pos = 0;
+
+        rc = sscanf(current + sz, ":%d%n", &tosser0, &pos);
+        debug(DEBUG, "current:\"%s\" rc:%d pos:%d\n", current+sz, rc, pos);
+        arrow(DEBUG, spaces, 9, pos, rc, 1);
+        if (rc != 0 && rc != 1)
+                return -1;
+        sz += pos;
+        pos = 0;
+
+        /* next:
+         *    /end_device-4:0
+         * or /end_device-4:0:0
+         * awesomely these are the exact same fields that go into port-blah,
+         * but we don't care for now about any of them anyway.
+         */
+        debug(DEBUG, "searching for /end_device-4:0 or /end_device-4:0:0");
+        rc = sscanf(current + sz, "/end_device-%d:%d%n", &tosser0, &tosser1, &pos);
+        debug(DEBUG, "current:\"%s\" rc:%d pos:%d\n", current+sz, rc, pos);
+        arrow(DEBUG, spaces, 9, pos, rc, 2);
+        if (rc != 2)
+                return -1;
+        sz += pos;
+        pos = 0;
+
+        rc = sscanf(current + sz, ":%d%n", &tosser0, &pos);
+        debug(DEBUG, "current:\"%s\" rc:%d pos:%d\n", current+sz, rc, pos);
+        arrow(DEBUG, spaces, 9, pos, rc, 2);
+        if (rc != 0 && rc != 1)
+                return -1;
+        sz += pos;
+        pos = 0;
+
+        /* now:
+         * /target4:0:0/
+         */
+        uint64_t tosser3;
+        debug(DEBUG, "searching for /target4:0:0/");
+        rc = sscanf(current + sz, "/target%d:%d:%"PRIu64"/%n", &tosser0, &tosser1,
+                    &tosser3, &pos);
+        debug(DEBUG, "current:\"%s\" rc:%d pos:%d\n", current+sz, rc, pos);
+        arrow(DEBUG, spaces, 9, pos, rc, 3);
+        if (rc != 3)
+                return -1;
+        sz += pos;
+        pos = 0;
+
+        /* now:
+         * %d:%d:%d:%llu/
+         */
+        debug(DEBUG, "searching for 4:0:0:0/");
+        rc = sscanf(current + sz, "%d:%d:%d:%"PRIu64"/%n",
+                    scsi_bus, scsi_device, scsi_target, scsi_lun, &pos);
+        debug(DEBUG, "current:\"%s\" rc:%d pos:%d\n", current+sz, rc, pos);
+        arrow(DEBUG, spaces, 9, pos, rc, 4);
+        if (rc != 4)
+                return -1;
+        sz += pos;
+
+        return sz;
+}
+
+static ssize_t
+parse_scsi(struct device *dev, const char *current)
+{
+        uint32_t scsi_host, scsi_bus, scsi_device, scsi_target;
+        uint64_t scsi_lun;
+        ssize_t sz;
+        int pos;
+        int rc;
+        char *spaces;
+
+        pos = strlen(current);
+        spaces = alloca(pos+1);
+        memset(spaces, ' ', pos+1);
+        spaces[pos] = '\0';
+        pos = 0;
+
+        debug(DEBUG, "entry");
+
+        debug(DEBUG, "searching for ../../../0:0:0:0");
+        rc = sscanf(dev->device, "../../../%d:%d:%d:%"PRIu64"%n",
+                    &dev->scsi_info.scsi_bus,
+                    &dev->scsi_info.scsi_device,
+                    &dev->scsi_info.scsi_target,
+                    &dev->scsi_info.scsi_lun,
+                    &pos);
+        debug(DEBUG, "current:\"%s\" rc:%d pos:%d\n", dev->device, rc, pos);
+        arrow(DEBUG, spaces, 9, pos, rc, 3);
+        if (rc != 4)
+                return 0;
+
+        sz = parse_scsi_link(current, &scsi_host,
+                              &scsi_bus, &scsi_device,
+                              &scsi_target, &scsi_lun);
+        if (sz < 0)
+                return 0;
+
+        /*
+         * SCSI disks can have up to 16 partitions, or 4 bits worth
+         * and have one bit for the disk number.
+         */
+        if (dev->major == 8) {
+                dev->interface_type = scsi;
+                dev->disknum = (dev->minor >> 4);
+                set_part(dev, dev->minor & 0xF);
+        } else if (dev->major >= 65 && dev->major <= 71) {
+                dev->interface_type = scsi;
+                dev->disknum = 16*(dev->major-64) + (dev->minor >> 4);
+                set_part(dev, dev->minor & 0xF);
+        } else if (dev->major >= 128 && dev->major <= 135) {
+                dev->interface_type = scsi;
+                dev->disknum = 16*(dev->major-128) + (dev->minor >> 4);
+                set_part(dev, dev->minor & 0xF);
+        } else {
+                efi_error("couldn't parse scsi major/minor");
+                return -1;
+        }
+
+        return sz;
+}
+
+static ssize_t
+dp_create_scsi(struct device *dev,
+               uint8_t *buf,  ssize_t size, ssize_t off)
+{
+        ssize_t sz = 0;
+
+        debug(DEBUG, "entry");
+
+        sz = efidp_make_scsi(buf + off, size ? size - off : 0,
+                             dev->scsi_info.scsi_target,
+                             dev->scsi_info.scsi_lun);
+        if (sz < 0)
+                efi_error("efidp_make_scsi() failed");
+
+        return sz;
+}
+
+enum interface_type scsi_iftypes[] = { scsi, unknown };
+
+struct dev_probe HIDDEN scsi_parser = {
+        .name = "scsi",
+        .iftypes = scsi_iftypes,
+        .flags = DEV_PROVIDES_HD,
+        .parse = parse_scsi,
+        .create = dp_create_scsi,
+};

--- a/src/linux-virtblk.c
+++ b/src/linux-virtblk.c
@@ -1,0 +1,87 @@
+/*
+ * libefiboot - library for the manipulation of EFI boot variables
+ * Copyright 2012-2018 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "fix_coverity.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "efiboot.h"
+
+/*
+ * support for virtio block devices
+ * /sys/dev/block/maj:min look like:
+ * 252:0 -> ../../devices/pci0000:00/0000:00:07.0/virtio2/block/vda
+ * 252:1 -> ../../devices/pci0000:00/0000:00:07.0/virtio2/block/vda/vda1
+ *
+ * vda/device looks like:
+ * device -> ../../../virtio2
+ *
+ * In this case we get 1 storage controller per pci device, so we actually
+ * write the device path as:
+ *
+ * PciRoot(0x0)/Pci(0x7,0x0)/HD(1,GPT,14d30998-b5e3-4b8f-9be3-58a454dd06bf,0x800,0x53000)/File(\EFI\fedora\shimx64.efi)
+ *
+ * But usually we just write the HD() entry, of course.
+ */
+static ssize_t
+parse_virtblk(struct device *dev, const char *current)
+{
+        uint32_t tosser;
+        int pos;
+        int rc;
+        char *spaces;
+
+        pos = strlen(current);
+        spaces = alloca(pos+1);
+        memset(spaces, ' ', pos+1);
+        spaces[pos] = '\0';
+        pos = 0;
+
+        debug(DEBUG, "entry");
+
+        debug(DEBUG, "searching for virtio0/");
+        rc = sscanf(current, "virtio%x/%n", &tosser, &pos);
+        debug(DEBUG, "current:\"%s\" rc:%d pos:%d\n", current, rc, pos);
+        arrow(DEBUG, spaces, 9, pos, rc, 1);
+        /*
+         * If we couldn't find virtioX/ then it isn't a virtio device.
+         */
+        if (rc < 1)
+                return 0;
+
+        dev->interface_type = virtblk;
+
+        return pos;
+}
+
+enum interface_type virtblk_iftypes[] = { virtblk, unknown };
+
+struct dev_probe HIDDEN virtblk_parser = {
+        .name = "virtio block",
+        .iftypes = virtblk_iftypes,
+        .flags = DEV_PROVIDES_HD,
+        .parse = parse_virtblk,
+        .create = NULL,
+};
+

--- a/src/linux.c
+++ b/src/linux.c
@@ -127,7 +127,7 @@ get_partition_number(const char *devpath)
 	int rc;
 	unsigned int maj, min;
 	char *linkbuf;
-	uint8_t *partbuf;
+	uint8_t *partbuf = NULL; /* XXX this is wrong and the code below will be wrong */
 	int ret = -1;
 
 	rc = stat(devpath, &statbuf);

--- a/src/linux.c
+++ b/src/linux.c
@@ -280,6 +280,10 @@ device_free(struct device *dev)
                         free(dev->part_name);
         }
 
+        for (unsigned int i = 0; i < dev->n_pci_devs; i++)
+                if (dev->pci_dev[i].driverlink)
+                        free(dev->pci_dev[i].driverlink);
+
         if (dev->pci_dev)
                 free(dev->pci_dev);
 

--- a/src/linux.c
+++ b/src/linux.c
@@ -1202,3 +1202,22 @@ err:
 		close(fd);
 	return ret;
 }
+
+/************************************************************
+ * get_sector_size
+ * Requires:
+ *  - filedes is an open file descriptor, suitable for reading
+ * Modifies: nothing
+ * Returns:
+ *  sector size, or 512.
+ ************************************************************/
+int UNUSED
+get_sector_size(int filedes)
+{
+        int rc, sector_size = 512;
+
+        rc = ioctl(filedes, BLKSSZGET, &sector_size);
+        if (rc)
+                sector_size = 512;
+        return sector_size;
+}

--- a/src/linux.c
+++ b/src/linux.c
@@ -881,9 +881,6 @@ make_blockdev_path(uint8_t *buf, ssize_t size, struct disk_info *info)
 			return -1;
 		driver+=1;
 
-		if (!strncmp(driver, "pata_", 5) ||
-		    !(strcmp(driver, "ata_piix")))
-			info->interface_type = ata;
 	}
 
 	if (!found &&
@@ -1032,42 +1029,6 @@ eb_disk_info_from_fd(int fd, struct disk_info *info)
 	} else {
 		efi_error("Cannot stat non-block or non-regular file");
 		return 1;
-	}
-
-	/* IDE disks can have up to 64 partitions, or 6 bits worth,
-	 * and have one bit for the disk number.
-	 * This leaves an extra bit at the top.
-	 */
-	if (info->major == 3) {
-		info->disknum = (info->minor >> 6) & 1;
-		info->controllernum = (info->major - 3 + 0) + info->disknum;
-		info->interface_type = ata;
-		info->part    = info->minor & 0x3F;
-		return 0;
-	} else if (info->major == 22) {
-		info->disknum = (info->minor >> 6) & 1;
-		info->controllernum = (info->major - 22 + 2) + info->disknum;
-		info->interface_type = ata;
-		info->part    = info->minor & 0x3F;
-		return 0;
-	} else if (info->major >= 33 && info->major <= 34) {
-		info->disknum = (info->minor >> 6) & 1;
-		info->controllernum = (info->major - 33 + 4) + info->disknum;
-		info->interface_type = ata;
-		info->part    = info->minor & 0x3F;
-		return 0;
-	} else if (info->major >= 56 && info->major <= 57) {
-		info->disknum = (info->minor >> 6) & 1;
-		info->controllernum = (info->major - 56 + 8) + info->disknum;
-		info->interface_type = ata;
-		info->part    = info->minor & 0x3F;
-		return 0;
-	} else if (info->major >= 88 && info->major <= 91) {
-		info->disknum = (info->minor >> 6) & 1;
-		info->controllernum = (info->major - 88 + 12) + info->disknum;
-		info->interface_type = ata;
-		info->part    = info->minor & 0x3F;
-		return 0;
 	}
 
         /* I2O disks can have up to 16 partitions, or 4 bits worth. */

--- a/src/linux.c
+++ b/src/linux.c
@@ -889,7 +889,6 @@ make_blockdev_path(uint8_t *buf, ssize_t size, struct disk_info *info)
 	     info->interface_type == usb ||
 	     info->interface_type == i1394 ||
 	     info->interface_type == fibre ||
-	     info->interface_type == i2o ||
 	     info->interface_type == md)) {
 		uint32_t tosser;
 		int tmpoff;
@@ -1004,14 +1003,6 @@ eb_disk_info_from_fd(int fd, struct disk_info *info)
 	} else {
 		efi_error("Cannot stat non-block or non-regular file");
 		return 1;
-	}
-
-        /* I2O disks can have up to 16 partitions, or 4 bits worth. */
-	if (info->major >= 80 && info->major <= 87) {
-		info->interface_type = i2o;
-		info->disknum = 16*(info->major-80) + (info->minor >> 4);
-		info->part    = (info->minor & 0xF);
-		return 0;
 	}
 
 	rc = sysfs_readlink(&driver, "dev/block/%"PRIu64":%"PRIu32"/device/driver",

--- a/src/linux.c
+++ b/src/linux.c
@@ -1014,8 +1014,8 @@ eb_disk_info_from_fd(int fd, struct disk_info *info)
 
 	memset(info, 0, sizeof *info);
 
-	info->pci_root.root_pci_domain = 0xffff;
-	info->pci_root.root_pci_bus = 0xff;
+	info->pci_root.pci_root_domain = 0xffff;
+	info->pci_root.pci_root_bus = 0xff;
 
 	memset(&buf, 0, sizeof(struct stat));
 	rc = fstat(fd, &buf);

--- a/src/linux.c
+++ b/src/linux.c
@@ -46,40 +46,40 @@
 int HIDDEN
 find_parent_devpath(const char * const child, char **parent)
 {
-	int ret;
-	char *node;
-	char *linkbuf;
+        int ret;
+        char *node;
+        char *linkbuf;
 
-	/* strip leading /dev/ */
-	node = strrchr(child, '/');
-	if (!node)
-		return -1;
-	node++;
+        /* strip leading /dev/ */
+        node = strrchr(child, '/');
+        if (!node)
+                return -1;
+        node++;
 
-	/* look up full path symlink */
-	ret = sysfs_readlink(&linkbuf, "class/block/%s", node);
-	if (ret < 0 || !linkbuf)
-		return ret;
+        /* look up full path symlink */
+        ret = sysfs_readlink(&linkbuf, "class/block/%s", node);
+        if (ret < 0 || !linkbuf)
+                return ret;
 
-	/* strip child */
-	node = strrchr(linkbuf, '/');
-	if (!node)
-		return -1;
-	*node = '\0';
+        /* strip child */
+        node = strrchr(linkbuf, '/');
+        if (!node)
+                return -1;
+        *node = '\0';
 
-	/* read parent */
-	node = strrchr(linkbuf, '/');
-	if (!node)
-		return -1;
-	*node = '\0';
-	node++;
+        /* read parent */
+        node = strrchr(linkbuf, '/');
+        if (!node)
+                return -1;
+        *node = '\0';
+        node++;
 
-	/* write out new path */
-	ret = asprintf(parent, "/dev/%s", node);
-	if (ret < 0)
-		return ret;
+        /* write out new path */
+        ret = asprintf(parent, "/dev/%s", node);
+        if (ret < 0)
+                return ret;
 
-	return 0;
+        return 0;
 }
 
 int HIDDEN

--- a/src/linux.c
+++ b/src/linux.c
@@ -883,26 +883,6 @@ make_blockdev_path(uint8_t *buf, ssize_t size, struct disk_info *info)
 
 	}
 
-	if (!found &&
-	    (info->interface_type == interface_type_unknown ||
-	     info->interface_type == atapi ||
-	     info->interface_type == usb ||
-	     info->interface_type == i1394 ||
-	     info->interface_type == fibre ||
-	     info->interface_type == md)) {
-		uint32_t tosser;
-		int tmpoff;
-
-		rc = sscanf(linkbuf+loff, "virtio%x/%n", &tosser, &tmpoff);
-		if (rc < 0) {
-			return -1;
-		} else if (rc == 1) {
-			info->interface_type = virtblk;
-			loff += tmpoff;
-			found = 1;
-		}
-	}
-
 	/* /dev/nvme0n1 looks like:
 	 * /sys/dev/block/259:0 -> ../../devices/pci0000:00/0000:00:1d.0/0000:05:00.0/nvme/nvme0/nvme0n1
 	 */

--- a/src/linux.h
+++ b/src/linux.h
@@ -259,6 +259,7 @@ extern ssize_t parse_scsi_link(const char *current, uint32_t *host,
 #define set_part(x, y) /* XXX remove later */
 
 /* device support implementations */
+extern struct dev_probe i2o_parser;
 extern struct dev_probe scsi_parser;
 extern struct dev_probe ata_parser;
 

--- a/src/linux.h
+++ b/src/linux.h
@@ -108,6 +108,8 @@ extern int eb_nvme_ns_id(int fd, uint32_t *ns_id);
 
 extern int HIDDEN get_partition_number(const char *devpath);
 
+int UNUSED get_sector_size(int filedes);
+
 extern int HIDDEN find_parent_devpath(const char * const child,
                                       char **parent);
 

--- a/src/linux.h
+++ b/src/linux.h
@@ -22,10 +22,11 @@
 #define _EFIBOOT_LINUX_H
 
 struct pci_root_info {
-	uint16_t root_pci_domain;
-	uint8_t root_pci_bus;
-	uint32_t root_pci_acpi_hid;
-	uint32_t root_pci_acpi_uid;
+        uint16_t pci_root_domain;
+        uint8_t pci_root_bus;
+        uint32_t pci_root_acpi_hid;
+        uint64_t pci_root_acpi_uid;
+        char *pci_root_acpi_uid_str;
 };
 
 struct pci_dev_info {

--- a/src/linux.h
+++ b/src/linux.h
@@ -106,14 +106,12 @@ extern int make_blockdev_path(uint8_t *buf, ssize_t size,
 
 extern int eb_nvme_ns_id(int fd, uint32_t *ns_id);
 
-extern int get_partition_number(const char *devpath)
-        HIDDEN;
+extern int HIDDEN get_partition_number(const char *devpath);
 
-extern int find_parent_devpath(const char * const child, char **parent)
-	HIDDEN;
+extern int HIDDEN find_parent_devpath(const char * const child,
+                                      char **parent);
 
-extern ssize_t make_mac_path(uint8_t *buf, ssize_t size,
-			     const char * const ifname)
-	HIDDEN;
+extern ssize_t HIDDEN make_mac_path(uint8_t *buf, ssize_t size,
+                                    const char * const ifname);
 
 #endif /* _EFIBOOT_LINUX_H */

--- a/src/linux.h
+++ b/src/linux.h
@@ -30,10 +30,10 @@ struct pci_root_info {
 };
 
 struct pci_dev_info {
-	uint16_t pci_domain;
-	uint8_t pci_bus;
-	uint8_t pci_device;
-	uint8_t pci_function;
+        uint16_t pci_domain;
+        uint8_t pci_bus;
+        uint8_t pci_device;
+        uint8_t pci_function;
 };
 
 struct scsi_info {
@@ -259,6 +259,7 @@ extern ssize_t parse_scsi_link(const char *current, uint32_t *host,
 #define set_part(x, y) /* XXX remove later */
 
 /* device support implementations */
+extern struct dev_probe pci_parser;
 extern struct dev_probe sas_parser;
 extern struct dev_probe sata_parser;
 extern struct dev_probe nvme_parser;

--- a/src/linux.h
+++ b/src/linux.h
@@ -259,6 +259,7 @@ extern ssize_t parse_scsi_link(const char *current, uint32_t *host,
 #define set_part(x, y) /* XXX remove later */
 
 /* device support implementations */
+extern struct dev_probe pmem_parser;
 extern struct dev_probe pci_parser;
 extern struct dev_probe sas_parser;
 extern struct dev_probe sata_parser;

--- a/src/linux.h
+++ b/src/linux.h
@@ -34,6 +34,7 @@ struct pci_dev_info {
         uint8_t pci_bus;
         uint8_t pci_device;
         uint8_t pci_function;
+        char *driverlink;
 };
 
 struct scsi_info {
@@ -63,6 +64,15 @@ struct sata_info {
         uint32_t ata_pmp;
 
         uint32_t ata_print_id;
+};
+
+struct ata_info {
+        uint32_t scsi_bus;
+        uint32_t scsi_device;
+        uint32_t scsi_target;
+        uint64_t scsi_lun;
+
+        uint32_t scsi_host;
 };
 
 struct nvme_info {
@@ -114,6 +124,7 @@ struct device {
                                 struct scsi_info scsi_info;
                                 struct sas_info sas_info;
                                 struct sata_info sata_info;
+                                struct ata_info ata_info;
                                 struct nvme_info nvme_info;
                                 efi_guid_t nvdimm_label;
                         };
@@ -128,7 +139,7 @@ extern int HIDDEN set_disk_and_part_name(struct device *dev);
 extern int HIDDEN set_part(struct device *dev, int value);
 extern int HIDDEN set_part_name(struct device *dev, const char * const fmt, ...);
 extern int HIDDEN set_disk_name(struct device *dev, const char * const fmt, ...);
-
+extern bool HIDDEN is_pata(struct device *dev);
 extern int HIDDEN make_blockdev_path(uint8_t *buf, ssize_t size,
                                      struct device *dev);
 

--- a/src/linux.h
+++ b/src/linux.h
@@ -157,7 +157,7 @@ extern int eb_nvme_ns_id(int fd, uint32_t *ns_id);
 
 extern int HIDDEN get_partition_number(const char *devpath);
 
-int UNUSED get_sector_size(int filedes);
+int HIDDEN get_sector_size(int filedes);
 
 extern int HIDDEN find_parent_devpath(const char * const child,
                                       char **parent);

--- a/src/linux.h
+++ b/src/linux.h
@@ -259,5 +259,6 @@ extern ssize_t parse_scsi_link(const char *current, uint32_t *host,
 #define set_part(x, y) /* XXX remove later */
 
 /* device support implementations */
+extern struct dev_probe ata_parser;
 
 #endif /* _EFIBOOT_LINUX_H */

--- a/src/linux.h
+++ b/src/linux.h
@@ -37,10 +37,10 @@ struct pci_dev_info {
 };
 
 struct scsi_info {
-	uint32_t scsi_bus;
-	uint32_t scsi_device;
-	uint32_t scsi_target;
-	uint64_t scsi_lun;
+        uint32_t scsi_bus;
+        uint32_t scsi_device;
+        uint32_t scsi_target;
+        uint64_t scsi_lun;
 };
 
 struct sas_info {
@@ -259,6 +259,8 @@ extern ssize_t parse_scsi_link(const char *current, uint32_t *host,
 #define set_part(x, y) /* XXX remove later */
 
 /* device support implementations */
+extern struct dev_probe scsi_parser;
 extern struct dev_probe ata_parser;
+
 
 #endif /* _EFIBOOT_LINUX_H */

--- a/src/linux.h
+++ b/src/linux.h
@@ -44,12 +44,12 @@ struct scsi_info {
 };
 
 struct sas_info {
-	uint32_t scsi_bus;
-	uint32_t scsi_device;
-	uint32_t scsi_target;
-	uint64_t scsi_lun;
+        uint32_t scsi_bus;
+        uint32_t scsi_device;
+        uint32_t scsi_target;
+        uint64_t scsi_lun;
 
-	uint64_t sas_address;
+        uint64_t sas_address;
 };
 
 struct sata_info {
@@ -259,6 +259,7 @@ extern ssize_t parse_scsi_link(const char *current, uint32_t *host,
 #define set_part(x, y) /* XXX remove later */
 
 /* device support implementations */
+extern struct dev_probe sas_parser;
 extern struct dev_probe sata_parser;
 extern struct dev_probe nvme_parser;
 extern struct dev_probe virtblk_parser;

--- a/src/linux.h
+++ b/src/linux.h
@@ -66,10 +66,10 @@ struct sata_info {
 };
 
 struct nvme_info {
-	int32_t ctrl_id;
-	int32_t ns_id;
-	int has_eui;
-	uint8_t eui[8];
+        int32_t ctrl_id;
+        int32_t ns_id;
+        int has_eui;
+        uint8_t eui[8];
 };
 
 struct disk_info {
@@ -259,6 +259,7 @@ extern ssize_t parse_scsi_link(const char *current, uint32_t *host,
 #define set_part(x, y) /* XXX remove later */
 
 /* device support implementations */
+extern struct dev_probe nvme_parser;
 extern struct dev_probe virtblk_parser;
 extern struct dev_probe i2o_parser;
 extern struct dev_probe scsi_parser;

--- a/src/linux.h
+++ b/src/linux.h
@@ -53,16 +53,16 @@ struct sas_info {
 };
 
 struct sata_info {
-	uint32_t scsi_bus;
-	uint32_t scsi_device;
-	uint32_t scsi_target;
-	uint64_t scsi_lun;
+        uint32_t scsi_bus;
+        uint32_t scsi_device;
+        uint32_t scsi_target;
+        uint64_t scsi_lun;
 
-	uint32_t ata_devno;
-	uint32_t ata_port;
-	uint32_t ata_pmp;
+        uint32_t ata_devno;
+        uint32_t ata_port;
+        uint32_t ata_pmp;
 
-	uint32_t ata_print_id;
+        uint32_t ata_print_id;
 };
 
 struct nvme_info {
@@ -259,6 +259,7 @@ extern ssize_t parse_scsi_link(const char *current, uint32_t *host,
 #define set_part(x, y) /* XXX remove later */
 
 /* device support implementations */
+extern struct dev_probe sata_parser;
 extern struct dev_probe nvme_parser;
 extern struct dev_probe virtblk_parser;
 extern struct dev_probe i2o_parser;

--- a/src/linux.h
+++ b/src/linux.h
@@ -259,6 +259,7 @@ extern ssize_t parse_scsi_link(const char *current, uint32_t *host,
 #define set_part(x, y) /* XXX remove later */
 
 /* device support implementations */
+extern struct dev_probe virtblk_parser;
 extern struct dev_probe i2o_parser;
 extern struct dev_probe scsi_parser;
 extern struct dev_probe ata_parser;

--- a/src/linux.h
+++ b/src/linux.h
@@ -82,6 +82,11 @@ struct nvme_info {
         uint8_t eui[8];
 };
 
+struct nvdimm_info {
+        efi_guid_t namespace_label;
+        efi_guid_t nvdimm_label;
+};
+
 enum interface_type {
         unknown,
         isa, pci, network,
@@ -126,7 +131,7 @@ struct device {
                                 struct sata_info sata_info;
                                 struct ata_info ata_info;
                                 struct nvme_info nvme_info;
-                                efi_guid_t nvdimm_label;
+                                struct nvdimm_info nvdimm_info;
                         };
                 };
                 char *ifname;

--- a/src/linux.h
+++ b/src/linux.h
@@ -148,12 +148,12 @@ struct device {
         };
 };
 
-extern int eb_disk_info_from_fd(int fd, struct disk_info *info);
+extern int HIDDEN eb_disk_info_from_fd(int fd, struct disk_info *info);
 extern int HIDDEN set_disk_and_part_name(struct disk_info *info);
-extern int make_blockdev_path(uint8_t *buf, ssize_t size,
-			      struct disk_info *info);
+extern int HIDDEN make_blockdev_path(uint8_t *buf, ssize_t size,
+                                     struct disk_info *info);
 
-extern int eb_nvme_ns_id(int fd, uint32_t *ns_id);
+extern int HIDDEN eb_nvme_ns_id(int fd, uint32_t *ns_id);
 
 extern int HIDDEN get_partition_number(const char *devpath);
 

--- a/src/loadopt.c
+++ b/src/loadopt.c
@@ -25,6 +25,8 @@
 
 #include "efiboot.h"
 #include "include/efivar/efiboot-loadopt.h"
+#include "util.h"
+#include "hexdump.h"
 
 typedef struct efi_load_option_s {
 	uint32_t attributes;
@@ -44,6 +46,9 @@ efi_loadopt_create(uint8_t *buf, ssize_t size, uint32_t attributes,
 		     + sizeof (uint16_t) + desc_len
 		     + dp_size + optional_data_size;
 
+	debug(DEBUG, "entry buf:%p size:%zd dp:%p dp_size:%zd",
+	      buf, size, dp, dp_size);
+
 	if (size == 0)
 		return sz;
 
@@ -52,24 +57,37 @@ efi_loadopt_create(uint8_t *buf, ssize_t size, uint32_t attributes,
 		return -1;
 	}
 
+	debug(DEBUG, "testing buf");
 	if (!buf) {
 invalid:
 		errno = EINVAL;
 		return -1;
 	}
 
+	debug(DEBUG, "testing optional data presence");
 	if (!optional_data && optional_data_size != 0)
 		goto invalid;
 
+	debug(DEBUG, "testing dp presence");
 	if ((!dp && dp_size == 0) || dp_size < 0)
 		goto invalid;
 
 	if (dp) {
-		if (!efidp_is_valid(dp, dp_size))
+		debug(DEBUG, "testing dp validity");
+		if (!efidp_is_valid(dp, dp_size)) {
+			if (efi_get_verbose() >= 1)
+				hexdump((void *)dp, dp_size);
 			goto invalid;
+		}
 
-		if (efidp_size(dp) != dp_size)
+		debug(DEBUG,
+		      "testing dp size: dp_size:%zd efidp_size(dp):%zd",
+		      dp_size, efidp_size(dp));
+		if (efidp_size(dp) != dp_size) {
+			if (efi_get_verbose() >= 1)
+				hexdump((void *)dp, dp_size);
 			goto invalid;
+		}
 	}
 
 	if (buf) {

--- a/src/path-helpers.c
+++ b/src/path-helpers.c
@@ -1,0 +1,173 @@
+/*
+ * path-helper.c
+ * Copyright 2018 Peter Jones <pjones@redhat.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "efivar.h"
+
+static bool
+cinpat(const char c, const char *pat)
+{
+        for (unsigned int i = 0; pat[i]; i++)
+                if (pat[i] == c)
+                        return true;
+        return false;
+}
+
+static unsigned int
+strxcspn(const char *s, const char *pattern)
+{
+        unsigned int i;
+        for (i = 0; s[i]; i++) {
+                if (!cinpat(s[i], pattern))
+                        break;
+        }
+        return i;
+}
+
+struct span {
+        const char *pos;
+        size_t len;
+};
+
+/*
+ * count how many parts of a path there are, with some caveats:
+ * a leading / is one because it's a directory, but all other slashes are
+ * treated as separators, so i.e.:
+ * 1: /
+ * 2: /foo foo/bar foo/bar/
+ * 3: /foo/bar /foo/bar/ foo/bar/baz
+ *
+ * the usage model here is 1 pass to count, one allocation, one pass to
+ * separate.
+ */
+unsigned int HIDDEN
+count_spans(const char *str, const char *reject, unsigned int *chars)
+{
+        unsigned int s = 0, c = 0, pos = 0;
+
+        if (str[0] == '/') {
+                s += 1;
+                c += 2;
+                pos += 1;
+        }
+
+        while (str[pos]) {
+                unsigned int n;
+
+                n = strcspn(str + pos, reject);
+                if (n) {
+                        s += 1;
+                        c += n + 1;
+                        pos += n;
+                }
+
+                pos += strxcspn(str + pos, reject);
+        }
+
+        if (chars)
+                *chars = c;
+        return s;
+}
+
+void HIDDEN
+fill_spans(const char *str, const char *reject, void *spanbuf)
+{
+        struct span *spans = (struct span *)spanbuf;
+        struct span *span = spans;
+        unsigned int pos = 0;
+
+        if (str[0] == '/') {
+                span->pos = str;
+                span->len = 1;
+                span++;
+                pos += 1;
+        }
+
+        while (str[pos]) {
+                unsigned int n;
+
+                n = strcspn(str + pos, reject);
+                if (n) {
+                        span->pos = str + pos;
+                        span->len = n;
+                        span++;
+                        pos += n;
+                }
+
+                pos += strxcspn(str + pos, reject);
+        }
+        span->pos = NULL;
+        span->len = 0;
+}
+
+#define split_spans(str, reject)                                        \
+        ({                                                              \
+                struct span *ret_ = NULL;                               \
+                unsigned int s_, c_;                                    \
+                                                                        \
+                s_ = count_spans(str, "/", &c_);                        \
+                if (s_) {                                               \
+                        ret_ = alloca(sizeof(struct span[s_+1]));       \
+                        if (ret_)                                       \
+                                fill_spans(str, reject, ret_);          \
+                } else {                                                \
+                        errno = 0;                                      \
+                }                                                       \
+                ret_;                                                   \
+        })
+
+int HIDDEN
+find_path_segment(const char *path, int segment, const char **pos, size_t *len)
+{
+        struct span *span, *last;
+        int nspans = 0;
+
+        if (!pos || !len) {
+                errno = EINVAL;
+                return -1;
+        }
+
+        span = split_spans(path, "/");
+        if (!span) {
+                if (errno)
+                        return -1;
+                *pos = NULL;
+                *len = 0;
+                return 0;
+        }
+
+        for (last = span; last->pos; last++)
+                nspans += 1;
+
+        if (segment < 0)
+                segment = nspans + segment;
+
+        if (nspans < 1 || segment < 0 || segment >= nspans) {
+                errno = ENOENT;
+                return -1;
+        }
+
+        for (int i = 0; i < segment; i++)
+                span++;
+
+        *pos = span->pos;
+        *len = span->len;
+        return 0;
+}
+
+// vim:fenc=utf-8:tw=75:et

--- a/src/path-helpers.h
+++ b/src/path-helpers.h
@@ -1,0 +1,48 @@
+/*
+ * path-helper.h
+ * Copyright 2018 Peter Jones <pjones@redhat.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PATH_HELPER_H_
+#define PATH_HELPER_H_
+
+void HIDDEN fill_spans(const char *str, const char *reject, void *spanbuf);
+unsigned int HIDDEN count_spans(const char *str, const char *reject, unsigned int *chars);
+int HIDDEN find_path_segment(const char *path, int segment, const char **pos, size_t *len);
+
+#define pathseg(path, seg)                                              \
+        ({                                                              \
+                const char *pos_ = NULL;                                \
+                char *ret_ = NULL;                                      \
+                size_t len_ = 0;                                        \
+                int rc_;                                                \
+                                                                        \
+                rc_ = find_path_segment(path, seg, &pos_, &len_);       \
+                if (rc_ >= 0) {                                         \
+                        ret_ = alloca(len_ + 1);                        \
+                        if (ret_) {                                     \
+                                memcpy(ret_, pos_, len_);               \
+                                ret_[len_] = '\0';                      \
+                        }                                               \
+                }                                                       \
+                ret_;                                                   \
+        })
+
+
+
+#endif /* !PATH_HELPER_H_ */
+// vim:fenc=utf-8:tw=75:et

--- a/src/ucs2.h
+++ b/src/ucs2.h
@@ -76,7 +76,7 @@ ucs2_to_utf8(const uint16_t * const chars, ssize_t limit)
 
 	if (limit < 0)
 		limit = ucs2len(chars, -1);
-	ret = alloca(limit * 6 + 1);
+	ret = malloc(limit * 6 + 1);
 	if (!ret)
 		return NULL;
 	memset(ret, 0, limit * 6 +1);
@@ -120,7 +120,7 @@ ucs2_to_utf8(const uint16_t * const chars, ssize_t limit)
 #endif
 	}
 	ret[j] = '\0';
-	return (unsigned char *)strdup((char *)ret);
+	return ret;
 }
 
 static inline ssize_t UNUSED NONNULL(4)

--- a/src/util.h
+++ b/src/util.h
@@ -241,25 +241,6 @@ lcm(uint64_t x, uint64_t y)
         return (x / n) * y;
 }
 
-/************************************************************
- * get_sector_size
- * Requires:
- *  - filedes is an open file descriptor, suitable for reading
- * Modifies: nothing
- * Returns:
- *  sector size, or 512.
- ************************************************************/
-static inline int UNUSED
-get_sector_size(int filedes)
-{
-        int rc, sector_size = 512;
-
-        rc = ioctl(filedes, BLKSSZGET, &sector_size);
-        if (rc)
-                sector_size = 512;
-        return sector_size;
-}
-
 #ifndef strndupa
 #define strndupa(s, l)                                                  \
        (__extension__ ({                                                \

--- a/src/util.h
+++ b/src/util.h
@@ -157,8 +157,10 @@ read_file(int fd, uint8_t **buf, size_t *bufsize)
         ssize_t s = 0;
 
         uint8_t *newbuf;
-        if (!(newbuf = calloc(size, sizeof (uint8_t))))
+        if (!(newbuf = calloc(size, sizeof (uint8_t)))) {
+                efi_error("could not allocate memory");
                 return -1;
+        }
         *buf = newbuf;
 
         do {
@@ -181,6 +183,7 @@ read_file(int fd, uint8_t **buf, size_t *bufsize)
                         *buf = NULL;
                         *bufsize = 0;
                         errno = saved_errno;
+                        efi_error("could not read from file");
                         return -1;
                 }
                 filesize += s;
@@ -195,6 +198,7 @@ read_file(int fd, uint8_t **buf, size_t *bufsize)
                                 *buf = NULL;
                                 *bufsize = 0;
                                 errno = ENOMEM;
+                                efi_error("could not read from file");
                                 return -1;
                         }
                         newbuf = realloc(*buf, size + 4096);
@@ -204,6 +208,7 @@ read_file(int fd, uint8_t **buf, size_t *bufsize)
                                 *buf = NULL;
                                 *bufsize = 0;
                                 errno = saved_errno;
+                                efi_error("could not allocate memory");
                                 return -1;
                         }
                         *buf = newbuf;
@@ -216,6 +221,7 @@ read_file(int fd, uint8_t **buf, size_t *bufsize)
         if (!newbuf) {
                 free(*buf);
                 *buf = NULL;
+                efi_error("could not allocate memory");
                 return -1;
         }
         newbuf[filesize] = '\0';

--- a/src/util.h
+++ b/src/util.h
@@ -292,60 +292,70 @@ get_sector_size(int filedes)
                 _rc;                                                    \
         })
 
-#define read_sysfs_file(buf, fmt, args...)                              \
+#define vasprintfa(str, fmt, ap)                                        \
         ({                                                              \
-                int _rc=-1;                                             \
-                char *_pathname;                                        \
-                uint8_t *_buf=NULL;                                     \
-                size_t _bufsize=-1;                                     \
-                int _saved_errno;                                       \
-                                                                        \
-                *(buf) = NULL;                                          \
-                _rc = asprintfa(&_pathname, (fmt), ## args);            \
-                if (_rc >= 0) {                                         \
-                        int _fd;                                        \
-                        _fd = open(_pathname, O_RDONLY);                \
-                        _saved_errno = errno;                           \
+                char *_tmp = NULL;                                      \
+                int _rc;                                                \
+                *(str) = NULL;                                          \
+                _rc = vasprintf((str), (fmt), (ap));                    \
+                if (_rc > 0) {                                          \
+                        _tmp = strdupa(*(str));                         \
+                        if (!_tmp) {                                    \
+                                _rc = -1;                               \
+                        } else {                                        \
+                                free(*(str));                           \
+                                *(str) = _tmp;                          \
+                        }                                               \
+                } else {                                                \
                         _rc = -1;                                       \
-                        if (_fd >= 0) {                                 \
-                                _rc = read_file(_fd, &_buf, &_bufsize); \
-                                _saved_errno = errno;                   \
-                                close(_fd);                             \
-                                errno = _saved_errno;                   \
-                        }                                               \
-                }                                                       \
-                if (_rc >= 0) {                                         \
-                        uint8_t *_buf2 = alloca(_bufsize);              \
-                        _saved_errno = errno;                           \
-                        if (_buf2) {                                    \
-                                memcpy(_buf2, _buf, _bufsize);          \
-                                _rc = _bufsize;                         \
-                        }                                               \
-                        free(_buf);                                     \
-                        *((uint8_t **)buf) = _buf2;                     \
-                        errno = _saved_errno;                           \
                 }                                                       \
                 _rc;                                                    \
         })
 
-#define sysfs_readlink(linkbuf, fmt, args...)                           \
-        ({                                                              \
-                char *_lb = alloca(PATH_MAX+1);                         \
-                char *_pn;                                              \
-                int _rc;                                                \
-                                                                        \
-                *(linkbuf) = NULL;                                      \
-                _rc = asprintfa(&_pn, fmt, ## args);                    \
-                if (_rc >= 0) {                                         \
-                        ssize_t _linksz;                                \
-                        _linksz = readlink(_pn, _lb, PATH_MAX);         \
-                        _rc = _linksz;                                  \
-                        if (_linksz >= 0)                               \
-                                _lb[_linksz] = '\0';                    \
-                        *(linkbuf) = _lb;                               \
-                }                                                       \
-                _rc;                                                    \
-        })
+static inline ssize_t
+get_file(uint8_t **result, const char * const fmt, ...)
+{
+        char *path;
+        uint8_t *buf = NULL;
+        size_t bufsize = 0;
+        ssize_t rc;
+        va_list ap;
+        int error;
+        int fd;
+
+        if (result == NULL) {
+                efi_error("invalid parameter 'result'");
+                return -1;
+        }
+
+        va_start(ap, fmt);
+        rc = vasprintfa(&path, fmt, ap);
+        va_end(ap);
+        if (rc < 0) {
+                efi_error("could not allocate memory");
+                return -1;
+        }
+
+        fd = open(path, O_RDONLY);
+        if (fd < 0) {
+                efi_error("could not open file \"%s\" for reading",
+                          path);
+                return -1;
+        }
+
+        rc = read_file(fd, &buf, &bufsize);
+        error = errno;
+        close(fd);
+        errno = error;
+
+        if (rc < 0) {
+                efi_error("could not read file \"%s\"", path);
+                return -1;
+        }
+
+        *result = buf;
+        return bufsize;
+}
 
 static inline void UNUSED
 swizzle_guid_to_uuid(efi_guid_t *guid)

--- a/src/util.h
+++ b/src/util.h
@@ -365,6 +365,7 @@ swizzle_guid_to_uuid(efi_guid_t *guid)
         })
 
 #define debug(level, fmt, args...) debug_(__FILE__, __LINE__, __func__, level, fmt, ## args)
+#define arrow(l,b,o,p,n,m) ({if(n==m){char c_=b[p+1]; b[o]='^'; b[p+o]='^';b[p+o+1]='\0';debug(l,"%s",b);b[o]=' ';b[p+o]=' ';b[p+o+1]=c_;}})
 
 #define DEBUG 1
 


### PR DESCRIPTION
This involves re-writing most of the linux-specific libefiboot code because of how we were detecting "partitions" our EDD heuristic before; the new version is much much cleaner.