### PR TITLE
sbchooser: fix load_secdb_from_file returning fd instead of rc

### DIFF
--- a/src/sbchooser-db.c
+++ b/src/sbchooser-db.c
@@ -256,7 +256,7 @@ load_secdb_from_file(const char * const filename, efi_secdb_t **secdbp)
 	close(fd);
 	if (rc < 0) {
 		efi_error("Could not read file \"%s\": %m", filename);
-		return fd;
+		return rc;
 	}
 	data_size -= 1;
 


### PR DESCRIPTION
When read_file() fails, returning fd instead of rc causes callers to miss the error since fd is a non-negative integer after close(). Fix by returning rc.
This affects when an invalid path is passed as db where the output shows not trusted rather than a read error.

```
# bugged output
LD_LIBRARY_PATH=src src/sbchooser --explain -d /tmp -i tests/shim-16.1-4.el10.x64.msft2023.efi -i tests/shim-16.1-4.el10.x64.msft2011.efi; echo "exit code: $?"
tests/shim-16.1-4.el10.x64.msft2023.efi is not trusted because no certs or hashes trust it
tests/shim-16.1-4.el10.x64.msft2011.efi is not trusted because no certs or hashes trust it
exit code: 0

# expected output
LD_LIBRARY_PATH=src src/sbchooser --explain -d /tmp -i tests/shim-16.1-4.el10.x64.msft2023.efi -i tests/shim-16.1-4.el10.x64.msft2011.efi; echo "exit code: $?"
sbchooser: Could not load db from "/tmp": Is a directory
exit code: 2
```

