### PR TITLE
Run CI on more targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,18 @@
     "jobs": {
         "linux": {
             "runs-on": "ubuntu-latest",
-            "container": "vathpela/efi-ci:f35-x64",
+            "strategy": {
+                "fail-fast": false,
+                "matrix": {
+                    "container": [
+                        "f33", "f34", "f35", "f36", "centos8", "centos9",
+                    ],
+                },
+            },
+            "container": "vathpela/efi-ci:${{ matrix.container }}-x64",
             "steps": [
                 { "uses": "actions/checkout@v2" },
-                { "run": "make" },
+                { "run": "make all test" },
             ],
         },
     },

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -61,7 +61,7 @@
 # if GNUC_PREREQ(10,0)
 #  define VERSION(sym, ver) __attribute__ ((symver (# ver)))
 # else
-#  define VERSION(sym, ver) __asm__(".symver " # sym "," # ver)
+#  define VERSION(sym, ver) __asm__(".symver " # sym "," # ver);
 # endif
 #endif
 #define NORETURN __attribute__((__noreturn__))

--- a/src/lib.c
+++ b/src/lib.c
@@ -28,8 +28,8 @@ struct efi_var_operations default_ops = {
 
 struct efi_var_operations *ops = NULL;
 
-int NONNULL(2, 3) PUBLIC
 VERSION(_efi_set_variable, _efi_set_variable@libefivar.so.0)
+int NONNULL(2, 3) PUBLIC
 _efi_set_variable(efi_guid_t guid, const char *name, uint8_t *data,
 		  size_t data_size, uint32_t attributes)
 {
@@ -45,8 +45,8 @@ _efi_set_variable(efi_guid_t guid, const char *name, uint8_t *data,
 	return rc;
 }
 
-int NONNULL(2, 3) PUBLIC
 VERSION(_efi_set_variable_variadic, efi_set_variable@libefivar.so.0)
+int NONNULL(2, 3) PUBLIC
 _efi_set_variable_variadic(efi_guid_t guid, const char *name, uint8_t *data,
 			   size_t data_size, uint32_t attributes, ...)
 {
@@ -62,8 +62,8 @@ _efi_set_variable_variadic(efi_guid_t guid, const char *name, uint8_t *data,
 	return rc;
 }
 
-int NONNULL(2, 3) PUBLIC
 VERSION(_efi_set_variable_mode,efi_set_variable@@LIBEFIVAR_0.24)
+int NONNULL(2, 3) PUBLIC
 _efi_set_variable_mode(efi_guid_t guid, const char *name, uint8_t *data,
 		       size_t data_size, uint32_t attributes, mode_t mode)
 {


### PR DESCRIPTION
This makes the CI hook run "make test" as well as building the image,
and builds on more versions of fedora and centos.

Note that this is stacked on top of #185 

Signed-off-by: Peter Jones <pjones@redhat.com>