### PR TITLE
linux-nvme: allow eui to be empty

### DIFF
--- a/src/linux-nvme.c
+++ b/src/linux-nvme.c
@@ -117,8 +117,6 @@ parse_nvme(struct device *dev, const char *current, const char *root UNUSED)
                 }
                 dev->nvme_info.has_eui = 1;
                 memcpy(dev->nvme_info.eui, eui, sizeof(eui));
-        } else {
-                return -1;
         }
 
         return pos0;


### PR DESCRIPTION
The device path creator can handle nvme without eui.

Signed-off-by: Gary Lin <glin@suse.com>