### PR TITLE
Ignore and clean built src util-makeguids.c

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -9,3 +9,4 @@ makeguids
 guid-symbols.c
 guids.lds
 thread-test
+util-makeguids.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -134,8 +134,9 @@ deps : $(ALL_SOURCES)
 
 clean : 
 	@rm -rfv *~ *.o *.a *.E *.so *.so.* *.pc *.bin .*.d *.map \
-		makeguids guid-symbols.c include/efivar/efivar-guids.h \
-		$(TARGETS) $(STATICTARGETS)
+		makeguids guid-symbols.cutil-makeguids.c	\
+		include/efivar/efivar-guids.h $(TARGETS)	\
+		$(STATICTARGETS)
 	@# remove the deps files we used to create, as well.
 	@rm -rfv .*.P .*.h.P *.S.P include/efivar/.*.h.P
 


### PR DESCRIPTION
util-makeguids.c is copied from util.c at build time. This PR adds it to .gitignore and to the files cleaned by make clean.