### PR TITLE
Allow overriding PKG_CONFIG

### DIFF
--- a/src/include/defaults.mk
+++ b/src/include/defaults.mk
@@ -106,7 +106,7 @@ override HOST_LDFLAGS = $(HOST_CFLAGS) -L. \
 			$(call pkg-config-ccldflags)
 override HOST_CCLDFLAGS = $(HOST_LDFLAGS)
 
-PKG_CONFIG = $(shell if [ -e "$$(env $(CROSS_COMPILE)pkg-config 2>&1)" ]; then echo $(CROSS_COMPILE)pkg-config ; else echo pkg-config ; fi)
+PKG_CONFIG ?= $(shell if [ -e "$$(env $(CROSS_COMPILE)pkg-config 2>&1)" ]; then echo $(CROSS_COMPILE)pkg-config ; else echo pkg-config ; fi)
 INSTALL ?= install
 AR	:= $(CROSS_COMPILE)$(COMPILER)-ar
 NM	:= $(CROSS_COMPILE)$(COMPILER)-nm


### PR DESCRIPTION
In my ChromiumOS build calling pkg-config without an appropriate cross-compilation prefix is considered an error. The current method of detecting PKG_CONFIG in efivar _always_ calls pkg-config, even if PKG_CONFIG has already been set in the environment.

Allow overriding PKG_CONFIG, rather than always checking for the cross-compiled version. This is more in-line with how the other tools are chosen.

Signed-off-by: Ted Brandston <tbrandston@google.com>