### PR TITLE
Fix glibc 2.36 build (mount.h conflicts)

### DIFF
--- a/src/gpt.c
+++ b/src/gpt.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mount.h>
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/utsname.h>

--- a/src/linux.c
+++ b/src/linux.c
@@ -20,6 +20,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <sys/ioctl.h>
+#include <sys/mount.h>
 #include <sys/socket.h>
 #include <sys/sysmacros.h>
 #include <sys/types.h>

--- a/src/util.h
+++ b/src/util.h
@@ -23,7 +23,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/ioctl.h>
-#include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <tgmath.h>


### PR DESCRIPTION
glibc has decided that sys/mount.h and linux/mount.h are no longer
usable at the same time.  This broke the build, since linux/fs.h itself
includes linux/mount.h.  For now, fix the build by only including
sys/mount.h where we need it.

See-also: https://sourceware.org/glibc/wiki/Release/2.36#Usage_of_.3Clinux.2Fmount.h.3E_and_.3Csys.2Fmount.h.3E
Resolves: #227
Signed-off-by: Robbie Harwood <rharwood@redhat.com>