### PR TITLE
gcc.specs: drop --fatal-warnings from linker options (ia64 compatibility)

### DIFF
--- a/src/include/gcc.specs
+++ b/src/include/gcc.specs
@@ -2,7 +2,7 @@
 + %{!r:%{!fpie:%{!fPIE:%{!fpic:%{!fPIC:%{!fno-pic:-fPIE}}}}}} -grecord-gcc-switches
 
 *self_spec:
-+ %{!shared:%{!static:%{!r:-pie}}} %{static:-Wl,-no-fatal-warnings -Wl,-static -static -Wl,-z,relro,-z,now} -grecord-gcc-switches
++ %{!shared:%{!static:%{!r:-pie}}} %{static:-Wl,-static -static -Wl,-z,relro,-z,now} -grecord-gcc-switches
 
 *link:
-+ %{!static:--fatal-warnings} --no-undefined-version --no-allow-shlib-undefined --add-needed -z now --build-id %{!static:%{!shared:-pie}} %{shared:-z relro} %{static:%<pie}
++ --no-undefined-version --no-allow-shlib-undefined --add-needed -z now --build-id %{!static:%{!shared:-pie}} %{shared:-z relro} %{static:%<pie}


### PR DESCRIPTION
```
$ LANG=C make HOSTCC=x86_64-pc-linux-gnu-gcc CC=ia64-unknown-linux-gnu-gcc HOST_ARCH=ia64
ia64-unknown-linux-gnu-gcc ...  \
  -o libefivar.so ...
/usr/libexec/gcc/ia64-unknown-linux-gnu/ld: warning: -z relro ignored
collect2: error: ld returned 1 exit status
make[1]: *** [/home/slyfox/dev/git/efivar/src/include/rules.mk:32: libefivar.so] Error 1
```

ia64 (and a few others) binutils target does not support '-z relro' and always
issues a warning. --fatal-warnings spec option turns the build into always failing one.

The change drops `--fatal-warnings` options from gcc.spec entirely.

Reported-by: Émeric Maschino
Bug: https://bugs.gentoo.org/749963