### PR TITLE
Fix the -march issue for ppc64le

### DIFF
--- a/src/include/defaults.mk
+++ b/src/include/defaults.mk
@@ -74,7 +74,11 @@ override SOFLAGS = $(_SOFLAGS) \
 HOST_ARCH=$(shell uname -m)
 ifneq ($(HOST_ARCH),ia64)
 ifneq ($(HOST_ARCH),riscv64)
+ifneq ($(HOST_ARCH),ppc64le)
 	HOST_MARCH=-march=native
+else
+	HOST_MARCH=
+endif
 else
 	HOST_MARCH=
 endif


### PR DESCRIPTION
Similar to the fix in aab4e9b10ac, need to also support the ppc64le architecture.

The failure without this fix on a ppc64le machine:
```
| cp util.c util-makeguids.c
| gcc: error: unrecognized command-line option ‘-march=native’; did you mean ‘-mcpu=native’?
```