### PR TITLE
Fix build with gcc version less then 10

### DIFF
--- a/src/lib.c
+++ b/src/lib.c
@@ -29,7 +29,7 @@ struct efi_var_operations default_ops = {
 struct efi_var_operations *ops = NULL;
 
 int NONNULL(2, 3) PUBLIC
-VERSION(_efi_set_variable, _efi_set_variable@libefivar.so.0)
+VERSION_ATTR(_efi_set_variable, _efi_set_variable@libefivar.so.0)
 _efi_set_variable(efi_guid_t guid, const char *name, uint8_t *data,
 		  size_t data_size, uint32_t attributes)
 {
@@ -44,9 +44,10 @@ _efi_set_variable(efi_guid_t guid, const char *name, uint8_t *data,
 		efi_error("ops->set_variable() failed");
 	return rc;
 }
+VERSION_ASM(_efi_set_variable, _efi_set_variable@libefivar.so.0);
 
 int NONNULL(2, 3) PUBLIC
-VERSION(_efi_set_variable_variadic, efi_set_variable@libefivar.so.0)
+VERSION_ATTR(_efi_set_variable_variadic, efi_set_variable@libefivar.so.0)
 _efi_set_variable_variadic(efi_guid_t guid, const char *name, uint8_t *data,
 			   size_t data_size, uint32_t attributes, ...)
 {
@@ -61,9 +62,10 @@ _efi_set_variable_variadic(efi_guid_t guid, const char *name, uint8_t *data,
 		efi_error("ops->set_variable() failed");
 	return rc;
 }
+VERSION_ASM(_efi_set_variable_variadic, efi_set_variable@libefivar.so.0);
 
 int NONNULL(2, 3) PUBLIC
-VERSION(_efi_set_variable_mode,efi_set_variable@@LIBEFIVAR_0.24)
+VERSION_ATTR(_efi_set_variable_mode,efi_set_variable@@LIBEFIVAR_0.24)
 _efi_set_variable_mode(efi_guid_t guid, const char *name, uint8_t *data,
 		       size_t data_size, uint32_t attributes, mode_t mode)
 {
@@ -80,6 +82,7 @@ _efi_set_variable_mode(efi_guid_t guid, const char *name, uint8_t *data,
 		efi_error_clear();
 	return rc;
 }
+VERSION_ASM(_efi_set_variable_mode,efi_set_variable@@LIBEFIVAR_0.24);
 
 int NONNULL(2, 3) PUBLIC
 efi_set_variable(efi_guid_t guid, const char *name, uint8_t *data,

--- a/src/util.h
+++ b/src/util.h
@@ -40,9 +40,14 @@
 #define FLATTEN __attribute__((__flatten__))
 #define PACKED __attribute__((__packed__))
 #if GNUC_PREREQ(10,0)
-# define VERSION(sym, ver) __attribute__ ((symver (# ver)))
+# define VERSION_ATTR(sym, ver) __attribute__ ((symver (# ver)))
 #else
-# define VERSION(sym, ver) __asm__(".symver " # sym "," # ver)
+# define VERSION_ATTR(sym, ver)
+#endif
+#if !GNUC_PREREQ(10,0)
+# define VERSION_ASM(sym, ver) __asm__(".symver " # sym "," # ver)
+#else
+# define VERSION_ASM(sym, ver)
 #endif
 
 


### PR DESCRIPTION
We cannot use VERSION macro in current way because __asm__
cannot be placed in function definition. Also this patch fixes
build with clang.