### PR TITLE
Fix musl build

### DIFF
--- a/src/compiler.h
+++ b/src/compiler.h
@@ -7,8 +7,6 @@
 #ifndef COMPILER_H_
 #define COMPILER_H_
 
-#include <sys/cdefs.h>
-
 /* GCC version checking borrowed from glibc. */
 #if defined(__GNUC__) && defined(__GNUC_MINOR__)
 #  define GNUC_PREREQ(maj,min) \

--- a/src/efisecdb.c
+++ b/src/efisecdb.c
@@ -255,8 +255,7 @@ list_guids(void)
  * failure.
  */
 static int
-parse_input_files(list_t *infiles, char **outfile, efi_secdb_t **secdb,
-		  bool dump)
+parse_input_files(list_t *infiles, efi_secdb_t **secdb, bool dump)
 {
 	int status = 0;
 	list_t *pos, *tmp;
@@ -297,8 +296,6 @@ parse_input_files(list_t *infiles, char **outfile, efi_secdb_t **secdb,
 				if (!dump)
 					exit(1);
 				status = 1;
-				xfree(*outfile);
-				*outfile = NULL;
 				break;
 			}
 		}
@@ -528,7 +525,7 @@ sort_err:
 	efi_secdb_set_bool(secdb, EFI_SECDB_SORT_DATA, do_sort_data);
 	efi_secdb_set_bool(secdb, EFI_SECDB_SORT_DESCENDING, sort_descending);
 
-	status = parse_input_files(&infiles, &outfile, &secdb, dump);
+	status = parse_input_files(&infiles, &secdb, dump);
 	if (status == 0) {
 		for_each_action_safe(pos, tmp, &actions) {
 			action_t *action = list_entry(pos, action_t, list);

--- a/src/efisecdb.c
+++ b/src/efisecdb.c
@@ -25,6 +25,10 @@
 extern char *optarg;
 extern int optind, opterr, optopt;
 
+static efi_secdb_t *secdb = NULL;
+static list_t infiles;
+static list_t actions;
+
 struct hash_param {
 	char *name;
 	efi_secdb_type_t algorithm;
@@ -187,12 +191,11 @@ add_action(list_t *list, action_type_t action_type, const efi_guid_t *owner,
 }
 
 static void
-free_actions(int status UNUSED, void *actionsp)
+free_actions(void)
 {
-	list_t *actions = (list_t *)actionsp;
 	list_t *pos, *tmp;
 
-	for_each_action_safe(pos, tmp, actions) {
+	for_each_action_safe(pos, tmp, &actions) {
 		action_t *action = list_entry(pos, action_t, list);
 
 		list_del(&action->list);
@@ -202,12 +205,11 @@ free_actions(int status UNUSED, void *actionsp)
 }
 
 static void
-free_infiles(int status UNUSED, void *infilesp)
+free_infiles(void)
 {
-	list_t *infiles = (list_t *)infilesp;
 	list_t *pos, *tmp;
 
-	for_each_ptr_safe(pos, tmp, infiles) {
+	for_each_ptr_safe(pos, tmp, &infiles) {
 		ptrlist_t *entry = list_entry(pos, ptrlist_t, list);
 
 		list_del(&entry->list);
@@ -216,27 +218,12 @@ free_infiles(int status UNUSED, void *infilesp)
 }
 
 static void
-maybe_free_secdb(int status UNUSED, void *voidp)
+maybe_free_secdb(void)
 {
-	efi_secdb_t **secdbp = (efi_secdb_t **)voidp;
-
-	if (secdbp == NULL || *secdbp == NULL)
+	if (secdb == NULL)
 		return;
 
-	efi_secdb_free(*secdbp);
-}
-
-static void
-maybe_do_unlink(int status, void *filep)
-{
-	char **file = (char **)filep;
-
-	if (status == 0)
-		return;
-	if (file == NULL || *file == NULL)
-		return;
-
-	unlink(*file);
+	efi_secdb_free(secdb);
 }
 
 static void
@@ -323,15 +310,6 @@ parse_input_files(list_t *infiles, char **outfile, efi_secdb_t **secdb,
 	return status;
 }
 
-/*
- * These need to be static globals so that they're not on main's stack when
- * on_exit() fires.
- */
-static efi_secdb_t *secdb = NULL;
-static list_t infiles;
-static list_t actions;
-static char *outfile = NULL;
-
 int
 main(int argc, char *argv[])
 {
@@ -351,6 +329,7 @@ main(int argc, char *argv[])
 	bool do_sort_data = false;
 	bool sort_descending = false;
 	int status = 0;
+	char *outfile = NULL;
 
 	const char sopts[] = ":aAc:dfg:h:i:Lo:rs:t:v?";
 	const struct option lopts[] = {
@@ -376,10 +355,9 @@ main(int argc, char *argv[])
 	INIT_LIST_HEAD(&infiles);
 	INIT_LIST_HEAD(&actions);
 
-	on_exit(free_actions, &actions);
-	on_exit(free_infiles, &infiles);
-	on_exit(maybe_free_secdb, &secdb);
-	on_exit(maybe_do_unlink, &outfile);
+	atexit(free_actions);
+	atexit(free_infiles);
+	atexit(maybe_free_secdb);
 
 	/*
 	 * parse the command line.
@@ -587,24 +565,30 @@ sort_err:
 	outfd = open(outfile, flags, 0600);
 	if (outfd < 0) {
 		char *tmpoutfile = outfile;
-		if (errno == EEXIST)
-			outfile = NULL;
+		if (errno != EEXIST)
+			unlink(outfile);
 		err(1, "could not open \"%s\"", tmpoutfile);
 	}
 
 	rc = ftruncate(outfd, 0);
-	if (rc < 0)
+	if (rc < 0) {
+		unlink(outfile);
 		err(1, "could not truncate output file \"%s\"", outfile);
+	}
 
 	void *output;
 	size_t size = 0;
 	rc = efi_secdb_realize(secdb, &output, &size);
-	if (rc < 0)
+	if (rc < 0) {
+		unlink(outfile);
 		secdb_err(1, "could not realize signature list");
+	}
 
 	rc = write(outfd, output, size);
-	if (rc < 0)
+	if (rc < 0) {
+		unlink(outfile);
 		err(1, "could not write signature list");
+	}
 
 	close(outfd);
 	xfree(output);


### PR DESCRIPTION
Fix build with musl by using POSTIX atexit(3) instead of GNU specific on_exit(3).

Also fix potential double free in error handling while at it.

Fixes https://github.com/rhboot/efivar/issues/197
Fixes https://github.com/rhboot/efivar/issues/202