### PR TITLE
Fix linux virtual root device parsing

### DIFF
--- a/src/linux-virtual-root.c
+++ b/src/linux-virtual-root.c
@@ -49,12 +49,12 @@ parse_virtual_root(struct device *dev UNUSED, const char *current, const char *r
 		rc = sscanf(current, subdirs[i].fmt, &pos0, &pos1);
 		debug("current:'%s' rc:%d pos0:%d pos1:%d\n", current, rc, pos0, pos1);
 		dbgmk("         ", pos0, pos1);
-		if (rc == 1) {
-			sz += pos1;
-			current += pos1;
-			if (i > 0)
-				goto found;
-		}
+		if (rc != 0 || pos0 == -1 || pos1 == -1)
+			continue;
+		sz += pos1;
+		current += pos1;
+		if (i > 0)
+			goto found;
 	}
 
 	sz = 0;


### PR DESCRIPTION
When some Samsung NVMe devices have mutlipath mode enabled, that
switches which kind of NVMe device shows up in sysfs, and we get a
path link that's like
"../../devices/virtual/nvme-subsystem/nvme-subsys0/nvme0n1".  The first
part of that, "../../devices/virtual/nvme-subsystem/", is supposed to be
consumed by the parser in linux-virtual-root.c.  Unfortunately, that
parse loop incorrectly expects that sscanf will return nonzero when it
parses the format string "%n../../devices/virtual/%n", but libc does not
consider %n to be a conversion, and does not count it.  In the log, we
see it find the string and set pos, but rc is 0, and "current" is not
advanced:

linux-virtual-root.c:47 parse_virtual_root(): searching for ../../devices/virtual
linux-virtual-root.c:50 parse_virtual_root(): current:'../../devices/virtual/nvme-subsystem/nvme-subsys0/nvme0n1' rc:0 pos0:0 pos1:22
linux-virtual-root.c:51 parse_virtual_root():          ^^^^^^^^^^^^^^^^^^^^^^
linux-virtual-root.c:47 parse_virtual_root(): searching for nvme-subsystem/
linux-virtual-root.c:50 parse_virtual_root(): current:'../../devices/virtual/nvme-subsystem/nvme-subsys0/nvme0n1' rc:0 pos0:0 pos1:-1

This patch makes it expect rc == 0, in the same way parse_acpi_root() in
linux-acpi-root.c does.

Signed-off-by: Peter Jones <pjones@redhat.com>