### PR TITLE
Make README statement match license

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Tools and libraries to manipulate EFI variables
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; version 2.1
-of the License.
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
 This library is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of


### PR DESCRIPTION
All of the source files are tagged LGPL-2.1-or-later. Make the README license statement reflect that.

Fixes #215 
