### PR TITLE
Handle /sys/devices/virtual/{nvme-fabrics,nvme-subsystem} devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.so
 *.so.*
 *.spec
+*.strace
 *.tar.*
 *.var
 core.*

--- a/src/dp-acpi.c
+++ b/src/dp-acpi.c
@@ -1,6 +1,6 @@
 /*
  * libefivar - library for the manipulation of EFI variables
- * Copyright 2012-2015 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -52,9 +52,9 @@ _format_acpi_hid_ex(unsigned char *buf, size_t size,
 {
 	ssize_t off = 0;
 
-	debug("hid:0x%08x hidstr:\"%s\"", dp->acpi_hid_ex.hid, hidstr);
-	debug("cid:0x%08x cidstr:\"%s\"", dp->acpi_hid_ex.cid, cidstr);
-	debug("uid:0x%08x uidstr:\"%s\"", dp->acpi_hid_ex.uid, uidstr);
+	debug("hid:0x%08x hidstr:'%s'", dp->acpi_hid_ex.hid, hidstr);
+	debug("cid:0x%08x cidstr:'%s'", dp->acpi_hid_ex.cid, cidstr);
+	debug("uid:0x%08x uidstr:'%s'", dp->acpi_hid_ex.uid, uidstr);
 
 	if (!hidstr && !cidstr && (uidstr || dp->acpi_hid_ex.uid)) {
 		format(buf, size, off, "AcpiExp",

--- a/src/error.c
+++ b/src/error.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2015 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  * Copyright (C) 2000-2001 Dell Computer Corporation <Matt_Domsch@dell.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -27,6 +27,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <sys/random.h>
 #include <unistd.h>
 
 #include "efiboot.h"
@@ -166,6 +167,7 @@ efi_error_pop(void)
 static int efi_verbose;
 static FILE *efi_errlog, *efi_dbglog;
 static int efi_dbglog_fd = -1;
+static intptr_t efi_dbglog_cookie;
 static int log_level;
 static char efi_dbglog_buf[4096];
 
@@ -176,7 +178,7 @@ efi_set_loglevel(int level)
 }
 
 static ssize_t
-dbglog_write(void *cookie UNUSED, const char *buf, size_t size)
+dbglog_write(void *cookie, const char *buf, size_t size)
 {
 	FILE *log = efi_errlog ? efi_errlog : stderr;
 	ssize_t ret = size;
@@ -185,6 +187,11 @@ dbglog_write(void *cookie UNUSED, const char *buf, size_t size)
 		ret = fwrite(buf, 1, size, log);
 	} else if (efi_dbglog_fd >= 0) {
 		lseek(efi_dbglog_fd, 0, SEEK_SET);
+		if ((intptr_t)cookie != 0 &&
+		    (intptr_t)cookie == efi_dbglog_cookie &&
+		    size > 0 &&
+		    buf[size-1] == '\n')
+			size -= 1;
 		ret = write(efi_dbglog_fd, buf, size);
 	}
 	return ret;
@@ -248,6 +255,7 @@ efi_error_fini(void)
 static void CONSTRUCTOR
 efi_error_init(void)
 {
+	ssize_t bytes;
 	cookie_io_functions_t io_funcs = {
 		.write = dbglog_write,
 		.seek = dbglog_seek,
@@ -258,7 +266,11 @@ efi_error_init(void)
 	if (efi_dbglog_fd == -1)
 		return;
 
-	efi_dbglog = fopencookie(NULL, "a", io_funcs);
+	bytes = getrandom(&efi_dbglog_cookie, sizeof(efi_dbglog_cookie), 0);
+	if (bytes < (ssize_t)sizeof(efi_dbglog_cookie))
+		efi_dbglog_cookie = 0;
+
+	efi_dbglog = fopencookie((void *)efi_dbglog_cookie, "a", io_funcs);
 	if (efi_dbglog)
 		setvbuf(efi_dbglog, efi_dbglog_buf, _IOLBF,
 			sizeof(efi_dbglog_buf));

--- a/src/include/defaults.mk
+++ b/src/include/defaults.mk
@@ -22,6 +22,7 @@ WARNINGS_GCC ?= -Wmaybe-uninitialized \
 WARNINGS_CCC_ANALYZER ?= $(WARNINGS_GCC)
 WARNINGS ?= -Wall -Wextra \
 	    -Wno-address-of-packed-member \
+	    -Wno-missing-field-initializers \
 	    $(call family,WARNINGS)
 ERRORS ?= -Werror -Wno-error=cpp $(call family,ERRORS)
 CPPFLAGS ?=

--- a/src/linux-acpi-root.c
+++ b/src/linux-acpi-root.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2018 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -63,6 +63,7 @@ parse_acpi_root(struct device *dev, const char *current, const char *root UNUSED
 	 */
 	rc = sscanf(devpart, "../../devices/platform/%n", &pos);
 	debug("devpart:\"%s\" rc:%d pos:%d", devpart, rc, pos);
+	dbgmk("         ", pos);
 	if (rc != 0 || pos < 1)
 		return 0;
 	devpart += pos;
@@ -97,6 +98,7 @@ parse_acpi_root(struct device *dev, const char *current, const char *root UNUSED
 
 	pos -= 4;
 	debug("devpart:\"%s\" rc:%d pos:%d", devpart, rc, pos);
+	dbgmk("         ", pos);
 	acpi_header = strndupa(devpart, pos);
 	if (!acpi_header)
 		return 0;
@@ -114,6 +116,7 @@ parse_acpi_root(struct device *dev, const char *current, const char *root UNUSED
 	}
 	debug("devpart:\"%s\" parsed:%04hx:%02hhx pos:%d rc:%d",
 	      devpart, pad0, pad1, pos, rc);
+	dbgmk("         ", pos);
 
 	devpart += pos;
 

--- a/src/linux-acpi-root.c
+++ b/src/linux-acpi-root.c
@@ -144,7 +144,7 @@ parse_acpi_root(struct device *dev, const char *path, const char *root UNUSED)
 			return rc;
 		}
 	}
-	debug("Parsed HID:0x%08x UID:0x%"PRIx64" uidstr:\"%s\" path:\"%s\"",
+	debug("Parsed HID:0x%08x UID:0x%"PRIx64" uidstr:'%s' path:'%s'",
 	      dev->acpi_root.acpi_hid, dev->acpi_root.acpi_uid,
 	      dev->acpi_root.acpi_uid_str,
 	      dev->acpi_root.acpi_cid_str);
@@ -162,7 +162,7 @@ dp_create_acpi_root(struct device *dev,
 	debug("entry buf:%p size:%zd off:%zd", buf, size, off);
 
 	if (dev->acpi_root.acpi_uid_str || dev->acpi_root.acpi_cid_str) {
-		debug("creating acpi_hid_ex dp hid:0x%08x uid:0x%"PRIx64" uidstr:\"%s\" cidstr:\"%s\"",
+		debug("creating acpi_hid_ex dp hid:0x%08x uid:0x%"PRIx64" uidstr:'%s' cidstr:'%s'",
 		      dev->acpi_root.acpi_hid, dev->acpi_root.acpi_uid,
 		      dev->acpi_root.acpi_uid_str, dev->acpi_root.acpi_cid_str);
 		new = efidp_make_acpi_hid_ex(buf + off, size ? size - off : 0,

--- a/src/linux-acpi.c
+++ b/src/linux-acpi.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2018 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -54,7 +54,7 @@ parse_acpi_hid_uid(struct device *dev, const char *fmt, ...)
 		if (l > 1) {
 			fbuf[l-1] = 0;
 			dev->acpi_root.acpi_cid_str = strdup(fbuf);
-			debug("Setting ACPI root path to \"%s\"", fbuf);
+			debug("Setting ACPI root path to '%s'", fbuf);
 		}
 	}
 
@@ -111,7 +111,7 @@ hid_err:
 			}
 		}
 	}
-	debug("acpi root UID:0x%"PRIx64" uidstr:\"%s\"",
+	debug("acpi root UID:0x%"PRIx64" uidstr:'%s'",
 	      dev->acpi_root.acpi_uid, dev->acpi_root.acpi_uid_str);
 
 	errno = 0;

--- a/src/linux-ata.c
+++ b/src/linux-ata.c
@@ -60,6 +60,7 @@ is_pata(struct device *dev)
 static ssize_t
 parse_ata(struct device *dev, const char *path, const char *root UNUSED)
 {
+	const char *current = path;
 	uint32_t scsi_host, scsi_bus, scsi_device, scsi_target;
 	uint64_t scsi_lun;
 	int pos;
@@ -118,6 +119,7 @@ parse_ata(struct device *dev, const char *path, const char *root UNUSED)
 			      NULL, NULL, NULL);
 	if (pos < 0)
 		return -1;
+	current += pos;
 
 	dev->ata_info.scsi_host = scsi_host;
 	dev->ata_info.scsi_bus = scsi_bus;
@@ -125,10 +127,11 @@ parse_ata(struct device *dev, const char *path, const char *root UNUSED)
 	dev->ata_info.scsi_target = scsi_target;
 	dev->ata_info.scsi_lun = scsi_lun;
 
-	char *block = strstr(path, "/block/");
-	if (!block)
-		return -1;
-	return block + 1 - path;
+	char *block = strstr(current, "/block/");
+	if (block)
+		current += block + 1 - current;
+	debug("current:'%s' sz:%zd", current, current - path);
+	return current - path;
 }
 
 static ssize_t

--- a/src/linux-ata.c
+++ b/src/linux-ata.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2018 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -58,7 +58,7 @@ is_pata(struct device *dev)
  * 11:0 -> ../../devices/pci0000:00/0000:00:11.5/ata3/host2/target2:0:0/2:0:0:0/block/sr0
  */
 static ssize_t
-parse_ata(struct device *dev, const char *current, const char *root UNUSED)
+parse_ata(struct device *dev, const char *path, const char *root UNUSED)
 {
 	uint32_t scsi_host, scsi_bus, scsi_device, scsi_target;
 	uint64_t scsi_lun;
@@ -108,7 +108,7 @@ parse_ata(struct device *dev, const char *current, const char *root UNUSED)
 		return 0;
 	}
 
-	char *host = strstr(current, "/host");
+	char *host = strstr(path, "/host");
 	if (!host)
 		return -1;
 
@@ -125,10 +125,10 @@ parse_ata(struct device *dev, const char *current, const char *root UNUSED)
 	dev->ata_info.scsi_target = scsi_target;
 	dev->ata_info.scsi_lun = scsi_lun;
 
-	char *block = strstr(current, "/block/");
+	char *block = strstr(path, "/block/");
 	if (!block)
 		return -1;
-	return block + 1 - current;
+	return block + 1 - path;
 }
 
 static ssize_t

--- a/src/linux-emmc.c
+++ b/src/linux-emmc.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2018 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -58,6 +58,7 @@ parse_emmc(struct device *dev, const char *current, const char *root UNUSED)
 	            &tosser0, &tosser1, &tosser2, &slot_id,
 	            &pos0, &tosser3, &partition, &pos1);
 	debug("current:\"%s\" rc:%d pos0:%d pos1:%d\n", current, rc, pos0, pos1);
+	dbgmk("         ", pos0, pos1);
 	/*
 	 * If it isn't of that form, it's not one of our emmc devices.
 	 */

--- a/src/linux-i2o.c
+++ b/src/linux-i2o.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2018 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -33,7 +33,7 @@
  * ... probably doesn't work.
  */
 static ssize_t
-parse_i2o(struct device *dev, const char *current UNUSED, const char *root UNUSED)
+parse_i2o(struct device *dev, const char *current, const char *root UNUSED)
 {
 	debug("entry");
 	/* I2O disks can have up to 16 partitions, or 4 bits worth. */
@@ -47,9 +47,9 @@ parse_i2o(struct device *dev, const char *current UNUSED, const char *root UNUSE
 	}
 
 	char *block = strstr(current, "/block/");
-	if (!block)
-	        return -1;
-	return block + 1 - current;
+	ssize_t sz = block ? block + 1 - current : -1;
+	debug("current:'%s' sz:%zd", current, sz);
+	return sz;
 }
 
 enum interface_type i2o_iftypes[] = { i2o, unknown };

--- a/src/linux-md.c
+++ b/src/linux-md.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2018 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -51,6 +51,7 @@ parse_md(struct device *dev, const char *current, const char *root UNUSED)
 	rc = sscanf(current, "md%d/%nmd%dp%d%n",
 	            &md, &pos0, &tosser0, &part, &pos1);
 	debug("current:\"%s\" rc:%d pos0:%d pos1:%d\n", current, rc, pos0, pos1);
+	dbgmk("         ", pos0, pos1);
 	/*
 	 * If it isn't of that form, it's not one of our partitioned md devices.
 	 */

--- a/src/linux-md.c
+++ b/src/linux-md.c
@@ -50,7 +50,7 @@ parse_md(struct device *dev, const char *current, const char *root UNUSED)
 	debug("searching for mdM/mdMpN");
 	rc = sscanf(current, "md%d/%nmd%dp%d%n",
 	            &md, &pos0, &tosser0, &part, &pos1);
-	debug("current:\"%s\" rc:%d pos0:%d pos1:%d\n", current, rc, pos0, pos1);
+	debug("current:'%s' rc:%d pos0:%d pos1:%d\n", current, rc, pos0, pos1);
 	dbgmk("         ", pos0, pos1);
 	/*
 	 * If it isn't of that form, it's not one of our partitioned md devices.
@@ -63,9 +63,9 @@ parse_md(struct device *dev, const char *current, const char *root UNUSED)
 	if (dev->part == -1)
 	        dev->part = part;
 
+	debug("current:'%s' sz:%d\n", current, pos1);
 	return pos1;
 }
-
 
 static char *
 make_part_name(struct device *dev)

--- a/src/linux-nvme.c
+++ b/src/linux-nvme.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2018 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -62,6 +62,7 @@ parse_nvme(struct device *dev, const char *current, const char *root UNUSED)
 	            &tosser0, &ctrl_id, &ns_id, &pos0,
 	            &tosser1, &tosser2, &partition, &pos1);
 	debug("current:\"%s\" rc:%d pos0:%d pos1:%d\n", current, rc, pos0, pos1);
+	dbgmk("         ", pos0, pos1);
 	/*
 	 * If it isn't of that form, it's not one of our nvme devices.
 	 */

--- a/src/linux-nvme.c
+++ b/src/linux-nvme.c
@@ -89,13 +89,12 @@ parse_nvme(struct device *dev, const char *path, const char *root UNUSED)
 	/*
 	 * now fish the eui out of sysfs is there is one...
 	 */
-	rc = read_sysfs_file(&filebuf,
-	                     "class/block/nvme%dn%d/eui",
-	                     ctrl_id, ns_id);
-	if ((rc < 0 && errno == ENOENT) || filebuf == NULL) {
-	        rc = read_sysfs_file(&filebuf,
-	                     "class/block/nvme%dn%d/device/eui",
-	                     ctrl_id, ns_id);
+	char *euipath = NULL;
+	rc = read_sysfs_file(&filebuf, "class/block/nvme%dn%d/eui", ctrl_id, ns_id);
+	if (rc < 0 && (errno == ENOENT || errno == ENOTDIR)) {
+		rc = find_device_file(&euipath, "eui", "class/block/nvme%dn%d", ctrl_id, ns_id);
+		if (rc >= 0 && euipath != NULL)
+			rc = read_sysfs_file(&filebuf, "%s", euipath);
 	}
 	if (rc >= 0 && filebuf != NULL) {
 	        uint8_t eui[8];

--- a/src/linux-nvme.c
+++ b/src/linux-nvme.c
@@ -15,7 +15,6 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with this library; if not, see
  * <http://www.gnu.org/licenses/>.
- *
  */
 
 #include "fix_coverity.h"
@@ -35,6 +34,12 @@
  * /sys/dev/block/$major:$minor looks like:
  * 259:0 -> ../../devices/pci0000:00/0000:00:1d.0/0000:05:00.0/nvme/nvme0/nvme0n1
  * 259:1 -> ../../devices/pci0000:00/0000:00:1d.0/0000:05:00.0/nvme/nvme0/nvme0n1/nvme0n1p1
+ * or:
+ * 259:0 ->../../devices/virtual/nvme-fabrics/ctl/nvme0/nvme0n1
+ * 259:1 ->../../devices/virtual/nvme-fabrics/ctl/nvme0/nvme0n1/nvme0n1p1
+ * or:
+ * 259:5 -> ../../devices/virtual/nvme-subsystem/nvme-subsys0/nvme0n1
+ * 259:6 -> ../../devices/virtual/nvme-subsystem/nvme-subsys0/nvme0n1/nvme0n1p1
  *
  * /sys/dev/block/259:0/device looks like:
  * device -> ../../nvme0
@@ -56,14 +61,42 @@ parse_nvme(struct device *dev, const char *path, const char *root UNUSED)
 	int32_t tosser0, tosser1, tosser2, ctrl_id, ns_id, partition;
 	uint8_t *filebuf = NULL;
 	int pos0 = -1, pos1 = -1, pos2 = -1;
+	ssize_t sz = 0;
+	struct subdir {
+		const char * const name;
+		const char * const fmt;
+		int *pos0, *pos1;
+	} subdirs[] = {
+		{"nvme-subsysN/", "%nnvme-subsys%d/%n", &pos0, &pos2},
+		{"ctl/", "%nctl/%n%n", &pos0, &pos1},
+		{"nvme/", "%nnvme/%n%n", &pos0, &pos1},
+		{NULL, }
+	};
 
 	debug("entry");
 
-	debug("searching for nvme/nvme0/nvme0n1 or nvme/nvme0/nvme0n1/nvme0n1p1");
-	rc = sscanf(current, "%nnvme/nvme%d/nvme%dn%d%n/nvme%dn%dp%d%n",
-	            &pos0, &tosser0, &ctrl_id, &ns_id,
-		    &pos1, &tosser1, &tosser2, &partition, &pos2);
-	debug("current:\"%s\" rc:%d pos0:%d pos1:%d pos2:%d\n", current, rc, pos0, pos1, pos2);
+	/*
+	 * in this case, *any* of these is okay.
+	 */
+	for (int i = 0; subdirs[i].name; i++) {
+		debug("searching for %s", subdirs[i].name);
+		pos0 = tosser0 = pos1 = -1;
+		rc = sscanf(current, subdirs[i].fmt, &pos0, &pos1, &pos2);
+		debug("current:'%s' rc:%d pos0:%d pos1:%d\n", current, rc,
+		      *subdirs[i].pos0, *subdirs[i].pos1);
+		dbgmk("         ", *subdirs[i].pos0, *subdirs[i].pos1);
+		if (*subdirs[i].pos0 >= 0 && *subdirs[i].pos1 >= *subdirs[i].pos0) {
+			sz += *subdirs[i].pos1;
+			current += *subdirs[i].pos1;
+			break;
+		}
+	}
+
+	debug("searching for nvme0/nvme0n1 or nvme0/nvme0n1/nvme0n1p1");
+	rc = sscanf(current, "%nnvme%d/nvme%dn%d%n/nvme%dn%dp%d%n",
+	            &pos0, &tosser0, &ctrl_id, &ns_id, &pos1,
+	            &tosser1, &tosser2, &partition, &pos2);
+	debug("current:'%s' rc:%d pos0:%d pos1:%d pos2:%d\n", current, rc, pos0, pos1, pos2);
 	dbgmk("         ", pos0, MAX(pos1,pos2));
 	/*
 	 * If it isn't of that form, it's not one of our nvme devices.
@@ -82,13 +115,15 @@ parse_nvme(struct device *dev, const char *path, const char *root UNUSED)
 	        if (dev->part == -1)
 	                dev->part = partition;
 
-	        pos1 = pos2;
+		pos1 = pos2;
 	}
+
 	current += pos1;
 
 	/*
 	 * now fish the eui out of sysfs is there is one...
 	 */
+	debug("looking for the eui");
 	char *euipath = NULL;
 	rc = read_sysfs_file(&filebuf, "class/block/nvme%dn%d/eui", ctrl_id, ns_id);
 	if (rc < 0 && (errno == ENOENT || errno == ENOTDIR)) {
@@ -111,6 +146,9 @@ parse_nvme(struct device *dev, const char *path, const char *root UNUSED)
 	                errno = EINVAL;
 	                return -1;
 	        }
+		debug("eui is %02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx",
+		      eui[0], eui[1], eui[2], eui[3],
+		      eui[4], eui[5], eui[6], eui[7]);
 	        dev->nvme_info.has_eui = 1;
 	        memcpy(dev->nvme_info.eui, eui, sizeof(eui));
 	}

--- a/src/linux-pci-root.c
+++ b/src/linux-pci-root.c
@@ -87,7 +87,7 @@ dp_create_pci_root(struct device *dev UNUSED,
 	debug("entry buf:%p size:%zd off:%zd", buf, size, off);
 	debug("returning 0");
 	if (dev->acpi_root.acpi_uid_str) {
-	        debug("creating acpi_hid_ex dp hid:0x%08x uid:\"%s\"",
+	        debug("creating acpi_hid_ex dp hid:0x%08x uid:'%s'",
 	              dev->acpi_root.acpi_hid,
 	              dev->acpi_root.acpi_uid_str);
 	        new = efidp_make_acpi_hid_ex(buf + off, size ? size - off : 0,

--- a/src/linux-pci-root.c
+++ b/src/linux-pci-root.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2018 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -57,6 +57,8 @@ parse_pci_root(struct device *dev, const char *current, const char *root UNUSED)
 	 *    ^d   ^p
 	 */
 	rc = sscanf(devpart, "../../devices/pci%hx:%hhx/%n", &root_domain, &root_bus, &pos);
+	debug("current:\"%s\" rc:%d pos:%d", devpart, rc, pos);
+	dbgmk("         ", pos);
 	/*
 	 * If we can't find that, it's not a PCI device.
 	 */

--- a/src/linux-pci-root.c
+++ b/src/linux-pci-root.c
@@ -41,13 +41,13 @@
  *
  */
 static ssize_t
-parse_pci_root(struct device *dev, const char *current, const char *root UNUSED)
+parse_pci_root(struct device *dev, const char *path, const char *root UNUSED)
 {
+	const char * current = path;
 	int rc;
-	int pos = 0;
+	int pos0 = -1, pos1 = -1;
 	uint16_t root_domain;
 	uint8_t root_bus;
-	const char *devpart = current;
 
 	debug("entry");
 
@@ -56,15 +56,15 @@ parse_pci_root(struct device *dev, const char *current, const char *root UNUSED)
 	 * pci0000:00/
 	 *    ^d   ^p
 	 */
-	rc = sscanf(devpart, "../../devices/pci%hx:%hhx/%n", &root_domain, &root_bus, &pos);
-	debug("current:\"%s\" rc:%d pos:%d", devpart, rc, pos);
-	dbgmk("         ", pos);
+	rc = sscanf(current, "%n../../devices/pci%hx:%hhx/%n", &pos0, &root_domain, &root_bus, &pos1);
+	debug("current:'%s' rc:%d pos0:%d pos1:%d", current, rc, pos0, pos1);
+	dbgmk("         ", pos0, pos1);
 	/*
 	 * If we can't find that, it's not a PCI device.
 	 */
 	if (rc != 2)
 	        return 0;
-	devpart += pos;
+	current += pos1;
 
 	dev->pci_root.pci_domain = root_domain;
 	dev->pci_root.pci_bus = root_bus;
@@ -75,7 +75,8 @@ parse_pci_root(struct device *dev, const char *current, const char *root UNUSED)
 	        return -1;
 
 	errno = 0;
-	return devpart - current;
+	debug("current:'%s' sz:%zd\n", current, current - path);
+	return current - path;
 }
 
 static ssize_t

--- a/src/linux-pci.c
+++ b/src/linux-pci.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2018 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -68,6 +68,7 @@ parse_pci(struct device *dev, const char *current, const char *root)
 	        rc = sscanf(devpart, "%hx:%hhx:%hhx.%hhx/%n",
 	                    &domain, &bus, &device, &function, &pos);
 	        debug("current:\"%s\" rc:%d pos:%d", devpart, rc, pos);
+		dbgmk("         ", pos);
 	        if (rc != 4)
 	                break;
 	        devpart += pos;

--- a/src/linux-pmem.c
+++ b/src/linux-pmem.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2018 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -105,6 +105,8 @@ parse_pmem(struct device *dev, const char *current, const char *root UNUSED)
 	            "../../devices/LNXSYSTM:%hhx/LNXSYBUS:%hhx/ACPI%hx:%hhx/ndbus%d/region%d/btt%d.%d/%n",
 	            &system, &sysbus, &pnp_id, &acpi_id, &ndbus, &region,
 	            &btt_region_id, &btt_id, &pos);
+	debug("current:\"%s\" rc:%d pos:%d", current, rc, pos);
+	dbgmk("         ", pos);
 	if (rc < 8)
 	        return 0;
 

--- a/src/linux-pmem.c
+++ b/src/linux-pmem.c
@@ -103,11 +103,12 @@ parse_pmem(struct device *dev, const char *path, const char *root UNUSED)
 	 *
 	 * 259:0 -> ../../devices/LNXSYSTM:00/LNXSYBUS:00/ACPI0012:00/ndbus0/region12/btt12.1/block/pmem12s
 	 */
+	pos0 = pos1 = -1;
 	rc = sscanf(current,
 	            "../../devices/%nLNXSYSTM:%hhx/LNXSYBUS:%hhx/ACPI%hx:%hhx/ndbus%d/region%d/btt%d.%d/%n",
 	            &pos0, &system, &sysbus, &pnp_id, &acpi_id, &ndbus,
 		    &region, &btt_region_id, &btt_id, &pos1);
-	debug("current:\"%s\" rc:%d pos0:%d pos1:%d", current, rc, pos0, pos1);
+	debug("current:'%s' rc:%d pos0:%d pos1:%d", current, rc, pos0, pos1);
 	dbgmk("         ", pos0, pos1);
 	if (rc < 8)
 	        return 0;
@@ -126,7 +127,7 @@ parse_pmem(struct device *dev, const char *path, const char *root UNUSED)
 	        return -1;
 
 	filebuf = NULL;
-	debug("nvdimm namespace is \"%s\"", namespace);
+	debug("nvdimm namespace is '%s'", namespace);
 	rc = read_sysfs_file(&filebuf, "bus/nd/devices/%s/uuid", namespace);
 	free(namespace);
 	if (rc < 0 || filebuf == NULL)

--- a/src/linux-sas.c
+++ b/src/linux-sas.c
@@ -148,8 +148,9 @@ get_local_sas_address(uint64_t *sas_address, struct device *dev)
  * anywhere.
  */
 static ssize_t
-parse_sas(struct device *dev, const char *current, const char *root UNUSED)
+parse_sas(struct device *dev, const char *path, const char *root UNUSED)
 {
+	const char *current = path;
 	struct stat statbuf = { 0, };
 	int rc;
 	uint32_t scsi_host, scsi_bus, scsi_device, scsi_target;
@@ -172,6 +173,7 @@ parse_sas(struct device *dev, const char *current, const char *root UNUSED)
 	 */
 	if (pos < 0)
 	        return 0;
+	current += pos;
 
 	/*
 	 * Make sure it has the actual /SAS/ bits before we continue
@@ -236,7 +238,9 @@ parse_sas(struct device *dev, const char *current, const char *root UNUSED)
 	dev->scsi_info.scsi_target = scsi_target;
 	dev->scsi_info.scsi_lun = scsi_lun;
 	dev->interface_type = sas;
-	return pos;
+
+	debug("current:'%s' sz:%zd", current, current - path);
+	return current - path;
 }
 
 static ssize_t

--- a/src/linux-sata.c
+++ b/src/linux-sata.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2018 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -162,6 +162,7 @@ parse_sata(struct device *dev, const char *devlink, const char *root UNUSED)
 	debug("searching for ata1/");
 	rc = sscanf(current, "ata%"PRIu32"/%n", &print_id, &pos);
 	debug("current:\"%s\" rc:%d pos:%d\n", current, rc, pos);
+	dbgmk("         ", pos);
 	/*
 	 * If we don't find this one, it isn't an ata device, so return 0 not
 	 * error.  Later errors mean it is an ata device, but we can't parse
@@ -175,6 +176,7 @@ parse_sata(struct device *dev, const char *devlink, const char *root UNUSED)
 	debug("searching for host0/");
 	rc = sscanf(current, "host%"PRIu32"/%n", &scsi_bus, &pos);
 	debug("current:\"%s\" rc:%d pos:%d\n", current, rc, pos);
+	dbgmk("         ", pos);
 	if (rc != 1)
 	        return -1;
 	current += pos;
@@ -184,6 +186,7 @@ parse_sata(struct device *dev, const char *devlink, const char *root UNUSED)
 	rc = sscanf(current, "target%"PRIu32":%"PRIu32":%"PRIu64"/%n",
 	            &scsi_device, &scsi_target, &scsi_lun, &pos);
 	debug("current:\"%s\" rc:%d pos:%d\n", current, rc, pos);
+	dbgmk("         ", pos);
 	if (rc != 3)
 	        return -1;
 	current += pos;
@@ -193,6 +196,7 @@ parse_sata(struct device *dev, const char *devlink, const char *root UNUSED)
 	rc = sscanf(current, "%"PRIu32":%"PRIu32":%"PRIu32":%"PRIu64"/%n",
 	            &tosser0, &tosser1, &tosser2, &tosser3, &pos);
 	debug("current:\"%s\" rc:%d pos:%d\n", current, rc, pos);
+	dbgmk("         ", pos);
 	if (rc != 4)
 	        return -1;
 	current += pos;

--- a/src/linux-scsi.c
+++ b/src/linux-scsi.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2018 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -101,6 +101,7 @@ parse_scsi_link(const char *current, uint32_t *scsi_host,
 	debug("searching for host4/");
 	rc = sscanf(current, "host%d/%n", scsi_host, &pos0);
 	debug("current:\"%s\" rc:%d pos0:%d\n", current+sz, rc, pos0);
+	dbgmk("         ", pos0);
 	if (rc != 1)
 	        return -1;
 	sz += pos0;
@@ -118,6 +119,7 @@ parse_scsi_link(const char *current, uint32_t *scsi_host,
 	rc = sscanf(current+sz, "port-%d:%d%n:%d%n", &tosser0,
 	            &tosser1, &pos0, &tosser2, &pos1);
 	debug("current:\"%s\" rc:%d pos0:%d pos1:%d\n", current+sz, rc, pos0, pos1);
+	dbgmk("         ", pos0, pos1);
 	if (rc == 2 || rc == 3) {
 	        sz += pos0;
 	        pos0 = 0;
@@ -143,6 +145,7 @@ parse_scsi_link(const char *current, uint32_t *scsi_host,
 	        debug("searching for expander-4:0/");
 	        rc = sscanf(current+sz, "expander-%d:%d/%n", &tosser0, &tosser1, &pos0);
 	        debug("current:\"%s\" rc:%d pos0:%d\n", current+sz, rc, pos0);
+		dbgmk("         ", pos0);
 	        if (rc == 2) {
 	                if (!remote_target_id) {
 	                        efi_error("Device is PHY is a remote target, but remote_target_id is NULL");
@@ -158,6 +161,7 @@ parse_scsi_link(const char *current, uint32_t *scsi_host,
 	                debug("searching for port-2:0:2/");
 	                rc = sscanf(current+sz, "port-%d:%d:%d/%n", &tosser0, &tosser1, &tosser2, &pos0);
 	                debug("current:\"%s\" rc:%d pos0:%d\n", current+sz, rc, pos0);
+			dbgmk("         ", pos0);
 	                if (rc != 3) {
 	                        efi_error("Couldn't parse port expander port string");
 	                        return -1;
@@ -182,6 +186,7 @@ parse_scsi_link(const char *current, uint32_t *scsi_host,
 	        rc = sscanf(current + sz + pos0, ":%d%n", &tosser2, &pos1);
 	        if (rc != 0 && rc != 1)
 	                return -1;
+		dbgmk("         ", pos0, pos0+pos1);
 	        if (remote_port_id && rc == 1)
 	                *remote_port_id = tosser2;
 	        if (local_port_id && rc == 0)
@@ -203,6 +208,7 @@ parse_scsi_link(const char *current, uint32_t *scsi_host,
 	rc = sscanf(current + sz, "target%d:%d:%"PRIu64"/%n", &tosser0, &tosser1,
 	            &tosser3, &pos0);
 	debug("current:\"%s\" rc:%d pos0:%d\n", current+sz, rc, pos0);
+	dbgmk("         ", pos0);
 	if (rc != 3)
 	        return -1;
 	sz += pos0;
@@ -215,6 +221,7 @@ parse_scsi_link(const char *current, uint32_t *scsi_host,
 	rc = sscanf(current + sz, "%d:%d:%d:%"PRIu64"/%n",
 	            scsi_bus, scsi_device, scsi_target, scsi_lun, &pos0);
 	debug("current:\"%s\" rc:%d pos0:%d\n", current+sz, rc, pos0);
+	dbgmk("         ", pos0);
 	if (rc != 4)
 	        return -1;
 	sz += pos0;
@@ -242,6 +249,7 @@ parse_scsi(struct device *dev, const char *current, const char *root UNUSED)
 	            &dev->scsi_info.scsi_lun,
 	            &pos);
 	debug("current:\"%s\" rc:%d pos:%d\n", dev->device, rc, pos);
+	dbgmk("         ", pos);
 	if (rc != 4)
 	        return 0;
 

--- a/src/linux-soc-root.c
+++ b/src/linux-soc-root.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2018 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -49,6 +49,8 @@ parse_soc_root(struct device *dev UNUSED, const char *current, const char *root 
 	rc = sscanf(devpart, "../../devices/platform/soc/%*[^/]/%n", &pos);
 	if (rc != 0)
 	        return 0;
+	debug("current:\"%s\" rc:%d pos:%d", current, rc, pos);
+	dbgmk("         ", pos);
 	devpart += pos;
 	debug("new position is \"%s\"", devpart);
 

--- a/src/linux-soc-root.c
+++ b/src/linux-soc-root.c
@@ -38,23 +38,23 @@
  * I don't *think* the devicetree nodes stack.
  */
 static ssize_t
-parse_soc_root(struct device *dev UNUSED, const char *current, const char *root UNUSED)
+parse_soc_root(struct device *dev UNUSED, const char *path, const char *root UNUSED)
 {
+	const char *current = path;
 	int rc;
-	int pos = 0;
-	const char *devpart = current;
+	int pos0 = -1, pos1 = -1;
 
 	debug("entry");
 
-	rc = sscanf(devpart, "../../devices/platform/soc/%*[^/]/%n", &pos);
-	if (rc != 0)
+	rc = sscanf(current, "../../devices/%nplatform/soc/%*[^/]/%n", &pos0, &pos1);
+	if (rc != 0 || pos0 == -1 || pos1 == -1)
 	        return 0;
-	debug("current:\"%s\" rc:%d pos:%d", current, rc, pos);
-	dbgmk("         ", pos);
-	devpart += pos;
-	debug("new position is \"%s\"", devpart);
+	debug("current:'%s' rc:%d pos0:%d pos1:%d", current, rc, pos0, pos1);
+	dbgmk("         ", pos0, pos1);
+	current += pos1;
 
-	return devpart - current;
+	debug("current:'%s' sz:%zd\n", current, current - path);
+	return current - path;
 }
 
 enum interface_type soc_root_iftypes[] = { soc_root, unknown };

--- a/src/linux-virtblk.c
+++ b/src/linux-virtblk.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2018 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public License as
@@ -56,6 +56,7 @@ parse_virtblk(struct device *dev, const char *current, const char *root UNUSED)
 	debug("searching for virtio0/");
 	rc = sscanf(current, "virtio%x/%n", &tosser, &pos);
 	debug("current:\"%s\" rc:%d pos:%d\n", current, rc, pos);
+	dbgmk("         ", pos);
 	/*
 	 * If we couldn't find virtioX/ then it isn't a virtio device.
 	 */

--- a/src/linux-virtblk.c
+++ b/src/linux-virtblk.c
@@ -45,18 +45,19 @@
  * But usually we just write the HD() entry, of course.
  */
 static ssize_t
-parse_virtblk(struct device *dev, const char *current, const char *root UNUSED)
+parse_virtblk(struct device *dev, const char *path, const char *root UNUSED)
 {
+	const char *current = path;
 	uint32_t tosser;
-	int pos = 0;
+	int pos0 = -1, pos1 = -1;
 	int rc;
 
 	debug("entry");
 
 	debug("searching for virtio0/");
-	rc = sscanf(current, "virtio%x/%n", &tosser, &pos);
-	debug("current:\"%s\" rc:%d pos:%d\n", current, rc, pos);
-	dbgmk("         ", pos);
+	rc = sscanf(current, "%nvirtio%x/%n", &pos0, &tosser, &pos1);
+	debug("current:'%s' rc:%d pos0:%d pos1:%d\n", current, rc, pos0, pos1);
+	dbgmk("         ", pos0, pos1);
 	/*
 	 * If we couldn't find virtioX/ then it isn't a virtio device.
 	 */
@@ -64,8 +65,10 @@ parse_virtblk(struct device *dev, const char *current, const char *root UNUSED)
 	        return 0;
 
 	dev->interface_type = virtblk;
+	current += pos1;
 
-	return pos;
+	debug("current:'%s' sz:%zd\n", current, current - path);
+	return current - path;
 }
 
 enum interface_type virtblk_iftypes[] = { virtblk, unknown };

--- a/src/linux-virtual-root.c
+++ b/src/linux-virtual-root.c
@@ -1,0 +1,88 @@
+/*
+ * libefiboot - library for the manipulation of EFI boot variables
+ * Copyright 2012-2019 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of the
+ * License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "fix_coverity.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <stdint.h>
+#include <unistd.h>
+
+#include "efiboot.h"
+
+/*
+ * Support virtually rooted devices (fibre+nvme, etc.)
+ *
+ * /sys/dev/block/$major:$minor looks like:
+ * 259:0 ->../../devices/virtual/nvme-fabrics/ctl/nvme0/nvme0n1
+ * 259:1 ->../../devices/virtual/nvme-fabrics/ctl/nvme0/nvme0n1/nvme0n1p1
+ * or:
+ * 259:5 -> ../../devices/virtual/nvme-subsystem/nvme-subsys0/nvme0n1
+ * 259:6 -> ../../devices/virtual/nvme-subsystem/nvme-subsys0/nvme0n1/nvme0n1p1
+ */
+
+static ssize_t
+parse_virtual_root(struct device *dev UNUSED, const char *current, const char *root UNUSED)
+{
+	int rc;
+	ssize_t sz;
+	int pos0 = 0, pos1 = 0;
+	struct subdir {
+		const char * const name;
+		const char * const fmt;
+	} subdirs[] = {
+		{"../../devices/virtual", "%n../../devices/virtual/%n"},
+		{"nvme-subsystem/", "%nnvme-subsystem/%n"},
+		{"nvme-fabrics/ctl/", "%nnvme-fabrics/ctl/%n"},
+		{NULL, NULL}
+	};
+
+	debug("entry");
+
+	for (int i = 0; subdirs[i].name; i++) {
+		debug("searching for %s", subdirs[i].name);
+		pos0 = pos1 = -1;
+		rc = sscanf(current, subdirs[i].fmt, &pos0, &pos1);
+		debug("current:'%s' rc:%d pos0:%d pos1:%d\n", current, rc, pos0, pos1);
+		dbgmk("         ", pos0, pos1);
+		if (rc == 1) {
+			sz += pos1;
+			current += pos1;
+			if (i > 0)
+				goto found;
+		}
+	}
+
+	sz = 0;
+found:
+	debug("current:'%s' sz:%zd\n", current, sz);
+	return sz;
+}
+
+static enum interface_type virtual_root_iftypes[] = { virtual_root, unknown };
+
+struct dev_probe HIDDEN virtual_root_parser = {
+	.name = "virtual_root",
+	.iftypes = virtual_root_iftypes,
+	.flags = DEV_ABBREV_ONLY|DEV_PROVIDES_ROOT,
+	.parse = parse_virtual_root,
+};
+
+// vim:fenc=utf-8:tw=75:noet

--- a/src/linux.c
+++ b/src/linux.c
@@ -184,10 +184,10 @@ set_disk_and_part_name(struct device *dev)
 	errno = 0;
 	debug("dev->disk_name:%p dev->part_name:%p", dev->disk_name, dev->part_name);
 	debug("dev->part:%d", dev->part);
-	debug("ultimate:\"%s\"", ultimate ? : "");
-	debug("penultimate:\"%s\"", penultimate ? : "");
-	debug("approximate:\"%s\"", approximate ? : "");
-	debug("proximate:\"%s\"", proximate ? : "");
+	debug("ultimate:'%s'", ultimate ? : "");
+	debug("penultimate:'%s'", penultimate ? : "");
+	debug("approximate:'%s'", approximate ? : "");
+	debug("proximate:'%s'", proximate ? : "");
 
 	if (ultimate && penultimate &&
 	    ((proximate && !strcmp(proximate, "nvme")) ||
@@ -463,7 +463,11 @@ struct device HIDDEN
 	                efi_error("parsing %s failed", probe->name);
 	                goto err;
 	        } else if (pos > 0) {
-	                debug("%s matched %s", probe->name, current);
+			char match[pos+1];
+
+			strncpy(match, current, pos);
+			match[pos] = '\0';
+	                debug("%s matched '%s'", probe->name, match);
 	                dev->flags |= probe->flags;
 
 	                if (probe->flags & DEV_PROVIDES_HD ||
@@ -473,7 +477,10 @@ struct device HIDDEN
 
 	                dev->probes[n++] = dev_probes[i];
 	                current += pos;
-	                debug("current:%s", current);
+			if (current[0] == '\0')
+				debug("finished");
+			else
+				debug("current:'%s'", current);
 	                last_successful_probe = i;
 
 	                if (!*current || !strncmp(current, "block/", 6))
@@ -482,8 +489,8 @@ struct device HIDDEN
 	                continue;
 	        }
 
-	        debug("dev_probes[i+1]: %p dev->interface_type: %d\n",
-	              dev_probes[i+1], dev->interface_type);
+	        debug("dev_probes[%d]: %p dev->interface_type: %d\n",
+	              i+1, dev_probes[i+1], dev->interface_type);
 	        if (dev_probes[i+1] == NULL && dev->interface_type == unknown) {
 	                pos = 0;
 	                rc = sscanf(current, "%*[^/]/%n", &pos);
@@ -499,8 +506,8 @@ slash_err:
 	                if (!current[pos])
 	                        goto slash_err;
 
-	                debug("Cannot parse device link segment \"%s\"", current);
-	                debug("Skipping to \"%s\"", current + pos);
+	                debug("Cannot parse device link segment '%s'", current);
+	                debug("Skipping to '%s'", current + pos);
 	                debug("This means we can only create abbreviated paths");
 	                dev->flags |= DEV_ABBREV_ONLY;
 	                i = last_successful_probe;

--- a/src/linux.c
+++ b/src/linux.c
@@ -1,6 +1,6 @@
 /*
  * libefiboot - library for the manipulation of EFI boot variables
- * Copyright 2012-2015 Red Hat, Inc.
+ * Copyright 2012-2019 Red Hat, Inc.
  * Copyright (C) 2001 Dell Computer Corporation <Matt_Domsch@dell.com>
  *
  * This library is free software; you can redistribute it and/or
@@ -169,6 +169,8 @@ set_disk_name(struct device *dev, const char * const fmt, ...)
 int HIDDEN
 set_disk_and_part_name(struct device *dev)
 {
+	int rc = -1;
+
 	/*
 	 * results are like such:
 	 * maj:min -> ../../devices/pci$PCI_STUFF/$BLOCKDEV_STUFF/block/$DISK/$PART
@@ -200,6 +202,7 @@ set_disk_and_part_name(struct device *dev)
 	        set_disk_name(dev, "%s", penultimate);
 	        set_part_name(dev, "%s", ultimate);
 	        debug("disk:%s part:%s", penultimate, ultimate);
+		rc = 0;
 	} else if (ultimate && approximate && !strcmp(approximate, "nvme")) {
 	        /*
 	         * 259:0 -> ../../devices/pci0000:00/0000:00:1d.0/0000:05:00.0/nvme/nvme0/nvme0n1
@@ -207,6 +210,7 @@ set_disk_and_part_name(struct device *dev)
 	        set_disk_name(dev, "%s", ultimate);
 	        set_part_name(dev, "%sp%d", ultimate, dev->part);
 	        debug("disk:%s part:%sp%d", ultimate, ultimate, dev->part);
+		rc = 0;
 	} else if (ultimate && penultimate && !strcmp(penultimate, "block")) {
 	        /*
 	         * 253:0 -> ../../devices/virtual/block/dm-0 (... I guess)
@@ -220,15 +224,19 @@ set_disk_and_part_name(struct device *dev)
 	        set_disk_name(dev, "%s", ultimate);
 	        set_part_name(dev, "%s%d", ultimate, dev->part);
 	        debug("disk:%s part:%s%d", ultimate, ultimate, dev->part);
+		rc = 0;
 	} else if (ultimate && approximate && !strcmp(approximate, "mtd")) {
 	        /*
 	         * 31:0 -> ../../devices/platform/1e000000.palmbus/1e000b00.spi/spi_master/spi32766/spi32766.0/mtd/mtd0/mtdblock0
 	         */
 	        set_disk_name(dev, "%s", ultimate);
 	        debug("disk:%s", ultimate);
+		rc = 0;
 	}
 
-	return 0;
+	if (rc < 0)
+		efi_error("Could not parse disk name:\"%s\"", dev->link);
+	return rc;
 }
 
 static struct dev_probe *dev_probes[] = {

--- a/src/linux.h
+++ b/src/linux.h
@@ -99,7 +99,8 @@ struct emmc_info {
 
 enum interface_type {
 	unknown,
-	isa, acpi_root, pci_root, soc_root, pci, network,
+	isa, acpi_root, pci_root, soc_root, virtual_root,
+	pci, network,
 	ata, atapi, scsi, sata, sas,
 	usb, i1394, fibre, i2o,
 	md, virtblk,
@@ -346,6 +347,7 @@ extern struct dev_probe pmem_parser;
 extern struct dev_probe pci_root_parser;
 extern struct dev_probe acpi_root_parser;
 extern struct dev_probe soc_root_parser;
+extern struct dev_probe virtual_root_parser;
 extern struct dev_probe pci_parser;
 extern struct dev_probe sas_parser;
 extern struct dev_probe sata_parser;


### PR DESCRIPTION
This fixes some minor bugs, adds some debug logging to the parsers, and adds support for devices that show up in /sys/device/virtual/nvme-subsystem/ and /sys/device/virtual/nvme-fabrics/ .