### PR TITLE
Allow -a to create a non-existent variable

### DIFF
--- a/src/efivar.c
+++ b/src/efivar.c
@@ -355,14 +355,8 @@ edit_variable(const char *guid_name, void *data, size_t data_size,
 		exit(1);
 	}
 
-	rc = efi_get_variable(guid, name, &old_data, &old_data_size,
-			      &old_attributes);
-	if (rc < 0 && edit_type != EDIT_WRITE) {
-		fprintf(stderr, "efivar: %m\n");
-		show_errors();
-		exit(1);
-	}
-
+	rc = efi_get_variable(guid, name, &old_data, &old_data_size, &old_attributes);
+	/* Ignore errors, as -a can be used to create a variable */
 	if (attrib != 0)
 		old_attributes = attrib;
 


### PR DESCRIPTION
There is no much point in failing when trying to append, we may as well create the variable. This way it can be used for dbx update payloads that must be applied in append mode even if there isn't a dbx yet.

This is nicer than using -w with EFI_VARIABLE_APPEND_WRITE added to the attributes passed with -A