### PR TITLE
esl-iter.h: fix type declaration of return value for gcc-13

### DIFF
--- a/src/esl-iter.h
+++ b/src/esl-iter.h
@@ -58,7 +58,7 @@ extern esl_iter_status_t esl_iter_next(esl_iter *iter, efi_guid_t *type,
         __attribute__((__nonnull__(1, 2, 3, 4, 5)));
 
 
-extern int esl_iter_next_with_size_correction(esl_iter *iter, efi_guid_t *type,
+extern esl_iter_status_t esl_iter_next_with_size_correction(esl_iter *iter, efi_guid_t *type,
 					      efi_guid_t *owner, uint8_t **data,
 					      size_t *len, bool correct_size)
         __attribute__((__nonnull__(1, 2, 3, 4, 5)));


### PR DESCRIPTION
Upcoming `gcc-13` detected return type mismatch as:

    esl-iter.c:84:1: error: conflicting types for 'esl_iter_next_with_size_correction' due to enum/integer mismatch; have 'esl_iter_status_t(esl_iter *, efi_guid_t *, efi_guid_t *, uint8_t **, size_t *, _Bool)' {aka 'enum esl_iter_status(esl_iter *, efi_guid_t *, efi_guid_t *, unsigned char **, long unsigned int *, _Bool)'} [-Werror=enum-int-mismatch]
       84 | esl_iter_next_with_size_correction(esl_iter *iter, efi_guid_t *type,
          | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In file included from efisec.h:25,
                     from esl-iter.c:7:
    esl-iter.h:61:12: note: previous declaration of 'esl_iter_next_with_size_correction' with type 'int(esl_iter *, efi
    *, efi_guid_t *, uint8_t **, size_t *, _Bool)' {aka 'int(esl_iter *, efi_guid_t *, efi_guid_t *, unsigned char **, long unsigned int *, _Bool)'}
       61 | extern int esl_iter_next_with_size_correction(esl_iter *iter, efi_guid_t *type,
          |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

The change brings declaration and definition in sync.