### PR TITLE
Fix incorrect error handling in callers of `efidp_node_size()`

### DIFF
--- a/src/creator.c
+++ b/src/creator.c
@@ -221,12 +221,7 @@ efi_va_generate_file_device_path_from_esp(uint8_t *buf, ssize_t size,
 		debug("EFIBOOT_ABBREV_EDD10");
 
 	if (options & EFIBOOT_ABBREV_EDD10) {
-		va_list aq;
-		va_copy(aq, ap);
-
-		dev->edd10_devicenum = va_arg(aq, uint32_t);
-
-		va_end(aq);
+		dev->edd10_devicenum = va_arg(ap, uint32_t);
 	}
 
 	if (!(options & (EFIBOOT_ABBREV_FILE|EFIBOOT_ABBREV_HD))

--- a/src/dp-acpi.c
+++ b/src/dp-acpi.c
@@ -101,10 +101,17 @@ _format_acpi_dn(unsigned char *buf, size_t size, const_efidp dp)
 		return off;
 	} else if (dp->subtype != EFIDP_ACPI_HID_EX &&
 		   dp->subtype != EFIDP_ACPI_HID) {
+		ssize_t limit = efidp_node_size(dp);
+
 		debug("DP subtype %d, formatting as ACPI Path", dp->subtype);
+		if (SUB(limit, 4, &limit) ||
+		    DIV(limit, 2, &limit) ||
+		    limit < 0) {
+			efi_error("bad DP node size");
+			return -1;
+		}
 		format(buf, size, off, "AcpiPath", "AcpiPath(%d,", dp->subtype);
-		format_hex(buf, size, off, "AcpiPath", (uint8_t *)dp+4,
-			   (efidp_node_size(dp)-4) / 2);
+		format_hex(buf, size, off, "AcpiPath", (uint8_t *)dp+4, limit);
 		format(buf, size, off, "AcpiPath", ")");
 		return off;
 	} else if (dp->subtype == EFIDP_ACPI_HID_EX) {

--- a/src/dp-hw.c
+++ b/src/dp-hw.c
@@ -58,13 +58,20 @@ _format_hw_dn(unsigned char *buf, size_t size, const_efidp dp)
 		format(buf, size, off, "BMC", "BMC(%d,0x%"PRIx64")",
 		       dp->bmc.interface_type, dp->bmc.base_addr);
 		break;
-	default:
+	default: {
+		ssize_t sz = efidp_node_size(dp);
+
+		if (SUB(sz, 4, &sz) ||
+		    sz < 0) {
+			efi_error("bad DP node size");
+			return -1;
+		}
 		format(buf, size, off, "Hardware",
 		       "HardwarePath(%d,", dp->subtype);
-		format_hex(buf, size, off, "Hardware", (uint8_t *)dp+4,
-			   efidp_node_size(dp)-4);
+		format_hex(buf, size, off, "Hardware", (uint8_t *)dp+4, sz);
 		format(buf, size, off, "Hardware", ")");
 		break;
+		 }
 	}
 	return off;
 }

--- a/src/dp-media.c
+++ b/src/dp-media.c
@@ -58,9 +58,14 @@ _format_media_dn(unsigned char *buf, size_t size, const_efidp dp)
 		format_vendor(buf, size, off, "VenMedia", dp);
 		break;
 	case EFIDP_MEDIA_FILE: {
-		size_t limit = (efidp_node_size(dp)
-				- offsetof(efidp_file, name)) / 2;
-		format_ucs2(buf, size, off, "File", dp->file.name, limit);
+		ssize_t node_size = efidp_node_size(dp);
+		if (node_size > 0) {
+			size_t limit = ((size_t) node_size
+					- offsetof(efidp_file, name)) / 2;
+			format_ucs2(buf, size, off, "File", dp->file.name, limit);
+		} else {
+			efi_error("Invalid node size");
+		}
 		break;
 			       }
 	case EFIDP_MEDIA_PROTOCOL:

--- a/src/dp.h
+++ b/src/dp.h
@@ -101,9 +101,14 @@ format_vendor_helper(unsigned char *buf, size_t size, char *label,
 		     const_efidp dp)
 {
 	ssize_t off = 0;
-	ssize_t bytes = efidp_node_size(dp)
-			- sizeof (efidp_header)
-			- sizeof (efi_guid_t);
+	ssize_t bytes = efidp_node_size(dp);
+
+	if (SUB(bytes, sizeof (efidp_header), &bytes) ||
+	    SUB(bytes, sizeof (efi_guid_t), &bytes) ||
+	    bytes < 0) {
+		efi_error("bad DP node size");
+		return -1;
+	}
 
 	format(buf, size, off, label, "%s(", label);
 	format_guid(buf, size, off, label, &dp->hw_vendor.vendor_guid);

--- a/src/safemath.h
+++ b/src/safemath.h
@@ -32,7 +32,7 @@
 #define DIV(a, b, res) ({						\
 	bool ret_ = true;						\
 	if ((b) != 0) {							\
-		if (!is_null(res))					\
+		if (!(res == NULL))					\
 			(*(res)) = (a) / (b);				\
 		ret_ = false;						\
 	} else {							\
@@ -44,7 +44,7 @@
  * These really just exists for chaining results easily with || in an expr
  */
 #define MOD(a, b, res) ({						\
-	if (!is_null(res))						\
+	if (!(res == NULL))						\
 		(*(res)) = (a) % (b);					\
 	false;								\
 })


### PR DESCRIPTION
One of our internal analyzers noticed some issues in our usage of `efidp_node_size()` in the device path formatters.  This patch attempts to address those issues.