### PR TITLE
vars.c: fix chmod bug

### DIFF
--- a/src/vars.c
+++ b/src/vars.c
@@ -467,10 +467,6 @@ static int
 _vars_chmod_variable(char *path, mode_t mode)
 {
 	mode_t mask = umask(umask(0));
-	size_t len = strlen(path);
-	char c = path[len - 5];
-	path[len - 5] = '\0';
-
 	char *files[] = {
 		"", "attributes", "data", "guid", "raw_var", "size", NULL
 		};
@@ -494,7 +490,6 @@ _vars_chmod_variable(char *path, mode_t mode)
 			ret = -1;
 		}
 	}
-	path[len - 5] = c;
 	errno = saved_errno;
 	return ret;
 }


### PR DESCRIPTION
Looks like the `_vars_chmod_variable` function has had this bug since it was introduced in 2014.  This function is called from 2 paths, the `vars_chmod_variable` function, and `vars_set_variable`.

`_vars_chmod_variable` currently expects the filename of the `data` file to be passed in, however, the 2 functions that call it pass in the parent directory path.

We've applied this patch to our yocto rootfs and are now able to successfully set permissions on efivar variables (using the old efivar sysfs interface).