### PR TITLE
Make sure makeguids helper is compiled for the host's arch

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -52,7 +52,7 @@ include/efivar/efivar-guids.h : makeguids guids.txt
 	./makeguids guids.txt guids.bin names.bin \
 		guid-symbols.c include/efivar/efivar-guids.h
 
-makeguids : CPPFLAGS+=-DEFIVAR_BUILD_ENVIRONMENT
+makeguids : CPPFLAGS+=-DEFIVAR_BUILD_ENVIRONMENT -march=native
 makeguids : LIBS=dl
 makeguids : $(MAKEGUIDS_SOURCES)
 makeguids : CCLD=$(CCLD_FOR_BUILD)


### PR DESCRIPTION
Currently makeguids is compiled with the same flags/settings as the rest
of the package, which does not work in case of cross-compiles when arch
of the build host and the target host are different. Let's force
compiling for the native host arch to avoid this issue.

Note that this is not a full cross-compile solution as this does not
account for potential differences in host/target compilers (versions,
clang vs gcc, etc), but it removes one of the issue with package build
aborting due to invalid instruction on the host.

Signed-off-by: Dmitry Torokhov <dtor@chromium.org>