### PR TITLE
efivar: Copy VarToFile to RTStorageVolatile file at ESP

### DIFF
--- a/src/efivar.c
+++ b/src/efivar.c
@@ -441,7 +441,7 @@ usage(int ret)
 		"  -a, --append                      append to variable specified by --name\n"
 		"  -f, --datafile=<file>             load or save variable contents from <file>\n"
 		"  -e, --export=<file>               export variable to <file>\n"
-		"  -i, --import=<file>               import variable from <file\n"
+		"  -i, --import=<file>               import variable from <file>\n"
 		"  -L, --list-guids                  show internal guid list\n"
 		"  -w, --write                       write to variable specified by --name\n\n"
 		"Help options:\n"

--- a/src/efivarfs.c
+++ b/src/efivarfs.c
@@ -312,6 +312,8 @@ efivarfs_del_variable(efi_guid_t guid, const char *name)
 	if (rc < 0)
 		efi_error("unlink failed");
 
+	efi_save_esp_filename();
+
 	__typeof__(errno) errno_value = errno;
 	free(path);
 	errno = errno_value;
@@ -441,6 +443,8 @@ efivarfs_set_variable(efi_guid_t guid, const char *name, const uint8_t *data,
 		efi_error("writing to fd %d failed", wfd);
 		goto err;
 	}
+
+	efi_save_esp_filename();
 
 	/* we're done */
 	ret = 0;

--- a/src/include/efivar/efivar.h
+++ b/src/include/efivar/efivar.h
@@ -121,6 +121,8 @@ extern int efi_variable_get_attributes(efi_variable_t *var, uint64_t *attrs)
 extern int efi_variable_realize(efi_variable_t *var)
 			__attribute__((__nonnull__ (1)));
 
+extern void efi_save_esp_filename(void);
+
 #ifndef EFIVAR_BUILD_ENVIRONMENT
 extern int efi_error_get(unsigned int n,
 			 char ** const filename,

--- a/src/libefivar.map.in
+++ b/src/libefivar.map.in
@@ -90,6 +90,8 @@ libefivar.so.0 {
 		efi_guid_x509_sha384;
 		efi_guid_x509_sha512;
 		efi_guid_zero;
+
+		efi_save_esp_filename;
 	local:	*;
 };
 

--- a/src/vars.c
+++ b/src/vars.c
@@ -435,8 +435,10 @@ vars_del_variable(efi_guid_t guid, const char *name)
 	}
 
 	rc = write(fd, buf, buf_size);
-	if (rc >= 0)
+	if (rc >= 0) {
+		efi_save_esp_filename();
 		ret = 0;
+	}
 	else
 		efi_error("write() failed");
 err:
@@ -594,8 +596,10 @@ vars_set_variable(efi_guid_t guid, const char *name, const uint8_t *data,
 		rc = write(fd, &var32, sizeof(var32));
 	}
 
-	if (rc >= 0)
+	if (rc >= 0) {
+		efi_save_esp_filename();
 		ret = 0;
+	}
 	else
 		efi_error("write() failed");
 


### PR DESCRIPTION
An extension of [Ilias Apalodimas' work (@apalos)](https://lore.kernel.org/u-boot/20240406140203.248211-6-ilias.apalodimas@linaro.org/T/#m38fd1c825f9f9b145878688bf490f49e35d77cd8), merged in U-Boot, to support it in userspace.

EFI is becoming more common on embedded boards with the embracing of SystemReady-IR.

U-Boot which is most commonly used, is usually storing the EFI variables in a file in the ESP. That makes it impossible to support `SetVariable` at Runtime reliably, since the OS doesn't know how to access, read or write that file.

OS'es usually need `SetVariable` at runtime for three reasons:

- Set the `BootOrder`
- Enable UEFI Secure Boot
- `OSIndication` to signal capsule updates on-disk

Since the variables are stored in a file U-Boot enables `SetVariable` at runtime in the EFI config table and stores any updates in RAM. At the same file it creates two volatile variables:

- RTStorageVolatile is the location of the file relative to the ESP
- VarTofile contains a binary dump of the EFI variables that need to be preserved on the file (BS, RT, NV)

U-Boot fills in the VarToFile dynamically on reads and that includes any updates the OS did in the meantime.

So, let's update efivar to do the same thing. Once a variable is written to the `efivarfs`, make sure efivars is mounted as rw and scan for the file `RTStorageVolatile`. If we find that, copy the `VarToFile` contents in a file and preserve the variables across reboots

@apalos suggested that similar work should be done in `efibootmgr`. We will need to share code from `efivar`, so it can be called from `efibootmgr`. Please advise on what would be a better approach.

Suggested-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
Signed-off-by: Javier Tia <javier.tia@linaro.org>