### PR TITLE
Makefile: sort $(wildcard) output for reproducibility

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -15,7 +15,7 @@ TARGETS=$(LIBTARGETS) $(BINTARGETS) $(PCTARGETS)
 STATICTARGETS=$(STATICLIBTARGETS) $(STATICBINTARGETS)
 
 LIBEFIBOOT_SOURCES = crc32.c creator.c disk.c gpt.c loadopt.c path-helpers.c \
-		     linux.c $(wildcard linux-*.c)
+		     linux.c $(sort $(wildcard linux-*.c))
 LIBEFIBOOT_OBJECTS = $(patsubst %.c,%.o,$(LIBEFIBOOT_SOURCES))
 LIBEFIVAR_SOURCES = crc32.c dp.c dp-acpi.c dp-hw.c dp-media.c dp-message.c \
 	efivarfs.c error.c export.c guid.c guids.S guid-symbols.c \
@@ -25,7 +25,7 @@ EFIVAR_SOURCES = efivar.c
 GENERATED_SOURCES = include/efivar/efivar-guids.h guid-symbols.c
 MAKEGUIDS_SOURCES = makeguids.c guid.c
 ALL_SOURCES=$(LIBEFIBOOT_SOURCES) $(LIBEFIVAR_SOURCES) $(MAKEGUIDS_SOURCES) \
-	$(wildcard include/efivar/*.h) $(GENERATED_SOURCES) $(EFIVAR_SOURCES)
+	$(sort $(wildcard include/efivar/*.h)) $(GENERATED_SOURCES) $(EFIVAR_SOURCES)
 
 $(call deps-of,$(ALL_SOURCES)) : | deps
 -include $(call deps-of,$(ALL_SOURCES))
@@ -103,7 +103,7 @@ install : all
 	$(INSTALL) -d -m 755 $(DESTDIR)$(PCDIR)
 	$(foreach x, $(PCTARGETS), $(INSTALL) -m 644 $(x) $(DESTDIR)$(PCDIR) ;)
 	$(INSTALL) -d -m 755 $(DESTDIR)$(INCLUDEDIR)/efivar
-	$(foreach x, $(wildcard $(TOPDIR)/src/include/efivar/*.h), $(INSTALL) -m 644 $(x) $(DESTDIR)$(INCLUDEDIR)/efivar/$(notdir $(x));)
+	$(foreach x, $(sort $(wildcard $(TOPDIR)/src/include/efivar/*.h)), $(INSTALL) -m 644 $(x) $(DESTDIR)$(INCLUDEDIR)/efivar/$(notdir $(x));)
 	$(INSTALL) -d -m 755 $(DESTDIR)$(BINDIR)
 	$(foreach x, $(BINTARGETS), $(INSTALL) -m 755 $(x) $(DESTDIR)$(BINDIR);)
 


### PR DESCRIPTION
https://reproducible-builds.org/docs/stable-inputs/

This should fix reproducibility issues noticed on Debian[1] and NixOS[2]

[1] https://tests.reproducible-builds.org/debian/rb-pkg/buster/i386/diffoscope-results/efivar.html
[2] https://r13y.com/diff/b32a9d1c4159dab6aa15e873c0e5fc315ea2bdf545416d21d5b4a29f3c138727-3473019ee52f59732b13253b828bf2eb545384510f30db34413eb6c91dd3d047.html

(Note: technically that last one for the `install` target isn't necessary, since that has no influence on reproducibility of the output. I just added it for consistency -- all wildcards are sorted.)