### PR TITLE
Change set&append data to be const.

### DIFF
--- a/src/efivarfs.c
+++ b/src/efivarfs.c
@@ -324,7 +324,7 @@ efivarfs_del_variable(efi_guid_t guid, const char *name)
 }
 
 static int
-efivarfs_set_variable(efi_guid_t guid, const char *name, uint8_t *data,
+efivarfs_set_variable(efi_guid_t guid, const char *name, const uint8_t *data,
 		      size_t data_size, uint32_t attributes, mode_t mode)
 {
 	char *path;
@@ -471,7 +471,7 @@ err:
 }
 
 static int
-efivarfs_append_variable(efi_guid_t guid, const char *name, uint8_t *data,
+efivarfs_append_variable(efi_guid_t guid, const char *name, const uint8_t *data,
 	size_t data_size, uint32_t attributes)
 {
 	int rc;

--- a/src/generics.h
+++ b/src/generics.h
@@ -119,7 +119,7 @@ close_dir(void)
  * -- pjones */
 static int UNUSED FLATTEN
 generic_append_variable(efi_guid_t guid, const char *name,
-		       uint8_t *new_data, size_t new_data_size,
+		       const uint8_t *new_data, size_t new_data_size,
 		       uint32_t new_attributes)
 {
 	int rc;
@@ -157,10 +157,8 @@ generic_append_variable(efi_guid_t guid, const char *name,
 		free(d);
 		free(data);
 	} else if (rc < 0 && errno == ENOENT) {
-		data = new_data;
-		data_size = new_data_size;
 		attributes = new_attributes & ~EFI_VARIABLE_APPEND_WRITE;
-		rc = efi_set_variable(guid, name, data, data_size,
+		rc = efi_set_variable(guid, name, new_data, new_data_size,
 				      attributes, 0600);
 	}
 	if (rc < 0)

--- a/src/include/efivar/efivar.h
+++ b/src/include/efivar/efivar.h
@@ -46,11 +46,11 @@ extern int efi_get_variable(efi_guid_t guid, const char *name, uint8_t **data,
 extern int efi_del_variable(efi_guid_t guid, const char *name)
 				__attribute__((__nonnull__ (2)));
 extern int efi_set_variable(efi_guid_t guid, const char *name,
-			    uint8_t *data, size_t data_size,
+			    const uint8_t *data, size_t data_size,
 			    uint32_t attributes, mode_t mode)
 				__attribute__((__nonnull__ (2, 3)));
 extern int efi_append_variable(efi_guid_t guid, const char *name,
-			       uint8_t *data, size_t data_size,
+			       const uint8_t *data, size_t data_size,
 			       uint32_t attributes)
 			      __attribute__((__nonnull__ (2, 3)));
 extern int efi_get_next_variable_name(efi_guid_t **guid, char **name)

--- a/src/lib.c
+++ b/src/lib.c
@@ -30,7 +30,7 @@ struct efi_var_operations *ops = NULL;
 
 VERSION(_efi_set_variable, _efi_set_variable@libefivar.so.0)
 int NONNULL(2, 3) PUBLIC
-_efi_set_variable(efi_guid_t guid, const char *name, uint8_t *data,
+_efi_set_variable(efi_guid_t guid, const char *name, const uint8_t *data,
 		  size_t data_size, uint32_t attributes)
 {
 	int rc;
@@ -47,7 +47,7 @@ _efi_set_variable(efi_guid_t guid, const char *name, uint8_t *data,
 
 VERSION(_efi_set_variable_variadic, efi_set_variable@libefivar.so.0)
 int NONNULL(2, 3) PUBLIC
-_efi_set_variable_variadic(efi_guid_t guid, const char *name, uint8_t *data,
+_efi_set_variable_variadic(efi_guid_t guid, const char *name, const uint8_t *data,
 			   size_t data_size, uint32_t attributes, ...)
 {
 	int rc;
@@ -64,7 +64,7 @@ _efi_set_variable_variadic(efi_guid_t guid, const char *name, uint8_t *data,
 
 VERSION(_efi_set_variable_mode,efi_set_variable@@LIBEFIVAR_0.24)
 int NONNULL(2, 3) PUBLIC
-_efi_set_variable_mode(efi_guid_t guid, const char *name, uint8_t *data,
+_efi_set_variable_mode(efi_guid_t guid, const char *name, const uint8_t *data,
 		       size_t data_size, uint32_t attributes, mode_t mode)
 {
 	int rc;
@@ -82,12 +82,12 @@ _efi_set_variable_mode(efi_guid_t guid, const char *name, uint8_t *data,
 }
 
 int NONNULL(2, 3) PUBLIC
-efi_set_variable(efi_guid_t guid, const char *name, uint8_t *data,
+efi_set_variable(efi_guid_t guid, const char *name, const uint8_t *data,
 		 size_t data_size, uint32_t attributes, mode_t mode)
 	ALIAS(_efi_set_variable_mode);
 
 int NONNULL(2, 3) PUBLIC
-efi_append_variable(efi_guid_t guid, const char *name, uint8_t *data,
+efi_append_variable(efi_guid_t guid, const char *name, const uint8_t *data,
 			size_t data_size, uint32_t attributes)
 {
 	int rc;

--- a/src/lib.h
+++ b/src/lib.h
@@ -21,7 +21,7 @@ struct efi_variable {
 struct efi_var_operations {
 	char name[NAME_MAX];
 	int (*probe)(void);
-	int (*set_variable)(efi_guid_t guid, const char *name, uint8_t *data,
+	int (*set_variable)(efi_guid_t guid, const char *name, const uint8_t *data,
 			    size_t data_size, uint32_t attributes, mode_t mode);
 	int (*del_variable)(efi_guid_t guid, const char *name);
 	int (*get_variable)(efi_guid_t guid, const char *name, uint8_t **data,
@@ -32,7 +32,7 @@ struct efi_var_operations {
 				 size_t *size);
 	int (*get_next_variable_name)(efi_guid_t **guid, char **name);
 	int (*append_variable)(efi_guid_t guid, const char *name,
-			       uint8_t *data, size_t data_size,
+			       const uint8_t *data, size_t data_size,
 			       uint32_t attributes);
 	int (*chmod_variable)(efi_guid_t guid, const char *name, mode_t mode);
 };

--- a/src/vars.c
+++ b/src/vars.c
@@ -511,7 +511,7 @@ vars_chmod_variable(efi_guid_t guid, const char *name, mode_t mode)
 }
 
 static int
-vars_set_variable(efi_guid_t guid, const char *name, uint8_t *data,
+vars_set_variable(efi_guid_t guid, const char *name, const uint8_t *data,
 		 size_t data_size, uint32_t attributes, mode_t mode)
 {
 	int errno_value;


### PR DESCRIPTION
All implementations of set_variable and append_variable never modify the data pointed to. Callers don't know by the function signitures that their data will not be modified nor can they pass const buffers without warnings. This commit adds const to all function signatures and fixes the one assignment where the pointer is copied to a non-const pointer.