### PR TITLE
Use off_t instead of off64_t

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -191,7 +191,7 @@ dbglog_write(void *cookie, const char *buf, size_t size)
 }
 
 static int
-dbglog_seek(void *cookie UNUSED, off64_t *offset, int whence)
+dbglog_seek(void *cookie UNUSED, off_t *offset, int whence)
 {
 	FILE *log = efi_errlog ? efi_errlog : stderr;
 	int rc;

--- a/src/include/defaults.mk
+++ b/src/include/defaults.mk
@@ -34,6 +34,7 @@ CPPFLAGS ?=
 override _CPPFLAGS := $(CPPFLAGS)
 override CPPFLAGS = $(_CPPFLAGS) -DLIBEFIVAR_VERSION=$(VERSION) \
 	    -D_GNU_SOURCE \
+	    -D_FILE_OFFSET_BITS=64 \
 	    -I$(TOPDIR)/src/include/
 CFLAGS ?= $(OPTIMIZE) $(DEBUGINFO) $(WARNINGS) $(ERRORS)
 CFLAGS_GCC ?= -specs=$(TOPDIR)/src/include/gcc.specs \


### PR DESCRIPTION
Pass _FILE_OFFSET_BITS=64 to ensure 64bit off_t

Signed-off-by: Khem Raj <raj.khem@gmail.com>