### PR TITLE
Remove deprecated --add-needed linker flag

### DIFF
--- a/src/include/defaults.mk
+++ b/src/include/defaults.mk
@@ -51,7 +51,6 @@ LDFLAGS ?=
 override _CCLDFLAGS := $(CCLDFLAGS)
 override _LDFLAGS := $(LDFLAGS)
 override LDFLAGS = $(CFLAGS) -L. $(_LDFLAGS) $(_CCLDFLAGS) \
-		   -Wl,--add-needed \
 		   -Wl,--build-id \
 		   -Wl,--no-allow-shlib-undefined \
 		   -Wl,--no-undefined-version \
@@ -98,7 +97,6 @@ override _HOST_LDFLAGS := $(HOST_LDFLAGS)
 override _HOST_CCLDFLAGS := $(HOST_CCLDFLAGS)
 override HOST_LDFLAGS = $(HOST_CFLAGS) -L. \
 			$(_HOST_LDFLAGS) $(_HOST_CCLDFLAGS) \
-			-Wl,--add-needed \
 			-Wl,--build-id \
 			-Wl,--no-allow-shlib-undefined \
 			-Wl,-z,now \

--- a/src/include/gcc.specs
+++ b/src/include/gcc.specs
@@ -5,4 +5,4 @@
 + %{!shared:%{!static:%{!r:-pie}}} %{static:-Wl,-no-fatal-warnings -Wl,-static -static -Wl,-z,relro,-z,now} -grecord-gcc-switches
 
 *link:
-+ %{!static:--fatal-warnings} --no-undefined-version --no-allow-shlib-undefined --add-needed -z now --build-id %{!static:%{!shared:-pie}} %{shared:-z relro} %{static:%<pie}
++ %{!static:--fatal-warnings} --no-undefined-version --no-allow-shlib-undefined -z now --build-id %{!static:%{!shared:-pie}} %{shared:-z relro} %{static:%<pie}


### PR DESCRIPTION
Resolves #204 

The --add-needed linker flag is not supported by the LLD and Gold linkers, and moreover from what I can tell it doesn't actually serve much of a purpose.

I compiled efivar on Gentoo with --add-needed and with a patch to remove it, and the checksums of the resulting libraries were the same.

If there's any reason that I'm missing for keeping this flag in, please let me know.

Unfortunately this patch still doesn't allow for efivar to be compiled with Clang + LLD, as we get a new error: ```ld.lld: error: unable to insert .data after .data```