### PR TITLE
dp.c: check efidp_size return value

### DIFF
--- a/src/dp.c
+++ b/src/dp.c
@@ -194,6 +194,10 @@ efidp_append_node(const_efidp dp, const_efidp dn, efidp *out)
 			if (efidp_type(le) == EFIDP_END_TYPE &&
 			    efidp_subtype(le) == EFIDP_END_ENTIRE) {
 				ssize_t lesz = efidp_size(le);
+				if (lesz < 0) {
+					efi_error("efidp_size(dp) returned error");
+					return lesz;
+				}
 				lsz -= lesz;
 				break;
 			}


### PR DESCRIPTION
Detected by our SAST engine

"Error: INTEGER_OVERFLOW (CWE-190):
efivar-39/src/dp.c:196: tainted_data_return: Called function ""efidp_size(le)"", and a possible return value is known to be less than zero.
efivar-39/src/dp.c:196: assign: Assigning: ""lesz"" = ""efidp_size(le)"".
efivar-39/src/dp.c:197: overflow: The expression ""lsz"" is considered to have possibly overflowed.
efivar-39/src/dp.c:232: overflow_sink: ""lsz"", which might have overflowed, is passed to ""memcpy(new, dp, lsz)"". [Note: The source code implementation of the function has been overridden by a builtin model.]