### PR TITLE
linux: handle non-ACPI systems in device_get()

### DIFF
--- a/src/linux.c
+++ b/src/linux.c
@@ -526,8 +526,8 @@ struct device HIDDEN
 	        debug("trying %s", probe->name);
 	        pos = probe->parse(dev, current, dev->link);
 	        if (pos < 0) {
-	                efi_error("parsing %s failed", probe->name);
-	                goto err;
+	                debug("parsing %s failed", probe->name);
+	                continue;
 	        } else if (pos > 0) {
 			char match[pos+1];
 


### PR DESCRIPTION
/sys/devices/pci0000:00/firmware_node/hid does not exist on all systems. Kernel parameter acpi=off has been reported as one possible reason in https://github.com/rhboot/efivar/issues/120
But this is not the only case. On systems using device trees you may also not find this file.

We have multiple parsers in dev_probes[]. It is sufficient that one of these parsers succeeds to provide the device information.

If for instance pci_root_parser and pci_parser fails, we may still get information from nvme_parser.

If a parser fails, only write a debug information and continue.