### PR TITLE
makeguids: initialize memory

### DIFF
--- a/src/makeguids.c
+++ b/src/makeguids.c
@@ -147,6 +147,7 @@ main(int argc, char *argv[])
 		outbuf = realloc(outbuf, line * sizeof (struct guidname));
 		if (!outbuf)
 			err(1, "makeguids");
+		memset(outbuf + line - 1, 0, sizeof(struct guidname));
 
 		char *symbol = strchr(guidstr, '\t');
 		if (symbol == NULL)


### PR DESCRIPTION
initialize memory in makeguids
so that we do not write uninitialized memory into guids.bin and names.bin
which made the resulting libefivar.so.1.36 unreproducible.
See https://reproducible-builds.org/ for why this matters.

For background information on how ASLR triggers unreproducibility see https://github.com/bmwiedemann/theunreproduciblepackage/tree/master/aslr