### PR TITLE
Fix incorrect failure on absence of eui.

### DIFF
--- a/src/linux-nvme.c
+++ b/src/linux-nvme.c
@@ -117,8 +117,6 @@ parse_nvme(struct device *dev, const char *current, const char *root UNUSED)
                 }
                 dev->nvme_info.has_eui = 1;
                 memcpy(dev->nvme_info.eui, eui, sizeof(eui));
-        } else {
-                return -1;
         }
 
         return pos0;


### PR DESCRIPTION
Do not fail when there's no eui on an nvme device. This is a bug
introduced in ff696a432b. nvme devices do not have to have eui.

The previous version was correct and there's has_eui to indicate whether
eui was successfully read.

The issue causes efi_generate_file_device_path_from_esp() to fail on all
the platforms which have ESP on an NVMe device which do not have eui.