### PR TITLE
make: add option to disable building/installing the docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ include $(TOPDIR)/src/include/defaults.mk
 include $(TOPDIR)/src/include/coverity.mk
 include $(TOPDIR)/src/include/scan-build.mk
 
-SUBDIRS := src docs
+SUBDIRS := src
+ifeq ($(ENABLE_DOCS), 1)
+SUBDIRS += docs
+endif
 
 all : | efivar.spec src/include/version.mk prep
 all clean install prep :

--- a/src/include/defaults.mk
+++ b/src/include/defaults.mk
@@ -122,4 +122,8 @@ COMMIT_ID=$(shell git log -1 --pretty=%H 2>/dev/null || echo master)
 
 NAME=efivar
 
+# Docs are enabled by default. Set ENABLE_DOCS=0 to disable
+# building/installing docs.
+ENABLE_DOCS ?= 1
+
 # vim:ft=make


### PR DESCRIPTION
`ENABLE_DOCS=0 make` will remove the docs subdirectory from the list of targets. This is useful if the target OS does not ship manpages and so the builder doesn't have `mandoc`.