### PR TITLE
guids.S: Include <cet.h> when CET is enabled

### DIFF
--- a/src/guids.S
+++ b/src/guids.S
@@ -28,5 +28,8 @@ efi_well_known_names_end:
 	.byte 0
 
 #if defined(__linux__) && defined(__ELF__)
+#if defined(__CET__) && (defined(__i386__) || defined(__x86_64__))
+#include <cet.h>
+#endif
 .section .note.GNU-stack,"",%progbits
 #endif


### PR DESCRIPTION
Intel Control-flow Enforcement Technology (CET):

https://software.intel.com/en-us/articles/intel-sdm

contains shadow stack (SHSTK) and indirect branch tracking (IBT). When
CET is enabled, ELF object files must be marked with .note.gnu.property
section. CET enabled GCC provides a header file, <cet.h>, which can be
included in assembly files to generate the CET marker automatically.

This fixes: https://github.com/rhboot/efivar/issues/148

Signed-off-by: H.J. Lu <hjl.tools@gmail.com>