### PR TITLE
Make thread-test depend on libefivar.so

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -86,7 +86,7 @@ libefiboot.so : | libefiboot.map libefivar.so
 libefiboot.so : LIBS=efivar
 libefiboot.so : MAP=libefiboot.map
 
-thread-test : thread-test.o
+thread-test : libefivar.so
 thread-test : CFLAGS=$(HOST_CFLAGS) -I$(TOPDIR)/src/include/efivar
 thread-test : LIBS=pthread efivar
 


### PR DESCRIPTION
Fix "make -j8" build failure by making thread-test depend on libefivar.so
instead of thread-test.o.  There is no need to make thread-test depend
on thread-test.o since thread-test is created from thread-test.c by
default.

Signed-off-by: H.J. Lu <hjl.tools@gmail.com>