### PR TITLE
Fix the -march issue for riscv64

### DIFF
--- a/src/include/defaults.mk
+++ b/src/include/defaults.mk
@@ -73,7 +73,11 @@ override SOFLAGS = $(_SOFLAGS) \
 
 HOST_ARCH=$(shell uname -m)
 ifneq ($(HOST_ARCH),ia64)
+ifneq ($(HOST_ARCH),riscv64)
 	HOST_MARCH=-march=native
+else
+	HOST_MARCH=
+endif
 else
 	HOST_MARCH=
 endif


### PR DESCRIPTION
There is an issue on riscv64 system when compiling it natively:
gcc: error: '-march=native': ISA string must begin with rv32 or rv64

This patch set HOST_MARCH= like ia64 to resolve the issue.

Signed-off-by: Wei Fu <wefu@redhat.com>