### PR TITLE
Add script flag for files containing output sections

### DIFF
--- a/src/include/rules.mk
+++ b/src/include/rules.mk
@@ -37,7 +37,7 @@ family = $(foreach FAMILY_SUFFIX,$(FAMILY_SUFFIXES),$($(1)_$(FAMILY_SUFFIX)))
 
 %.so :
 	$(CCLD) $(CCLDFLAGS) $(CPPFLAGS) $(SOFLAGS) \
-		$(foreach LDS,$(LDSCRIPTS),$(LD_DASH_T) $(LDS)) \
+		$(foreach LDS,$(LDSCRIPTS),$(LD_DASH_T) -T $(LDS)) \
 		-o $@ $^ $(LDLIBS)
 	ln -vfs $@ $@.1
 


### PR DESCRIPTION
src/include/rules.mk:
Extend foreach loop that populates LDS with the linker scriptfile flag
(`-T`), as linking otherwise fails on LDSCRIPTS providing files with
output sections:

```
/usr/bin/ld: warning: guids.lds contains output sections; did you forget -T?
```