### PR TITLE
Properly check mmap return error

### DIFF
--- a/src/efivar.c
+++ b/src/efivar.c
@@ -449,7 +449,7 @@ prepare_data(const char *filename, uint8_t **data, size_t *data_size)
 
 	buflen = statbuf.st_size;
 	buf = mmap(NULL, buflen, PROT_READ, MAP_PRIVATE|MAP_POPULATE, fd, 0);
-	if (!buf)
+	if (buf == MAP_FAILED)
 		goto err;
 
 	*data = buf;


### PR DESCRIPTION
The return value check is wrong.
It expects mmap() to return zero on errors, however mmap() returns MAP_FAILED (or -1) when an error occurs.