### PR TITLE
A series of patches for Android porting

### DIFF
--- a/src/Android.mk
+++ b/src/Android.mk
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2019 The Android-x86 Open Source Project
+#
+# Licensed under the GNU Lesser General Public License Version 2.1.
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.gnu.org/licenses/lgpl-2.1.html
+#
+
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := makeguids
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
+LOCAL_CFLAGS := -DEFIVAR_BUILD_ENVIRONMENT
+LOCAL_SRC_FILES := guid.c makeguids.c
+LOCAL_LDLIBS := -ldl
+include $(BUILD_HOST_EXECUTABLE)
+
+include $(CLEAR_VARS)
+
+LOCAL_MODULE := libefivar
+LOCAL_MODULE_CLASS := STATIC_LIBRARIES
+LIBEFIBOOT_SOURCES := \
+	crc32.c \
+	creator.c \
+	disk.c \
+	gpt.c \
+	loadopt.c \
+	path-helpers.c \
+	$(notdir $(wildcard $(LOCAL_PATH)/linux*.c))
+
+LIBEFIVAR_SOURCES := \
+	dp.c \
+	dp-acpi.c \
+	dp-hw.c \
+	dp-media.c \
+	dp-message.c \
+	efivarfs.c \
+	error.c \
+	export.c \
+	guid.c \
+	guids.S \
+	lib.c \
+	vars.c
+
+LOCAL_SRC_FILES := $(LIBEFIBOOT_SOURCES) $(LIBEFIVAR_SOURCES)
+LOCAL_CFLAGS := -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -std=gnu11
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/include
+LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_C_INCLUDES) $(LOCAL_C_INCLUDES)/efivar $(local-generated-sources-dir)
+LIBEFIVAR_GUIDS_H := $(local-generated-sources-dir)/efivar/efivar-guids.h
+LOCAL_GENERATED_SOURCES := $(LIBEFIVAR_GUIDS_H) $(local-generated-sources-dir)/guid-symbols.c
+$(LIBEFIVAR_GUIDS_H): PRIVATE_CUSTOM_TOOL = $^ $(addprefix $(dir $(@D)),guids.bin names.bin guid-symbols.c efivar/efivar-guids.h)
+$(LIBEFIVAR_GUIDS_H): $(BUILD_OUT_EXECUTABLES)/makeguids $(LOCAL_PATH)/guids.txt
+	$(transform-generated-source)
+$(lastword $(LOCAL_GENERATED_SOURCES)): $(LIBEFIVAR_GUIDS_H)
+
+include $(BUILD_STATIC_LIBRARY)

--- a/src/dp-media.c
+++ b/src/dp-media.c
@@ -46,8 +46,7 @@ _format_media_dn(char *buf, size_t size, const_efidp dp)
 			break;
 		case EFIDP_HD_SIGNATURE_GUID:
 			format(buf, size, off, "HD", "GPT,");
-			format_guid(buf, size, off, "HD",
-				    (efi_guid_t *)dp->hd.signature);
+			format_guid(buf, size, off, "HD", dp->hd.signature);
 			format(buf, size, off, "HD",
 			       ",0x%"PRIx64",0x%"PRIx64")",
 			       dp->hd.start, dp->hd.size);

--- a/src/dp-message.c
+++ b/src/dp-message.c
@@ -364,7 +364,7 @@ _format_message_dn(char *buf, size_t size, const_efidp dp)
 			       dp->infiniband.port_gid[1],
 			       dp->infiniband.port_gid[0]);
 			format_guid(buf, size, off, "Infiniband",
-				    (efi_guid_t *)&dp->infiniband.ioc_guid);
+				    &dp->infiniband.ioc_guid);
 			format(buf, size, off, "Infiniband",
 			       ",%"PRIu64",%"PRIu64")",
 			       dp->infiniband.target_port_id,

--- a/src/linux.c
+++ b/src/linux.c
@@ -252,15 +252,6 @@ static struct dev_probe *dev_probes[] = {
         NULL
 };
 
-static inline bool
-supports_iface(struct dev_probe *probe, enum interface_type iftype)
-{
-        for (unsigned int i = 0; probe->iftypes[i] != unknown; i++)
-                if (probe->iftypes[i] == iftype)
-                        return true;
-        return false;
-}
-
 void HIDDEN
 device_free(struct device *dev)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -252,6 +252,17 @@ lcm(uint64_t x, uint64_t y)
         return (x / n) * y;
 }
 
+#ifndef strdupa
+#define strdupa(s)                                                      \
+       (__extension__ ({                                                \
+                const char *__in = (s);                                 \
+                size_t __len = strlen (__in);                           \
+                char *__out = (char *) alloca (__len + 1);              \
+                strcpy(__out, __in);                                    \
+                __out;                                                  \
+        }))
+#endif
+
 #ifndef strndupa
 #define strndupa(s, l)                                                  \
        (__extension__ ({                                                \


### PR DESCRIPTION
These patches are the Android porting of efivar. One of the patches adds an Android.mk makefile for Android build system. The others fixes some explicit errors(warnings) generated by Android's clang compiler. This was tested fine by Android-x86 project since nougat-x86.