### PR TITLE
Fix stack overflow caused by infinite recursion

### DIFF
--- a/src/include/efivar/efivar-dp.h
+++ b/src/include/efivar/efivar-dp.h
@@ -1122,6 +1122,8 @@ efidp_is_valid(const_efidp dp, ssize_t limit)
 		efidp_header *next;
 		if (limit < (int64_t)(sizeof (efidp_header)))
 			return 0;
+		if (hdr->length < 4)
+			return 0;
 
 		switch (hdr->type) {
 		case EFIDP_HARDWARE_TYPE:


### PR DESCRIPTION
if p < 4 the loop will continue forever because efidp_node_size (called by efidp_size) returns -1 if the length of the args passed to it are < 4. Fixes CVE-2026-6862

Resolves rhbz#2459982

Signed-off-by: Marta Lewandowska <mlewando@redhat.com>