### PR TITLE
Add `extern "C"` to headers for easier use by C++

### DIFF
--- a/src/include/efivar/efiboot-creator.h
+++ b/src/include/efivar/efiboot-creator.h
@@ -7,6 +7,10 @@
 #ifndef _EFIBOOT_CREATOR_H
 #define _EFIBOOT_CREATOR_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define EFIBOOT_ABBREV_NONE		0x00000001
 #define EFIBOOT_ABBREV_HD		0x00000002
 #define EFIBOOT_ABBREV_FILE		0x00000004
@@ -42,6 +46,10 @@ extern ssize_t efi_generate_ipv4_device_path(uint8_t *buf, ssize_t size,
 					     uint8_t addr_origin)
 	__attribute__((__nonnull__ (3,4,5,6,7)))
 	__attribute__((__visibility__ ("default")));
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* _EFIBOOT_CREATOR_H */
 

--- a/src/include/efivar/efiboot-loadopt.h
+++ b/src/include/efivar/efiboot-loadopt.h
@@ -7,6 +7,10 @@
 #ifndef _EFIBOOT_LOADOPT_H
 #define _EFIBOOT_LOADOPT_H 1
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct efi_load_option_s efi_load_option;
 
 extern ssize_t efi_loadopt_create(uint8_t *buf, ssize_t size,
@@ -58,6 +62,10 @@ extern ssize_t efi_loadopt_optional_data_size(efi_load_option *opt, size_t size)
 extern int efi_loadopt_is_valid(efi_load_option *opt, size_t size)
 	__attribute__((__nonnull__ (1)))
 	__attribute__((__visibility__ ("default")));
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* _EFIBOOT_LOADOPT_H */
 

--- a/src/include/efivar/efiboot.h
+++ b/src/include/efivar/efiboot.h
@@ -21,8 +21,16 @@
 #include <efivar/efiboot-creator.h>
 #include <efivar/efiboot-loadopt.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern uint32_t efi_get_libefiboot_version(void)
 	__attribute__((__visibility__("default")));
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* EFIBOOT_H */
 

--- a/src/include/efivar/efisec-secdb.h
+++ b/src/include/efivar/efisec-secdb.h
@@ -7,6 +7,10 @@
 #ifndef EFISEC_SECDB_H_
 #define EFISEC_SECDB_H_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct efi_secdb efi_secdb_t;
 
 typedef union {
@@ -89,6 +93,10 @@ typedef efi_secdb_visitor_status_t
 extern int efi_secdb_visit_entries(efi_secdb_t *secdb,
 				   efi_secdb_visitor_t *visitor,
 				   void *closure);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* !EFISEC_SECDB_H_ */
 // vim:fenc=utf-8:tw=75:noet

--- a/src/include/efivar/efisec-types.h
+++ b/src/include/efivar/efisec-types.h
@@ -10,6 +10,10 @@
 #include <stdint.h>
 #include <efivar/efivar-types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * Storage for specific hashes and cryptographic (pkcs1, not pkcs7)
  * signatures
@@ -230,6 +234,10 @@ typedef struct {
 	// uint8_t				newcert[];
 	// uint8_t				signing_cert[];
 } efi_variable_nonced_authentication_3 __attribute__((aligned (1)));
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* !SECURITY_H_ */
 // vim:fenc=utf-8:tw=75:noet

--- a/src/include/efivar/efisec.h
+++ b/src/include/efivar/efisec.h
@@ -12,8 +12,16 @@
 #include <efivar/efisec-types.h>
 #include <efivar/efisec-secdb.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern uint32_t efi_get_libefisec_version(void)
 	__attribute__((__visibility__("default")));
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* EFISEC_H */
 

--- a/src/include/efivar/efivar-dp.h
+++ b/src/include/efivar/efivar-dp.h
@@ -8,6 +8,10 @@
 
 #include <limits.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define efidp_encode_bitfield_(name, shift, mask)			\
 	(((name) << (shift)) & (mask))
 #define efidp_decode_bitfield_(value, name, shift, mask)		\
@@ -1213,6 +1217,11 @@ extern ssize_t efidp_make_generic(uint8_t *buf, ssize_t size, uint8_t type,
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
 #endif /* _EFIVAR_DP_H */
 
 // vim:fenc=utf-8:tw=75:noet

--- a/src/include/efivar/efivar-time.h
+++ b/src/include/efivar/efivar-time.h
@@ -14,6 +14,10 @@
 
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int tm_to_efi_time(const struct tm *const s, efi_time_t *d, bool tzadj);
 extern int efi_time_to_tm(const efi_time_t * const s, struct tm *d);
 
@@ -28,6 +32,10 @@ extern time_t efi_mktime(const efi_time_t *const time);
 extern char *efi_strptime(const char *s, const char *format, efi_time_t *time);
 extern size_t efi_strftime(char *s, size_t max, const char *format,
 			   const efi_time_t *time);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* !EFIVAR_TIME_H_ */
 // vim:fenc=utf-8:tw=75:noet

--- a/src/include/efivar/efivar-types.h
+++ b/src/include/efivar/efivar-types.h
@@ -10,6 +10,10 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
 	uint32_t	a;
 	uint16_t	b;
@@ -94,6 +98,10 @@ typedef struct {
 #define EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS	((uint64_t)0x0000000000000020)
 #define EFI_VARIABLE_APPEND_WRITE				((uint64_t)0x0000000000000040)
 #define EFI_VARIABLE_ENHANCED_AUTHENTICATED_ACCESS		((uint64_t)0x0000000000000080)
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif /* EFI_TYPES_H */
 // vim:fenc=utf-8:tw=75:noet

--- a/src/include/efivar/efivar.h
+++ b/src/include/efivar/efivar.h
@@ -24,6 +24,10 @@
 #include <efivar/efivar-guids.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define EFI_VARIABLE_HAS_AUTH_HEADER	0x0000000100000000
 #define EFI_VARIABLE_HAS_SIGNATURE	0x0000000200000000
 
@@ -199,6 +203,10 @@ extern FILE * efi_get_logfile(void)
 
 extern uint32_t efi_get_libefivar_version(void)
 	__attribute__((__visibility__("default")));
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #include <efivar/efivar-dp.h>
 #include <efivar/efivar-time.h>

--- a/src/makeguids.c
+++ b/src/makeguids.c
@@ -163,6 +163,10 @@ main(int argc, char *argv[])
 	char *strtab = guidnames->strtab;
 
 	fprintf(header, "#ifndef EFIVAR_GUIDS_H\n#define EFIVAR_GUIDS_H 1\n\n");
+	fprintf(header, "\
+#ifdef __cplusplus\n\
+extern \"C\" {\n\
+#endif\n");
 	fprintf(header, "\n\
 struct efivar_guidname {\n\
 	efi_guid_t guid;\n\
@@ -283,6 +287,10 @@ struct efivar_guidname {\n\
 	 * Emit the end from here as well.
 	 */
 
+	fprintf(header, "\n\
+#ifdef __cplusplus\n\
+} /* extern \"C\" */\n\
+#endif\n");
 	fprintf(header, "\n#endif /* EFIVAR_GUIDS_H */\n");
 	fclose(header);
 


### PR DESCRIPTION
Add `extern "C"` directly to all headers except efivar-guids.h, which
is generated. Because it interferes with C compilers, wrap each
`extern` in an `#ifdef __cplusplus`. For efivar-guids.h update the
generator, makeguids.c, to add the desired code.

From https://en.cppreference.com/w/cpp/language/language_linkage:
> extern "C" makes it possible to include header files containing
> declarations of C library functions in a C++ program, but if the
> same header file is shared with a C program, extern "C" (which
> is not allowed in C) must be hidden with an appropriate #ifdef,
> typically __cplusplus.

fixes #205 

Tests:
* `make` and `make test` both work
* tested in my project with `extern "C"` removed from my code.