### PR TITLE
dp.h: check _ucs2size in format_ucs2()

### DIFF
--- a/src/dp.h
+++ b/src/dp.h
@@ -123,7 +123,7 @@ format_vendor_helper(unsigned char *buf, size_t size, char *label,
 		uint16_t *_ucs2buf;					\
 		uint32_t _ucs2size = sizeof(uint16_t) * len;		\
 		_ucs2buf = alloca(_ucs2size);				\
-		if (_ucs2buf == NULL)					\
+		if (_ucs2buf == NULL || _ucs2size < sizeof(uint16_t))	\
 			return -1;					\
 		memset(_ucs2buf, '\0', _ucs2size);			\
 		memcpy(_ucs2buf, str, _ucs2size - sizeof(uint16_t));	\


### PR DESCRIPTION
When memcpy() is called in format_ucs2(), the value of ucs2size - sizeof(uint16_t) is not checked. It may result in out-of-bounds writing due to integer underflow.