### PR TITLE
Upstream a local patch from rawhide

### DIFF
--- a/src/libefiboot.abixml
+++ b/src/libefiboot.abixml
@@ -1800,6 +1800,7 @@
       <parameter type-id='type-id-18' name='size'/>
       <parameter type-id='type-id-215' name='filepath'/>
       <parameter type-id='type-id-5' name='options'/>
+      <parameter is-variadic='yes'/>
       <return type-id='type-id-18'/>
     </function-decl>
     <function-decl name='efi_generate_file_device_path_from_esp' mangled-name='efi_generate_file_device_path_from_esp' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='efi_generate_file_device_path_from_esp@@libefiboot.so.0'>
@@ -1809,6 +1810,7 @@
       <parameter type-id='type-id-25' name='partition'/>
       <parameter type-id='type-id-214' name='relpath'/>
       <parameter type-id='type-id-5' name='options'/>
+      <parameter is-variadic='yes'/>
       <return type-id='type-id-18'/>
     </function-decl>
     <function-decl name='efidp_make_hd' mangled-name='efidp_make_hd' filepath='src/include/efivar/efivar-dp.h' line='735' column='1' visibility='default' binding='global' size-in-bits='64'>

--- a/src/libefivar.abixml
+++ b/src/libefivar.abixml
@@ -393,6 +393,7 @@
       <parameter type-id='type-id-4' name='line' filepath='/usr/include/string.h' line='102' column='1'/>
       <parameter type-id='type-id-4' name='error' filepath='/usr/include/string.h' line='103' column='1'/>
       <parameter type-id='type-id-58' name='fmt' filepath='/usr/include/string.h' line='104' column='1'/>
+      <parameter is-variadic='yes'/>
       <return type-id='type-id-4'/>
     </function-decl>
     <typedef-decl name='__mode_t' type-id='type-id-1' filepath='/usr/include/bits/types.h' line='150' column='1' id='type-id-59'/>
@@ -467,6 +468,7 @@
       <parameter type-id='type-id-22' name='data' filepath='/usr/include/unistd.h' line='58' column='1'/>
       <parameter type-id='type-id-23' name='data_size' filepath='/usr/include/unistd.h' line='59' column='1'/>
       <parameter type-id='type-id-3' name='attributes' filepath='/usr/include/unistd.h' line='59' column='1'/>
+      <parameter is-variadic='yes'/>
       <return type-id='type-id-4'/>
     </function-decl>
     <function-decl name='_efi_set_variable' mangled-name='_efi_set_variable' filepath='/usr/include/unistd.h' line='46' column='1' visibility='default' binding='global' size-in-bits='64' elf-symbol-id='_efi_set_variable@libefivar.so.0'>


### PR DESCRIPTION
Currently, we carry this fix downstream:

```
Fix abidw output for missing variadic arguments

GCC forgets to add the varidic arguments into debugging data if the
compilation unit is built with -flto option. As a result, the prebuilt
XML ABI dumps were missing the last argument at 4 functions (e.g.
efi_error_set()).

This was unnoticed until Fedora enabled LTO globally and had to
disable LTO in efivar explicitly because efivar uses symbol versioning
with top-level assembler statements which is not compatible with LTO.

Since then the abicheck failed:

make[2]: Leaving directory '/builddir/build/BUILD/efivar-37/src'
abidiff \
 --suppr abignore \
 --headers-dir2 /builddir/build/BUILD/efivar-37/src/include/efivar/ \
 libefivar.abixml \
 libefivar.so
Functions changes summary: 0 Removed, 2 Changed (8 filtered out), 0 Added functions
Variables changes summary: 0 Removed, 0 Changed, 0 Added variable
2 functions with some indirect sub-type change:
  [C]'function int _efi_set_variable_variadic(efi_guid_t, const char*, uint8_t*, size_t, uint32_t)' at lib.c:44:1 has some indirect sub-type changes:
    parameter 6 of type '...' was added
  [C]'function int efi_error_set(const char*, const char*, int, int, const char*)' at error.c:86:1 has some indirect sub-type changes:
    parameter 6 of type '...' was added
make[1]: *** [/builddir/build/BUILD/efivar-37/src/include/rules.mk:41: libefivar.abicheck] Error 4
make[1]: Leaving directory '/builddir/build/BUILD/efivar-37/src'

This patch corrects the pregenerated abixml files that were probably
generated with the faulty GCC.

<https://bugzilla.redhat.com/show_bug.cgi?id=1863475>
<https://bugzilla.redhat.com/show_bug.cgi?id=1891787>

Signed-off-by: Petr Písař <ppisar@redhat.com>
```