### PR TITLE
File device paths: don't print "File(" or ")"

### DIFF
--- a/src/dp-media.c
+++ b/src/dp-media.c
@@ -60,9 +60,7 @@ _format_media_dn(unsigned char *buf, size_t size, const_efidp dp)
 	case EFIDP_MEDIA_FILE: {
 		size_t limit = (efidp_node_size(dp)
 				- offsetof(efidp_file, name)) / 2;
-		format(buf, size, off, "File", "File(");
 		format_ucs2(buf, size, off, "File", dp->file.name, limit);
-		format(buf, size, off, "File", ")");
 		break;
 			       }
 	case EFIDP_MEDIA_PROTOCOL:

--- a/src/dp-message.c
+++ b/src/dp-message.c
@@ -94,7 +94,7 @@ format_ipv6_addr_helper(unsigned char *buf, size_t size, const char *dp_type,
 	}
 
 	format(buf, size, off, dp_type, "]");
-	if (port >= 0)
+	if (port > 0)
 		format(buf, size, off, dp_type, ":%hu", (uint16_t)port);
 
 	return off;

--- a/src/dp-message.c
+++ b/src/dp-message.c
@@ -83,19 +83,19 @@ format_ipv6_addr_helper(unsigned char *buf, size_t size, const char *dp_type,
 
 	for (i = 0; i < 8; i++) {
 		if (largest_zero_block_offset == i) {
-			format(buf, size, off, "dp_type", "::");
+			format(buf, size, off, dp_type, "::");
 			i += largest_zero_block_size -1;
 			continue;
 		} else if (i > 0) {
-			format(buf, size, off, "dp_type", ":");
+			format(buf, size, off, dp_type, ":");
 		}
 
-		format(buf, size, off, "dp_type", "%x", ip[i]);
+		format(buf, size, off, dp_type, "%x", ip[i]);
 	}
 
-	format(buf, size, off, "dp_type", "]");
+	format(buf, size, off, dp_type, "]");
 	if (port >= 0)
-		format(buf, size, off, "Ipv6", ":%hu", (uint16_t)port);
+		format(buf, size, off, dp_type, ":%hu", (uint16_t)port);
 
 	return off;
 }

--- a/src/include/efivar/efivar-dp.h
+++ b/src/include/efivar/efivar-dp.h
@@ -473,6 +473,7 @@ typedef struct {
 } EFIVAR_PACKED efidp_ipv6_addr;
 
 #define EFIDP_IPv6_ORIGIN_MANUAL	0x00
+#define EFIDP_IPv6_ORIGIN_STATIC	0x00
 #define EFIDP_IPv6_ORIGIN_AUTOCONF	0x01
 #define EFIDP_IPv6_ORIGIN_STATEFUL	0x02
 

--- a/src/include/efivar/efivar-dp.h
+++ b/src/include/efivar/efivar-dp.h
@@ -469,7 +469,7 @@ typedef struct {
 	uint16_t	protocol;
 	uint8_t		ip_addr_origin;
 	uint8_t		prefix_length;
-	uint8_t		gateway_ipv6_addr;
+	uint8_t		gateway_ipv6_addr[16];
 } EFIVAR_PACKED efidp_ipv6_addr;
 
 #define EFIDP_IPv6_ORIGIN_MANUAL	0x00


### PR DESCRIPTION
ardb poked me about a few efivar device path issues:
- File device paths are printed wrong
- IPv4 device paths are printed wrong
- IPv6 device paths are printed wrong