### PR TITLE
Fix format specifier mismatches on 32-bit builds

### DIFF
--- a/src/efisecdb.c
+++ b/src/efisecdb.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
+#include <inttypes.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -244,7 +245,7 @@ list_guids(void)
 	const uint64_t n = efi_n_well_known_guids;
 	unsigned int i;
 
-	debug("&guid[0]:%p n:%lu", &guid[0], n);
+	debug("&guid[0]:%p n:%"PRIu64, &guid[0], n);
 	for (i = 0; i < n; i++) {
 		printf("{"GUID_FORMAT"}\t",
 		       GUID_FORMAT_ARGS(&guid[i].guid));

--- a/src/efivar.c
+++ b/src/efivar.c
@@ -10,6 +10,7 @@
 #include <err.h>
 #include <fcntl.h>
 #include <getopt.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/mman.h>
@@ -573,7 +574,7 @@ int main(int argc, char *argv[])
 			const uint64_t n = efi_n_well_known_guids;
 			size_t i;
 
-			debug("&guid[0]:%p n:%lu end:%p", &guid[0], n, &guid[n]);
+			debug("&guid[0]:%p n:%"PRIu64" end:%p", &guid[0], n, &guid[n]);
 			for (i = 0; i < n; i++) {
 				printf("{"GUID_FORMAT"}\t",
 				       GUID_FORMAT_ARGS(&guid[i].guid));

--- a/src/efivarfs.c
+++ b/src/efivarfs.c
@@ -93,7 +93,7 @@ get_esp_filepath(const char *filename, char *filepath, size_t sz)
 
 		rc = snprintf(filepath, sz, "%s%s", esp_paths[i], filename);
 		if (rc >= sz) {
-			fprintf(stderr, "Error: Filepath too big. Max allowed %ld\n", sz);
+			fprintf(stderr, "Error: Filepath too big. Max allowed %zu\n", sz);
 			return -1;
 		}
 		if (!stat(filepath, &buffer))
@@ -120,7 +120,7 @@ get_esp_filename(char *filename, size_t sz)
 		return rc;
 
 	if (size > sz) {
-		fprintf(stderr, "Error: Filename too big. Max allowed %ld\n", sz);
+		fprintf(stderr, "Error: Filename too big. Max allowed %zu\n", sz);
 		free(data);
 		return -1;
 	}

--- a/src/esl-iter.c
+++ b/src/esl-iter.c
@@ -395,8 +395,7 @@ esl_list_iter_next_with_size_correction(esl_list_iter *iter, efi_guid_t *type,
 		iter->offset += iter->esl->signature_list_size;
 		if ((uint32_t)iter->offset >= iter->len)
 			return 0;
-		iter->esl = (efi_signature_list_t *)((intptr_t)iter->buf
-						+ (unsigned long)iter->offset);
+		iter->esl = (efi_signature_list_t *)(iter->buf + (size_t)iter->offset);
 	}
 
 	efi_signature_list_t esl;

--- a/src/esl-iter.c
+++ b/src/esl-iter.c
@@ -324,24 +324,24 @@ esl_list_iter_next_with_size_correction(esl_list_iter *iter, efi_guid_t *type,
 		debug("Getting next ESL buffer (correct_size:%d)", correct_size);
 		iter->esl = (efi_signature_list_t *)iter->buf;
 
-		debug("list has %lu bytes left, element is %"PRIu32"(0x%"PRIx32") bytes",
-		      iter->len - iter->offset,
+		debug("list has %zu bytes left, element is %"PRIu32"(0x%"PRIx32") bytes",
+		      (size_t)(iter->len - iter->offset),
 		      iter->esl->signature_list_size,
 		      iter->esl->signature_list_size);
 
 		if (iter->len - iter->offset < iter->esl->signature_list_size) {
-			debug("EFI_SIGNATURE_LIST is malformed: len:%zd(0x%zx) offset:%zd(0x%zx) len-off:%zd(0x%zx) esl_size:%"PRIu32"(0x%"PRIx32")",
+			debug("EFI_SIGNATURE_LIST is malformed: len:%zu(0x%zx) offset:%jd(0x%jx) len-off:%jd(0x%jx) esl_size:%"PRIu32"(0x%"PRIx32")",
 			      iter->len, iter->len,
-			      iter->offset, iter->offset,
-			      iter->len - iter->offset, iter->len - iter->offset,
+			      (intmax_t)iter->offset, (uintmax_t)iter->offset,
+			      (intmax_t)(iter->len - iter->offset), (uintmax_t)(iter->len - iter->offset),
 			      iter->esl->signature_list_size, iter->esl->signature_list_size);
 			if (correct_size && (iter->len - iter->offset) > 0) {
-				warnx("correcting ESL size from %d to %jd at %lx",
+				warnx("correcting ESL size from %d to %jd at 0x%jx",
 				      iter->esl->signature_list_size,
-				      (intmax_t)(iter->len - iter->offset), (unsigned long)iter->offset);
-				debug("correcting ESL size from %d to %zd at %lx",
+				      (intmax_t)(iter->len - iter->offset), (uintmax_t)iter->offset);
+				debug("correcting ESL size from %d to %zu at 0x%jx",
 				      iter->esl->signature_list_size,
-				      iter->len - iter->offset, iter->offset);
+				      (size_t)(iter->len - iter->offset), (uintmax_t)iter->offset);
 				iter->esl->signature_list_size = iter->len - iter->offset;
 			} else {
 				efi_error("EFI_SIGNATURE_LIST is malformed");
@@ -352,8 +352,8 @@ esl_list_iter_next_with_size_correction(esl_list_iter *iter, efi_guid_t *type,
 
 	} else {
 		debug("Getting next efi_signature_list_t");
-		debug("list has %lu bytes left, element is %"PRIu32" bytes",
-		      iter->len - iter->offset,
+		debug("list has %zu bytes left, element is %"PRIu32" bytes",
+		      (size_t)(iter->len - iter->offset),
 		      iter->esl->signature_list_size);
 		efi_guid_t type;
 		errno = 0;
@@ -361,12 +361,12 @@ esl_list_iter_next_with_size_correction(esl_list_iter *iter, efi_guid_t *type,
 		if (iter->len - iter->offset < iter->esl->signature_list_size) {
 			debug("EFI_SIGNATURE_LIST is malformed");
 			if (correct_size && (iter->len - iter->offset) > 0) {
-				warnx("correcting ESL size from %d to %jd at 0x%lx",
+				warnx("correcting ESL size from %d to %jd at 0x%jx",
 				      iter->esl->signature_list_size,
-				      (intmax_t)(iter->len - iter->offset), (unsigned long)iter->offset);
-				debug("correcting ESL size from %d to %zd at 0x%lx",
+				      (intmax_t)(iter->len - iter->offset), (uintmax_t)iter->offset);
+				debug("correcting ESL size from %d to %zu at 0x%jx",
 				      iter->esl->signature_list_size,
-				      iter->len - iter->offset, iter->offset);
+				      (size_t)(iter->len - iter->offset), (uintmax_t)iter->offset);
 				iter->esl->signature_list_size = iter->len - iter->offset;
 			} else {
 				debug("EFI_SIGNATURE_LIST is malformed");
@@ -406,19 +406,19 @@ esl_list_iter_next_with_size_correction(esl_list_iter *iter, efi_guid_t *type,
 	if (!memcmp(&esl, iter->esl, sizeof(esl)))
 		return 0;
 
-	debug("signature list size:%d iter->len:%zd iter->offset:%zd signature_size:%u",
-	      iter->esl->signature_list_size, iter->len, iter->offset,
+	debug("signature list size:%d iter->len:%zu iter->offset:%jd signature_size:%u",
+	      iter->esl->signature_list_size, iter->len, (intmax_t)iter->offset,
 	      iter->esl->signature_size);
 	/* if this list size is too big for our data, then it's malformed */
 	if (iter->esl->signature_list_size > iter->len - iter->offset) {
 		debug("EFI_SIGNATURE_LIST is malformed");
 		if (correct_size && (iter->len - iter->offset) > 0) {
-			warnx("correcting ESL size from %d to %jd at 0x%lx",
+			warnx("correcting ESL size from %d to %jd at 0x%jx",
 			      iter->esl->signature_list_size,
-			      (intmax_t)(iter->len - iter->offset), (unsigned long)iter->offset);
-			debug("correcting ESL size from %d to %zd at 0x%lx",
+			      (intmax_t)(iter->len - iter->offset), (uintmax_t)iter->offset);
+			debug("correcting ESL size from %d to %zu at 0x%jx",
 			      iter->esl->signature_list_size,
-			      iter->len - iter->offset, iter->offset);
+			      (size_t)(iter->len - iter->offset), (uintmax_t)iter->offset);
 			iter->esl->signature_list_size = iter->len - iter->offset;
 		} else {
 			efi_error("EFI_SIGNATURE_LIST is malformed");

--- a/src/secdb.c
+++ b/src/secdb.c
@@ -264,7 +264,7 @@ efi_secdb_add_entry_or_secdb(efi_secdb_t *top,
 			return 0;
 	}
 
-	debug("adding %zd(0x%lx) bytes of data", datasz, datasz);
+	debug("adding %zu(0x%zx) bytes of data", datasz, datasz);
 	secdb_add_entry_data(secdb, owner, data, datasz);
 	if (sort_data && secdb->sigsz) {
 		debug("sorting data %s", sort_descending ? "desc" : "asc");

--- a/src/secdb.h
+++ b/src/secdb.h
@@ -180,7 +180,7 @@ secdb_entry_size(efi_secdb_t *secdb)
 	sz = sizeof(efi_signature_list_t)
 	     + secdb->hdrsz
 	     + secdb->sigsz * secdb->nsigs;
-	debug("secdb:%p sz:%zd (0x%lx)", secdb, sz, sz);
+	debug("secdb:%p sz:%zu (0x%zx)", secdb, sz, sz);
 	return sz;
 }
 


### PR DESCRIPTION
Fix 32-bit glibc `-Wformat` failures by correcting format specifiers for `size_t`, `off_t`, and `uint64_t` in `esl-iter`, `secdb`, `efivarfs`, `efivar`, and `efisecdb`.