### PR TITLE
Fix /sys/block sysfs parsing for eMMC-s

### DIFF
--- a/src/linux-emmc.c
+++ b/src/linux-emmc.c
@@ -56,13 +56,10 @@ parse_emmc(struct device *dev, const char *path, const char *root UNUSED)
 	dev->emmc_info.slot_id = slot_id;
 	dev->interface_type = emmc;
 
-	if (rc == 6) {
-	        if (dev->part == -1)
-	                dev->part = partition;
+	if (rc == 6 && dev->part == -1)
+                dev->part = partition;
 
-	        pos2 = pos1;
-	}
-	current += pos2;
+	current += pos1;
 
 	debug("current:'%s' sz:%zd", current, current - path);
 	return current - path;


### PR DESCRIPTION
Commit 471869409464 ("sysfs parsers: make all the /sys/block link
parsers work the same way") has broken sysfs parsing for eMMC-s when
the passed in path points to the whole block device.

In that case pos2 will stay at its -1 initializaton value, because we
only do 4 conversions; and when we then do:

current += pos2

We end up moving current one char position backwards and we end up
returning -1.

The correct position to use is always pos1 independent if we got
passed the whole disk; or a partition, as we always want to return
only the part which points to whole disk which ends at pos1.

Note that it seems that before commit 471869409464, the case where
path points to the partition was likely broken as the old code then
would return the entire path including the partition element.

Also see: https://bugzilla.redhat.com/show_bug.cgi?id=1826864