### PR TITLE
fix wrong if condition in efi_variable_get_data

### DIFF
--- a/src/export.c
+++ b/src/export.c
@@ -677,7 +677,7 @@ efi_variable_set_data(efi_variable_t *var, uint8_t *data, size_t size)
 ssize_t NONNULL(1, 2, 3) PUBLIC
 efi_variable_get_data(efi_variable_t *var, uint8_t **data, size_t *size)
 {
-	if (var->data || !var->data_size) {
+	if (!var->data || !var->data_size) {
 		errno = ENOENT;
 		return -1;
 	}


### PR DESCRIPTION
The wrong if condition in efi_variable_get_data result in empty value of printing variable from --import. 
Fix #254

Signed-off-by: zhouyihang <15151851377@163.com>