### PR TITLE
Fix building thread-test with parallel jobs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -86,8 +86,7 @@ libefiboot.so : | libefiboot.map libefivar.so
 libefiboot.so : LIBS=efivar
 libefiboot.so : MAP=libefiboot.map
 
-thread-test : thread-test.o
-thread-test : CFLAGS=$(HOST_CFLAGS) -I$(TOPDIR)/src/include/efivar
+thread-test : thread-test.c | libefivar.so
 thread-test : LIBS=pthread efivar
 
 deps : $(ALL_SOURCES)

--- a/src/thread-test.c
+++ b/src/thread-test.c
@@ -61,7 +61,7 @@ multi_pthread_join(pthread_t * threads, unsigned count, void **worst_result)
 	return 0;
 }
 
-#include <efivar.h>
+#include <efivar/efivar.h>
 #define LOOP_COUNT 100
 
 static void *loop_get_variable_size_test(void *_ __attribute__((__unused__)))


### PR DESCRIPTION
The `thread-test` program does not declare a dependency on libefivar, so it would fail to build if the library does not exist yet:

    /usr/libexec/gcc/riscv64-gentoo-linux-gnu/ld: cannot find -lefivar
    collect2: error: ld returned 1 exit status

Also drop the `CFLAGS` declaration that mixes options from different platforms.  Since the program gets installed, stick with the target system compiler and flags.