### PR TITLE
Fix invalid free in main()

### DIFF
--- a/src/efivar.c
+++ b/src/efivar.c
@@ -633,7 +633,7 @@ int main(int argc, char *argv[])
 				if (sz < 0)
 					err(1, "Could not import data from \"%s\"", infile);
 
-				free(data);
+				munmap(data, data_size);
 				data = NULL;
 				data_size = 0;
 


### PR DESCRIPTION
data is allocated by mmap() in prepare_data().

Resolves: #173
Signed-off-by: Robbie Harwood <rharwood@redhat.com>