### PR TITLE
Add NO_THREADS variable

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,10 @@ include $(TOPDIR)/src/include/defaults.mk
 
 LIBTARGETS=libefivar.so libefiboot.so libefisec.so
 STATICLIBTARGETS=libefivar.a libefiboot.a libefisec.a
-BINTARGETS=efivar efisecdb thread-test
+BINTARGETS=efivar efisecdb
+ifeq ($(NO_THREADS),)
+BINTARGETS += thread-test
+endif
 STATICBINTARGETS=efivar-static efisecdb-static
 PCTARGETS=efivar.pc efiboot.pc efisec.pc
 TARGETS=$(LIBTARGETS) $(BINTARGETS) $(PCTARGETS)

--- a/src/include/defaults.mk
+++ b/src/include/defaults.mk
@@ -8,6 +8,7 @@ BINDIR	?= $(EXEC_PREFIX)/bin
 PCDIR	?= $(LIBDIR)/pkgconfig
 DESTDIR	?=
 PKGS	?=
+NO_THREADS ?=
 
 CROSS_COMPILE	?=
 COMPILER 	?= gcc


### PR DESCRIPTION
Allow the user to disable building thread-test to avoid the following build failure without threads raised since version 38 and https://github.com/rhboot/efivar/commit/cff88dd96b9d43e2c5875a24ba6180b196890ded:

```
thread-test.c:14:10: fatal error: pthread.h: No such file or directory
   14 | #include <pthread.h>
      |          ^~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/277f783c33102a0cea7c82ca902119ab90f37ad4